### PR TITLE
Fixes tests running on windows

### DIFF
--- a/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
@@ -79,14 +79,11 @@ public class ConfigReaderTest {
 
     @Test
     public void shouldReplaceEnvPlaceholderWithEmptyStringIfEnvNotSet() {
-        Map<String, String> env = new HashMap<>(System.getenv());
-        env.remove("CUSTOM_ENV_VAR");
-        setEnv(env);
-        TestConfig testConfig = ConfigReader.fromFile("src/test/resources/testconfig.yml", TestConfig.class);
+        TestConfig testConfig = ConfigReader.fromFile("src/test/resources/testconfig-missing-value.yml", TestConfig.class);
         assertThat(testConfig.getConfigWithEnvPlaceholder()).isNull();
         assertThat(testConfig.getConfigWithEnvPlaceholderInMiddle()).isEqualTo("beforeafter");
 
-        testConfig = ConfigReader.fromTree(ConfigReader.readTree("src/test/resources/testconfig.yml"), TestConfig.class);
+        testConfig = ConfigReader.fromTree(ConfigReader.readTree("src/test/resources/testconfig-missing-value.yml"), TestConfig.class);
         assertThat(testConfig.getConfigWithEnvPlaceholder()).isNull();
         assertThat(testConfig.getConfigWithEnvPlaceholderInMiddle()).isEqualTo("beforeafter");
     }

--- a/config/src/test/resources/testconfig-missing-value.yml
+++ b/config/src/test/resources/testconfig-missing-value.yml
@@ -1,0 +1,5 @@
+myTestConfig:
+  myKey: myValue
+  configWithEnvPlaceholder: {{CUSTOM_MISSING_ENV_VAR}}
+  configWithEnvPlaceholderInMiddle: before{{CUSTOM_MISSING_ENV_VAR}}after
+  url: http://{{HOST}}:{{PORT}}/test

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -181,7 +181,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.20.1</version>
 				<configuration>
-					<argLine>${argLine} -Xmx96m -XX:+HeapDumpOnOutOfMemoryError</argLine>
+					<argLine>${argLine} -Dfile.encoding=UTF-8 -Xmx96m -XX:+HeapDumpOnOutOfMemoryError</argLine>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
- Surefire needs to be told that source is UTF-8 encoded
- setEnv doesnt seem to reset the environment on windows (?) so
  we use another configuration file with a placeholder that
  hasn't ever been defined.

Running win8.1 with jdk 1.8.0_65