### PR TITLE
Improvement in DbProxy allowing new connections providers

### DIFF
--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -448,14 +448,14 @@ public class HttpClientTest {
 
         resource.servertest("fast")
             // Delay needed so that repeat will not subscribe immediately, as the pooled connection is released on the event loop thread.
-            .delaySubscription(1, TimeUnit.MILLISECONDS)
+            .delaySubscription(10, TimeUnit.MILLISECONDS)
             .repeat(10).doOnNext(System.out::println).toBlocking().last();
 
         verify(serverLog, times(10)).accept("/hello/servertest/fast");
 
         try {
             resource.servertest("slowHeaders")
-                .delaySubscription(1, TimeUnit.MILLISECONDS)
+                .delaySubscription(10, TimeUnit.MILLISECONDS)
                 .retry(5)
                 .doOnNext(System.out::println).toBlocking().last();
             fail("expected exception");
@@ -494,7 +494,7 @@ public class HttpClientTest {
 
         try {
             resource.getHello()
-                .delaySubscription(1, TimeUnit.MILLISECONDS)
+                .delaySubscription(10, TimeUnit.MILLISECONDS)
                 .retry(5)
                 .toBlocking().last();
             fail("expected exception");

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -542,7 +542,7 @@ public class HttpClientTest {
 
         resource.servertest("fast")
             // Delay needed so that repeat will not subscribe immediately, as the pooled connection is released on the event loop thread.
-            .delaySubscription(1, TimeUnit.MILLISECONDS)
+            .delaySubscription(10, TimeUnit.MILLISECONDS)
             .repeat(10).toBlocking().last();
 
         verify(serverLog, times(10)).accept("/hello/servertest/fast");
@@ -550,7 +550,7 @@ public class HttpClientTest {
         try {
             resource.servertest("slowBody")
                 .timeout(50, TimeUnit.MILLISECONDS)
-                .delaySubscription(1, TimeUnit.MILLISECONDS)
+                .delaySubscription(10, TimeUnit.MILLISECONDS)
                 .retry(10)
                 .toBlocking()
                 .last();


### PR DESCRIPTION
In order to use the same database for multiple connections without the overhead of creating the deserializers for each connection, a new method DbProxy.usingConnectionProvider was added to return a new DbProxy reusing everything but the connection provider.