### PR TITLE
Added new constructor for WebException, so that we can combine error …

### DIFF
--- a/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/WebException.java
+++ b/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/WebException.java
@@ -29,6 +29,11 @@ public class WebException extends RuntimeException {
         this.logLevel = logLevelFromStatus(httpStatus);
     }
 
+    public WebException(HttpResponseStatus httpStatus, String errorCode, Throwable throwable) {
+        this(httpStatus, throwable, true);
+        this.error = errorCode;
+    }
+
     public WebException(HttpResponseStatus httpStatus) {
         this(httpStatus, (Throwable)null);
     }
@@ -62,7 +67,7 @@ public class WebException extends RuntimeException {
     }
 
     public WebException(HttpResponseStatus httpStatus, String errorCode) {
-        this(httpStatus, errorCode, null);
+        this(httpStatus, errorCode, (String)null);
     }
 
     private static String errorCodeFromStatus(HttpResponseStatus status) {

--- a/jaxrs-api/src/test/java/se/fortnox/reactivewizard/jaxrs/WebExceptionTest.java
+++ b/jaxrs-api/src/test/java/se/fortnox/reactivewizard/jaxrs/WebExceptionTest.java
@@ -110,6 +110,19 @@ public class WebExceptionTest {
     }
 
     @Test
+    public void shouldSetErrorToGivenValueWhenErrorCodeAndThrowableIsGiven() {
+        WebException webException = new WebException(BAD_REQUEST, "error_code",new IllegalArgumentException("cause"));
+        assertThat(webException.getError()).isEqualTo("error_code");
+        assertThat(webException.getCause()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void shouldSetThrowableToGivenValueWhenErrorCodeAndThrowableIsGiven() {
+        WebException webException = new WebException(BAD_REQUEST, "error_code",new IllegalArgumentException("cause"));
+        assertThat(webException.getCause()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void shouldSetErrorParams() {
         WebException webException = new WebException(BAD_REQUEST)
             .withErrorParams("donkey");


### PR DESCRIPTION
The idea about this pullrequest is that i want to combine error code and cause in the WebException. Before  only one of them could be used, the combination was not available. 

With this change, i hope we can generate better error logs in our applications when we have error_code given in our WebExceptions. 