### PR TITLE
ReflectionUtil - improve member lookup

### DIFF
--- a/utils/src/main/java/se/fortnox/reactivewizard/util/AccessorUtil.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/AccessorUtil.java
@@ -1,0 +1,30 @@
+package se.fortnox.reactivewizard.util;
+
+import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+class AccessorUtil {
+    /**
+     * Create a map of all generic type parameters on a super class to the actual types in a subclass.
+     *
+     * @param subClass The subclass to find out type information for
+     * @param member   The member (field or method) to find out type information for
+     * @return a mapping of the generic type names (ie. "T") to the actual types
+     */
+    static Map<String, Class<?>> typesByGenericName(Class<?> subClass, Member member) {
+        Map<String, Class<?>> typeByName = new HashMap<>();
+        for (int i = 0; i < member.getDeclaringClass().getTypeParameters().length; i++) {
+            String typeName = member.getDeclaringClass().getTypeParameters()[i].getTypeName();
+            Type genericSuperclass = subClass.getGenericSuperclass();
+            if (genericSuperclass != null) {
+                Class<?> type = (Class<?>) ((ParameterizedTypeImpl) genericSuperclass).getActualTypeArguments()[i];
+                typeByName.put(typeName, type);
+            }
+        }
+        return typeByName;
+    }
+}

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/FieldGetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/FieldGetter.java
@@ -9,7 +9,7 @@ import java.util.Map;
  */
 public class FieldGetter implements Getter {
     public static Getter create(Class<?> cls, Field field) {
-        Map<String, Class<?>> genericTypenameToType = Getter.typesByGenericName(cls, field);
+        Map<String, Class<?>> genericTypenameToType = AccessorUtil.typesByGenericName(cls, field);
         Class<?> returnType = field.getDeclaringClass().equals(cls) ?
             field.getType() :
             genericTypenameToType.get(field.getGenericType().getTypeName());

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/FieldGetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/FieldGetter.java
@@ -1,32 +1,47 @@
 package se.fortnox.reactivewizard.util;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 /**
  * Represents a getter field.
  */
 public class FieldGetter implements Getter {
-    private final Field field;
+    public static Getter create(Class<?> cls, Field field) {
+        Map<String, Class<?>> genericTypenameToType = Getter.typesByGenericName(cls, field);
+        Class<?> returnType = field.getDeclaringClass().equals(cls) ?
+            field.getType() :
+            genericTypenameToType.get(field.getGenericType().getTypeName());
+        Type genericReturnType = field.getDeclaringClass().equals(cls) ?
+            field.getGenericType() :
+            genericTypenameToType.get(field.getGenericType().getTypeName());
+        return new FieldGetter(field, returnType, genericReturnType);
+    }
 
-    public FieldGetter(Field field) {
+    private final Field    field;
+    private final Class<?> returnType;
+    private final Type     genericReturnType;
+
+    private FieldGetter(Field field, Class<?> returnType, Type genericReturnType) {
         this.field = field;
+        this.returnType = returnType;
+        this.genericReturnType = genericReturnType;
         field.setAccessible(true);
     }
 
     @Override
-    public Object invoke(Object instance) throws InvocationTargetException, IllegalAccessException {
+    public Object invoke(Object instance) throws IllegalAccessException {
         return field.get(instance);
     }
 
     @Override
     public Class<?> getReturnType() {
-        return field.getType();
+        return returnType;
     }
 
     @Override
     public Type getGenericReturnType() {
-        return field.getGenericType();
+        return genericReturnType;
     }
 }

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/FieldSetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/FieldSetter.java
@@ -1,32 +1,47 @@
 package se.fortnox.reactivewizard.util;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 /**
  * Represents a setter field.
  */
 public class FieldSetter implements Setter {
-    private final Field field;
+    public static Setter create(Class<?> cls, Field field) {
+        Map<String, Class<?>> genericTypenameToType = Getter.typesByGenericName(cls, field);
+        Class<?> returnType = field.getDeclaringClass().equals(cls) ?
+            field.getType() :
+            genericTypenameToType.get(field.getGenericType().getTypeName());
+        Type genericReturnType = field.getDeclaringClass().equals(cls) ?
+            field.getGenericType() :
+            genericTypenameToType.get(field.getGenericType().getTypeName());
+        return new FieldSetter(field, returnType, genericReturnType);
+    }
 
-    public FieldSetter(Field field) {
+    private final Field    field;
+    private final Class<?> parameterType;
+    private final Type     genericParameterType;
+
+    private FieldSetter(Field field, Class<?> parameterType, Type genericParameterType) {
         this.field = field;
+        this.parameterType = parameterType;
+        this.genericParameterType = genericParameterType;
         field.setAccessible(true);
     }
 
     @Override
-    public void invoke(Object instance, Object value) throws InvocationTargetException, IllegalAccessException {
+    public void invoke(Object instance, Object value) throws IllegalAccessException {
         field.set(instance, value);
     }
 
     @Override
     public Class<?> getParameterType() {
-        return field.getType();
+        return parameterType;
     }
 
     @Override
     public Type getGenericParameterType() {
-        return field.getGenericType();
+        return genericParameterType;
     }
 }

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/FieldSetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/FieldSetter.java
@@ -9,7 +9,7 @@ import java.util.Map;
  */
 public class FieldSetter implements Setter {
     public static Setter create(Class<?> cls, Field field) {
-        Map<String, Class<?>> genericTypenameToType = Getter.typesByGenericName(cls, field);
+        Map<String, Class<?>> genericTypenameToType = AccessorUtil.typesByGenericName(cls, field);
         Class<?> returnType = field.getDeclaringClass().equals(cls) ?
             field.getType() :
             genericTypenameToType.get(field.getGenericType().getTypeName());

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/Getter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/Getter.java
@@ -1,38 +1,12 @@
 package se.fortnox.reactivewizard.util;
 
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
-
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Member;
 import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Interface for a getter.
  */
 public interface Getter {
-    /**
-     * Create a map of all generic type parameters on a super class to the actual types in a subclass.
-     *
-     * @param cls    The subclass to find out type information for
-     * @param member The member (field or method) to find out type information for
-     * @return a mapping of the generic type names (ie. "T") to the actual types
-     */
-    static Map<String, Class<?>> typesByGenericName(Class<?> cls, Member member) {
-        Map<String, Class<?>> typeByName = new HashMap<>();
-        for (int i = 0; i < member.getDeclaringClass().getTypeParameters().length; i++) {
-            String typeName = member.getDeclaringClass().getTypeParameters()[i].getTypeName();
-            Type genericSuperclass = cls.getGenericSuperclass();
-            if (genericSuperclass != null) {
-                Class<?> type = (Class<?>) ((ParameterizedTypeImpl) genericSuperclass).getActualTypeArguments()[i];
-                typeByName.put(typeName, type);
-            }
-        }
-        return typeByName;
-    }
-
     Object invoke(Object instance) throws InvocationTargetException, IllegalAccessException;
 
     Class<?> getReturnType();

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/Getter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/Getter.java
@@ -1,12 +1,38 @@
 package se.fortnox.reactivewizard.util;
 
+import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
+
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
 import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Interface for a getter.
  */
 public interface Getter {
+    /**
+     * Create a map of all generic type parameters on a super class to the actual types in a subclass.
+     *
+     * @param cls    The subclass to find out type information for
+     * @param member The member (field or method) to find out type information for
+     * @return a mapping of the generic type names (ie. "T") to the actual types
+     */
+    static Map<String, Class<?>> typesByGenericName(Class<?> cls, Member member) {
+        Map<String, Class<?>> typeByName = new HashMap<>();
+        for (int i = 0; i < member.getDeclaringClass().getTypeParameters().length; i++) {
+            String typeName = member.getDeclaringClass().getTypeParameters()[i].getTypeName();
+            Type genericSuperclass = cls.getGenericSuperclass();
+            if (genericSuperclass != null) {
+                Class<?> type = (Class<?>) ((ParameterizedTypeImpl) genericSuperclass).getActualTypeArguments()[i];
+                typeByName.put(typeName, type);
+            }
+        }
+        return typeByName;
+    }
+
     Object invoke(Object instance) throws InvocationTargetException, IllegalAccessException;
 
     Class<?> getReturnType();

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/MethodGetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/MethodGetter.java
@@ -10,7 +10,7 @@ import java.util.Map;
  */
 public class MethodGetter implements Getter {
     public static Getter create(Class<?> cls, Method method) {
-        Map<String, Class<?>> genericTypenameToType = Getter.typesByGenericName(cls, method);
+        Map<String, Class<?>> genericTypenameToType = AccessorUtil.typesByGenericName(cls, method);
         Class<?> returnType = method.getDeclaringClass().equals(cls) ?
             method.getReturnType() :
             genericTypenameToType.get(method.getGenericReturnType().getTypeName());

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/MethodGetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/MethodGetter.java
@@ -3,15 +3,31 @@ package se.fortnox.reactivewizard.util;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 /**
  * Represents a getter method.
  */
 public class MethodGetter implements Getter {
-    private final Method method;
+    public static Getter create(Class<?> cls, Method method) {
+        Map<String, Class<?>> genericTypenameToType = Getter.typesByGenericName(cls, method);
+        Class<?> returnType = method.getDeclaringClass().equals(cls) ?
+            method.getReturnType() :
+            genericTypenameToType.get(method.getGenericReturnType().getTypeName());
+        Type genericReturnType = method.getDeclaringClass().equals(cls) ?
+            method.getGenericReturnType() :
+            genericTypenameToType.get(method.getGenericReturnType().getTypeName());
+        return new MethodGetter(method, returnType, genericReturnType);
+    }
 
-    public MethodGetter(Method method) {
+    private final Method   method;
+    private final Class<?> returnType;
+    private final Type     genericReturnType;
+
+    private MethodGetter(Method method, Class<?> returnType, Type genericReturnType) {
+        this.returnType = returnType;
         this.method = method;
+        this.genericReturnType = genericReturnType;
     }
 
     @Override
@@ -21,11 +37,11 @@ public class MethodGetter implements Getter {
 
     @Override
     public Class<?> getReturnType() {
-        return method.getReturnType();
+        return returnType;
     }
 
     @Override
     public Type getGenericReturnType() {
-        return method.getGenericReturnType();
+        return genericReturnType;
     }
 }

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/MethodSetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/MethodSetter.java
@@ -3,15 +3,31 @@ package se.fortnox.reactivewizard.util;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 /**
  * Represents a setter method.
  */
 public class MethodSetter implements Setter {
-    private final Method method;
+    public static Setter create(Class<?> cls, Method method) {
+        Map<String, Class<?>> genericTypenameToType = Getter.typesByGenericName(cls, method);
+        Class<?> returnType = method.getDeclaringClass().equals(cls) ?
+            method.getParameterTypes()[0] :
+            genericTypenameToType.get(method.getGenericParameterTypes()[0].getTypeName());
+        Type genericReturnType = method.getDeclaringClass().equals(cls) ?
+            method.getGenericParameterTypes()[0] :
+            genericTypenameToType.get(method.getGenericParameterTypes()[0].getTypeName());
+        return new MethodSetter(method, returnType, genericReturnType);
+    }
 
-    public MethodSetter(Method method) {
+    private final Method   method;
+    private final Class<?> parameterType;
+    private final Type     genericParameterType;
+
+    private MethodSetter(Method method, Class<?> parameterType, Type genericParameterType) {
         this.method = method;
+        this.parameterType = parameterType;
+        this.genericParameterType = genericParameterType;
     }
 
     @Override
@@ -21,11 +37,11 @@ public class MethodSetter implements Setter {
 
     @Override
     public Class<?> getParameterType() {
-        return method.getParameterTypes()[0];
+        return parameterType;
     }
 
     @Override
     public Type getGenericParameterType() {
-        return method.getGenericParameterTypes()[0];
+        return genericParameterType;
     }
 }

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/MethodSetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/MethodSetter.java
@@ -10,7 +10,7 @@ import java.util.Map;
  */
 public class MethodSetter implements Setter {
     public static Setter create(Class<?> cls, Method method) {
-        Map<String, Class<?>> genericTypenameToType = Getter.typesByGenericName(cls, method);
+        Map<String, Class<?>> genericTypenameToType = AccessorUtil.typesByGenericName(cls, method);
         Class<?> returnType = method.getDeclaringClass().equals(cls) ?
             method.getParameterTypes()[0] :
             genericTypenameToType.get(method.getGenericParameterTypes()[0].getTypeName());

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/ReflectionUtil.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/ReflectionUtil.java
@@ -194,6 +194,9 @@ public class ReflectionUtil {
             try {
                 field = cls.getDeclaredField(propertyName);
             } catch (NoSuchFieldException e) {
+                if (cls.getSuperclass() != null) {
+                    return getGetter(cls.getSuperclass(), propertyName);
+                }
                 return null;
             }
 
@@ -220,6 +223,9 @@ public class ReflectionUtil {
             Field field = cls.getDeclaredField(propertyName);
             return new FieldSetter(field);
         } catch (NoSuchFieldException ignored) {
+            if (cls.getSuperclass() != null) {
+                return getSetter(cls.getSuperclass(), propertyName);
+            }
         }
 
         return null;
@@ -293,8 +299,11 @@ public class ReflectionUtil {
 
     private static Method getMethod(Class<?> cls, String propertyName) {
         try {
-            return cls.getMethod(propertyName, new Class[0]);
+            return cls.getDeclaredMethod(propertyName);
         } catch (NoSuchMethodException e) {
+            if (cls.getSuperclass() != null) {
+                return getMethod(cls.getSuperclass(), propertyName);
+            }
             return null;
         }
     }

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/ReflectionUtil.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/ReflectionUtil.java
@@ -179,27 +179,44 @@ public class ReflectionUtil {
         throw new RuntimeException("Unexpected type: " + type);
     }
 
+    /**
+     * Locate a getter (method or field) for a property.
+     * <p>
+     * The class hierarchy will be traversed to find any inherited getter for the given property.
+     *
+     * @param cls          The class inspected.
+     * @param propertyName The property to locate a getter for.
+     * @return a Getter instance for either a method or a field
+     */
     public static Getter getGetter(Class<?> cls, String propertyName) {
         return getGetter(cls, cls, propertyName);
     }
 
-    private static Getter getGetter(Class<?> original, Class<?> cls, String propertyName) {
+    /**
+     * Recurse through the class hierarchy to find a getter for a property.
+     *
+     * @param original       The original class inspected for a getter.
+     * @param declaringClass The current class in the hierarchy being inspected.
+     * @param propertyName   The property to locate a getter for.
+     * @return a Getter instance for either a method or a field
+     */
+    private static Getter getGetter(Class<?> original, Class<?> declaringClass, String propertyName) {
         String capitalizedPropertyName = propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
 
-        Method method = getAccessor(cls, capitalizedPropertyName);
+        Method method = getAccessor(declaringClass, capitalizedPropertyName);
         if (method == null) {
-            method = getBooleanAccessor(cls, capitalizedPropertyName);
+            method = getBooleanAccessor(declaringClass, capitalizedPropertyName);
         }
         if (method == null) {
-            method = getMethod(cls, propertyName);
+            method = getMethod(declaringClass, propertyName);
         }
         if (method == null) {
             Field field;
             try {
-                field = cls.getDeclaredField(propertyName);
+                field = declaringClass.getDeclaredField(propertyName);
             } catch (NoSuchFieldException e) {
-                if (cls.getSuperclass() != null) {
-                    return getGetter(original, cls.getSuperclass(), propertyName);
+                if (declaringClass.getSuperclass() != null) {
+                    return getGetter(original, declaringClass.getSuperclass(), propertyName);
                 }
                 return null;
             }
@@ -210,29 +227,46 @@ public class ReflectionUtil {
         return MethodGetter.create(original, method);
     }
 
+    /**
+     * Locate a setter (method or field) for a property.
+     * <p>
+     * The class hierarchy will be traversed to find any inherited setter for the given property.
+     *
+     * @param cls          The class inspected.
+     * @param propertyName The property to locate a setter for.
+     * @return a Setter instance for either a method or a field
+     */
     public static Setter getSetter(Class<?> cls, String propertyName) {
         return getSetter(cls, cls, propertyName);
     }
 
-    private static Setter getSetter(Class<?> originalClass, Class<?> cls, String propertyName) {
+    /**
+     * Recurse through the class hierarchy to find a setter for a property.
+     *
+     * @param original       The original class inspected for a setter.
+     * @param declaringClass The current class in the hierarchy being inspected.
+     * @param propertyName   The property to locate a setter for.
+     * @return a Setter instance for either a method or a field
+     */
+    private static Setter getSetter(Class<?> original, Class<?> declaringClass, String propertyName) {
         String capitalizedPropertyName = propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
         try {
             String methodName = "set" + capitalizedPropertyName;
-            Optional<Method> first = Arrays.stream(cls.getMethods())
+            Optional<Method> first = Arrays.stream(declaringClass.getMethods())
                 .filter(m -> m.getName().equals(methodName) && m.getReturnType().equals(void.class) && m.getParameters().length == 1)
                 .findFirst();
             if (first.isPresent()) {
-                return MethodSetter.create(originalClass, first.get());
+                return MethodSetter.create(original, first.get());
             }
         } catch (Exception ignored) {
         }
 
         try {
-            Field field = cls.getDeclaredField(propertyName);
-            return FieldSetter.create(originalClass, field);
+            Field field = declaringClass.getDeclaredField(propertyName);
+            return FieldSetter.create(original, field);
         } catch (NoSuchFieldException ignored) {
-            if (cls.getSuperclass() != null) {
-                return getSetter(originalClass, cls.getSuperclass(), propertyName);
+            if (declaringClass.getSuperclass() != null) {
+                return getSetter(original, declaringClass.getSuperclass(), propertyName);
             }
         }
 

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/FieldGetterTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/FieldGetterTest.java
@@ -1,40 +1,72 @@
 package se.fortnox.reactivewizard.util;
 
+import org.junit.Before;
 import org.junit.Test;
 import rx.Observable;
+
+import java.util.stream.Stream;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static rx.Observable.empty;
 
 public class FieldGetterTest {
+    private Getter value;
+    private Getter longObservable;
+    private Getter superKey;
+    private Getter superValue;
+
+    @Before
+    public void setUp() {
+        value = ReflectionUtil.getGetter(Foo.class, "value");
+        longObservable = ReflectionUtil.getGetter(Foo.class, "longObservable");
+        superKey = ReflectionUtil.getGetter(Foo.class, "superKey");
+        superValue = ReflectionUtil.getGetter(Foo.class, "superValue");
+    }
+
+    @Test
+    public void shouldCreateFieldGetters() {
+        assertThat(Stream.of(value, longObservable, superKey, superValue).allMatch(FieldGetter.class::isInstance)).isTrue();
+    }
+
     @Test
     public void shouldGetValue() throws Exception {
-        Getter getter = ReflectionUtil.getGetter(Foo.class, "value");
-        assertThat(getter.invoke(new Foo(5))).isEqualTo(5);
+        assertThat(value.invoke(new Foo(5))).isEqualTo(5);
+        assertThat(superKey.invoke(new Foo(5))).isEqualTo("5");
+        assertThat(superValue.invoke(new Foo(5))).isEqualTo(5);
     }
 
     @Test
     public void shouldGetReturnType() {
-        Getter getter = ReflectionUtil.getGetter(Foo.class, "value");
-        assertThat(getter.getReturnType()).isEqualTo(Integer.class);
+        assertThat(value.getReturnType()).isEqualTo(Integer.class);
+        assertThat(superKey.getReturnType()).isEqualTo(String.class);
+        assertThat(superValue.getReturnType()).isEqualTo(Integer.class);
     }
 
     @Test
     public void shouldGetGenericReturnType() {
-        Getter getter = ReflectionUtil.getGetter(Foo.class, "longObservable");
-
-        assertThat(getter.getGenericReturnType().toString()).isEqualTo("rx.Observable<java.lang.Long>");
+        assertThat(longObservable.getGenericReturnType().toString()).isEqualTo("rx.Observable<java.lang.Long>");
+        assertThat(superKey.getGenericReturnType().toString()).isEqualTo("class java.lang.String");
+        assertThat(superValue.getGenericReturnType().toString()).isEqualTo("class java.lang.Integer");
     }
 
-    private class Foo {
+    private class Foo extends GenericSuper<String, Integer> {
         private final Integer          value;
         private final Observable<Long> longObservable;
 
         private Foo(Integer value) {
+            super(String.valueOf(value), value);
             this.value = value;
             longObservable = empty();
         }
-
     }
 
+    private class GenericSuper<K, V> {
+        private final K superKey;
+        private final V superValue;
+
+        private GenericSuper(K key, V value) {
+            this.superKey = key;
+            this.superValue = value;
+        }
+    }
 }

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/FieldSetterTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/FieldSetterTest.java
@@ -1,40 +1,86 @@
 package se.fortnox.reactivewizard.util;
 
+import org.junit.Before;
 import org.junit.Test;
 import rx.Observable;
+
+import java.util.stream.Stream;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static rx.Observable.empty;
 
 public class FieldSetterTest {
+    private Setter value;
+    private Setter longObservable;
+    private Setter superKey;
+    private Setter superValue;
+
+    @Before
+    public void setUp() {
+        value = ReflectionUtil.getSetter(Foo.class, "value");
+        longObservable = ReflectionUtil.getSetter(Foo.class, "longObservable");
+        superKey = ReflectionUtil.getSetter(Foo.class, "superKey");
+        superValue = ReflectionUtil.getSetter(Foo.class, "superValue");
+    }
+
+    @Test
+    public void shouldCreateFieldSetters() {
+        assertThat(Stream.of(value, longObservable, superKey, superValue).allMatch(FieldSetter.class::isInstance)).isTrue();
+    }
+
     @Test
     public void shouldSetFinalField() throws Exception {
-        Setter setter = ReflectionUtil.getSetter(Foo.class, "value");
-        Foo    foo    = new Foo(1);
-        setter.invoke(foo, 9);
+        Foo foo = new Foo(1);
+        value.invoke(foo, 9);
         assertThat(foo.value).isEqualTo(9);
+
+        superKey.invoke(foo, "9");
+        assertThat(foo.getSuperKey()).isEqualTo("9");
+
+        superValue.invoke(foo, 9);
+        assertThat(foo.getSuperValue()).isEqualTo(9);
     }
 
     @Test
-    public void shouldGetReturnType() {
-        Setter setter = ReflectionUtil.getSetter(Foo.class, "value");
-        assertThat(setter.getParameterType()).isEqualTo(Integer.class);
+    public void shouldGetParameterType() {
+        assertThat(value.getParameterType()).isEqualTo(Integer.class);
+        assertThat(superKey.getParameterType()).isEqualTo(String.class);
+        assertThat(superValue.getParameterType()).isEqualTo(Integer.class);
     }
 
     @Test
-    public void shouldGetGenericReturnType() {
-        Setter setter = ReflectionUtil.getSetter(Foo.class, "longObservable");
-        assertThat(setter.getGenericParameterType().toString()).isEqualTo("rx.Observable<java.lang.Long>");
+    public void shouldGetGenericParameterType() {
+        assertThat(longObservable.getGenericParameterType().toString()).isEqualTo("rx.Observable<java.lang.Long>");
+        assertThat(superKey.getGenericParameterType().toString()).isEqualTo("class java.lang.String");
+        assertThat(superValue.getGenericParameterType().toString()).isEqualTo("class java.lang.Integer");
     }
 
-    private class Foo {
+    private class Foo extends GenericSuper<String, Integer> {
         private final Integer          value;
         private final Observable<Long> longObservable;
 
         private Foo(Integer value) {
+            super(String.valueOf(value), value);
             this.value = value;
             longObservable = empty();
         }
+    }
 
+    private class GenericSuper<K, V> {
+        private final K superKey;
+        private final V superValue;
+
+        private GenericSuper(K key, V value) {
+            this.superKey = key;
+            this.superValue = value;
+        }
+
+        K getSuperKey() {
+            return superKey;
+        }
+
+        V getSuperValue() {
+            return superValue;
+        }
     }
 }

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/MethodGetterTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/MethodGetterTest.java
@@ -1,36 +1,60 @@
 package se.fortnox.reactivewizard.util;
 
+import org.junit.Before;
 import org.junit.Test;
 import rx.Observable;
+
+import java.util.stream.Stream;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static rx.Observable.empty;
 
 public class MethodGetterTest {
+    private Getter value;
+    private Getter longObservable;
+    private Getter superKey;
+    private Getter superValue;
+
+    @Before
+    public void setUp() {
+        value = ReflectionUtil.getGetter(Foo.class, "value");
+        longObservable = ReflectionUtil.getGetter(Foo.class, "longObservable");
+        superKey = ReflectionUtil.getGetter(Foo.class, "superKey");
+        superValue = ReflectionUtil.getGetter(Foo.class, "superValue");
+    }
+
+    @Test
+    public void shouldCreateMethodGetters() {
+        assertThat(Stream.of(value, longObservable, superKey, superValue).allMatch(MethodGetter.class::isInstance)).isTrue();
+    }
+
     @Test
     public void shouldGetValue() throws Exception {
-        Getter getter = ReflectionUtil.getGetter(Foo.class, "value");
-        assertThat(getter.invoke(new Foo(5))).isEqualTo(5);
+        assertThat(value.invoke(new Foo(5))).isEqualTo(5);
+        assertThat(superKey.invoke(new Foo(5))).isEqualTo("5");
+        assertThat(superValue.invoke(new Foo(5))).isEqualTo(5);
     }
 
     @Test
     public void shouldGetReturnType() {
-        Getter getter = ReflectionUtil.getGetter(Foo.class, "value");
-        assertThat(getter.getReturnType()).isEqualTo(Integer.class);
+        assertThat(value.getReturnType()).isEqualTo(Integer.class);
+        assertThat(superKey.getReturnType()).isEqualTo(String.class);
+        assertThat(superValue.getReturnType()).isEqualTo(Integer.class);
     }
 
     @Test
     public void shouldGetGenericReturnType() {
-        Getter getter = ReflectionUtil.getGetter(Foo.class, "longObservable");
-
-        assertThat(getter.getGenericReturnType().toString()).isEqualTo("rx.Observable<java.lang.Long>");
+        assertThat(longObservable.getGenericReturnType().toString()).isEqualTo("rx.Observable<java.lang.Long>");
+        assertThat(superKey.getGenericReturnType().toString()).isEqualTo("class java.lang.String");
+        assertThat(superValue.getGenericReturnType().toString()).isEqualTo("class java.lang.Integer");
     }
 
-    private class Foo {
-        private final Integer field;
+    private class Foo extends GenericSuper<String, Integer> {
+        private final Integer          field;
         private final Observable<Long> longObservable;
 
         private Foo(Integer value) {
+            super(String.valueOf(value), value);
             this.field = value;
             this.longObservable = empty();
         }
@@ -41,6 +65,24 @@ public class MethodGetterTest {
 
         public Observable<Long> getLongObservable() {
             return longObservable;
+        }
+    }
+
+    private class GenericSuper<K, V> {
+        private final K superKey;
+        private final V superValue;
+
+        private GenericSuper(K key, V value) {
+            this.superKey = key;
+            this.superValue = value;
+        }
+
+        public K getSuperKey() {
+            return superKey;
+        }
+
+        public V getSuperValue() {
+            return superValue;
         }
     }
 }

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/MethodSetterTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/MethodSetterTest.java
@@ -1,34 +1,60 @@
 package se.fortnox.reactivewizard.util;
 
+import org.junit.Before;
 import org.junit.Test;
 import rx.Observable;
+
+import java.util.stream.Stream;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 public class MethodSetterTest {
+    private Setter value;
+    private Setter longObservable;
+    private Setter superKey;
+    private Setter superValue;
+
+    @Before
+    public void setUp() {
+        value = ReflectionUtil.getSetter(Foo.class, "value");
+        longObservable = ReflectionUtil.getSetter(Foo.class, "longObservable");
+        superKey = ReflectionUtil.getSetter(Foo.class, "superKey");
+        superValue = ReflectionUtil.getSetter(Foo.class, "superValue");
+    }
+
+    @Test
+    public void shouldCreateMethodSetters() {
+        assertThat(Stream.of(value, longObservable, superKey, superValue).allMatch(MethodSetter.class::isInstance)).isTrue();
+    }
+
     @Test
     public void shouldSetValue() throws Exception {
-        Setter setter = ReflectionUtil.getSetter(Foo.class, "value");
-        Foo    foo    = new Foo(1);
-        setter.invoke(foo, 9);
+        Foo foo = new Foo(1);
+        value.invoke(foo, 9);
         assertThat(foo.field).isEqualTo(9);
-    }
 
+        superKey.invoke(foo, "9");
+        assertThat(foo.getSuperKey()).isEqualTo("9");
+
+        superValue.invoke(foo, 9);
+        assertThat(foo.getSuperValue());
+    }
 
     @Test
-    public void shouldGetReturnType() {
-        Setter setter = ReflectionUtil.getSetter(Foo.class, "value");
-        assertThat(setter.getParameterType()).isEqualTo(Integer.class);
+    public void shouldGetParameterType() {
+        assertThat(value.getParameterType()).isEqualTo(Integer.class);
+        assertThat(superKey.getParameterType()).isEqualTo(String.class);
+        assertThat(superValue.getParameterType()).isEqualTo(Integer.class);
     }
 
     @Test
-    public void shouldGetGenericReturnType() {
-        Setter setter = ReflectionUtil.getSetter(Foo.class, "observable");
-
-        assertThat(setter.getGenericParameterType().toString()).isEqualTo("rx.Observable<java.lang.Long>");
+    public void shouldGetGenericParameterType() {
+        assertThat(longObservable.getGenericParameterType().toString()).isEqualTo("rx.Observable<java.lang.Long>");
+        assertThat(superKey.getGenericParameterType().toString()).isEqualTo("class java.lang.String");
+        assertThat(superValue.getGenericParameterType().toString()).isEqualTo("class java.lang.Integer");
     }
 
-    private class Foo {
+    private class Foo extends GenericSuper<String, Integer> {
         private int              field;
         private Observable<Long> longObservable;
 
@@ -40,10 +66,29 @@ public class MethodSetterTest {
             this.field = value;
         }
 
-
-        public void setObservable(Observable<Long> longObservable) {
+        public void setLongObservable(Observable<Long> longObservable) {
             this.longObservable = longObservable;
         }
     }
 
+    private class GenericSuper<K, V> {
+        private K superKey;
+        private V superValue;
+
+        K getSuperKey() {
+            return superKey;
+        }
+
+        public void setSuperKey(K superKey) {
+            this.superKey = superKey;
+        }
+
+        V getSuperValue() {
+            return superValue;
+        }
+
+        public void setSuperValue(V superValue) {
+            this.superValue = superValue;
+        }
+    }
 }

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/ReflectionUtilTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/ReflectionUtilTest.java
@@ -24,12 +24,29 @@ public class ReflectionUtilTest {
     }
 
     @Test
-    public void shouldFindInheritedMethods() {
+    public void shouldFindSuperclassMethods() {
         Getter getter = ReflectionUtil.getGetter(Child.class, "i");
         assertThat(getter).isNotNull();
+        assertThat(getter).isInstanceOf(MethodGetter.class);
+
+        getter = ReflectionUtil.getGetter(Child.class, "k");
+        assertThat(getter).isNotNull();
+        assertThat(getter).isInstanceOf(MethodGetter.class);
 
         Setter setter = ReflectionUtil.getSetter(Child.class, "i");
         assertThat(setter).isNotNull();
+        assertThat(setter).isInstanceOf(MethodSetter.class);
+    }
+
+    @Test
+    public void shouldFindSuperclassFields() {
+        Getter getter = ReflectionUtil.getGetter(Child.class, "l");
+        assertThat(getter).isNotNull();
+        assertThat(getter).isInstanceOf(FieldGetter.class);
+
+        Setter setter = ReflectionUtil.getSetter(Child.class, "l");
+        assertThat(setter).isNotNull();
+        assertThat(setter).isInstanceOf(FieldSetter.class);
     }
 
     @Test
@@ -39,7 +56,7 @@ public class ReflectionUtilTest {
     }
 
     @Test
-    public void shouldInstantiate() throws Exception {
+    public void shouldInstantiate() {
         assertThat(ReflectionUtil.newInstance(Parent.class)).isNotNull();
         assertThat(ReflectionUtil.newInstance(Child.class)).isNotNull();
         assertThat(ReflectionUtil.newInstance(PrivateDefaultConstructor.class)).isNotNull();
@@ -68,6 +85,8 @@ public class ReflectionUtilTest {
 
     static class Parent {
         private int i;
+        private int k;
+        private int l;
 
         public int getI() {
             return i;
@@ -75,6 +94,10 @@ public class ReflectionUtilTest {
 
         public void setI(int i) {
             this.i = i;
+        }
+
+        protected int getK() {
+            return k;
         }
     }
 


### PR DESCRIPTION
This change allows for better field- and method lookup when using class hierarchies.

The two issues this fixes are 
1) Allowing ReflectionUtil to create Getter and Setter instances for non-visible fields and methods in a superclass.
2) Allowing Getters and Setters to properly determine the return types and parameter types of fields and methods in a generic superclass.