### PR TITLE
Promoted LoggingMockUtil to make it more available to other projects.

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -83,6 +83,13 @@
             <artifactId>rxjava</artifactId>
             <version>${rxjava.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/logging/src/test/java/se/fortnox/reactivewizard/logging/LoggingMockUtil.java
+++ b/logging/src/test/java/se/fortnox/reactivewizard/logging/LoggingMockUtil.java
@@ -1,0 +1,45 @@
+package se.fortnox.reactivewizard.logging;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.Logger;
+import org.slf4j.impl.Log4jLoggerAdapter;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LoggingMockUtil {
+    /**
+     * Create a new appender and attach it on the logger instance of the passed class
+     *
+     * @param cls Class which holds the logger
+     * @return The mock appender
+     * @throws NoSuchFieldException
+     * @throws IllegalAccessException
+     */
+    public static Appender createMockedLogAppender(Class cls) throws NoSuchFieldException, IllegalAccessException {
+        Logger   logger       = LoggingMockUtil.getLogger(cls);
+        Appender mockAppender = mock(Appender.class);
+        when(mockAppender.getName()).thenReturn("mockAppender");
+        logger.addAppender(mockAppender);
+        return mockAppender;
+    }
+
+    /**
+     * This unorthodox reflection magic is needed because the static logger of the ObservableStatementFactory may or may
+     * not be initialized with the current LogManager, depending on the tests that have been run before.
+     *
+     * @return Logger of the class
+     * @throws NoSuchFieldException
+     * @throws IllegalAccessException
+     */
+    private static Logger getLogger(Class cls) throws NoSuchFieldException, IllegalAccessException {
+        Field logField = cls.getDeclaredField("LOG");
+        logField.setAccessible(true);
+        Log4jLoggerAdapter loggerAdapter = (Log4jLoggerAdapter)logField.get(null);
+        Field              innerLogField = loggerAdapter.getClass().getDeclaredField("logger");
+        innerLogField.setAccessible(true);
+        return (Logger)innerLogField.get(loggerAdapter);
+    }
+}

--- a/logging/src/test/java/se/fortnox/reactivewizard/logging/LoggingMockUtilTest.java
+++ b/logging/src/test/java/se/fortnox/reactivewizard/logging/LoggingMockUtilTest.java
@@ -1,0 +1,33 @@
+package se.fortnox.reactivewizard.logging;
+
+import org.apache.log4j.Appender;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static se.fortnox.reactivewizard.test.TestUtil.matches;
+
+public class LoggingMockUtilTest {
+    @Test
+    public void shouldLogToMockAppender() throws NoSuchFieldException, IllegalAccessException {
+        ClassWithLogger classWithLogger = new ClassWithLogger();
+        Appender appender = LoggingMockUtil.createMockedLogAppender(ClassWithLogger.class);
+
+        classWithLogger.doSomethingLogged();
+
+        verify(appender).doAppend(matches(log -> {
+            assertThat(log.getLevel().toString()).isEqualTo("INFO");
+            assertThat(log.getMessage().toString()).contains("Information was logged");
+        }));
+    }
+}
+
+class ClassWithLogger {
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingMockUtilTest.class);
+
+    public void doSomethingLogged() {
+        LOG.info("Information was logged");
+    }
+}


### PR DESCRIPTION
This class was previously used in the dao module (not oss yet) and we recently wanted to use it elsewhere as well, so I propose to move this into the logging module for better availability.