### PR TITLE
Validate that host can be resolved

### DIFF
--- a/client/src/test/java/se/fortnox/reactivewizard/client/RestClientFactoryTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/RestClientFactoryTest.java
@@ -21,7 +21,7 @@ public class RestClientFactoryTest {
     @Test
     public void shouldProxyResourceInterfacesToHttpClient() throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig();
-        httpClientConfig.setUrl("http://anything");
+        httpClientConfig.setUrl("http://localhost");
 
         HttpClient mockClient = Mockito.spy(new HttpClient(httpClientConfig));
 


### PR DESCRIPTION
This will ensure that the system can look up it's httpClient host at startup, to avoid misconfigurations and dnsproblems at a later stage.