### PR TITLE
Consider also "maven.surefire.debug" environment variable while decid…

### DIFF
--- a/utils/src/main/java/se/fortnox/reactivewizard/util/DebugUtil.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/DebugUtil.java
@@ -4,14 +4,17 @@ package se.fortnox.reactivewizard.util;
  * Utilities for debugging in the development environment.
  */
 public class DebugUtil {
-    public static final boolean IS_DEBUG = isIdePresent();
+    public static final boolean IS_DEBUG = isIdePresent(DebugUtil.class.getClassLoader()) || isMavenDebug();
 
     /**
      * Checks for the presence of an IDE, currently just IntelliJ.
+     * @param classLoader to use for the check
      */
-    private static boolean isIdePresent() {
-        ClassLoader classLoader = DebugUtil.class.getClassLoader();
+    static boolean isIdePresent(ClassLoader classLoader) {
         return classLoader.getResource("com/intellij") != null;
     }
 
+    static boolean isMavenDebug() {
+        return Boolean.getBoolean("maven.surefire.debug");
+    }
 }

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/DebugUtilTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/DebugUtilTest.java
@@ -1,13 +1,40 @@
 package se.fortnox.reactivewizard.util;
 
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 
 public class DebugUtilTest {
 
     @Test
-    public void testIsIdePresent() {
-        assertThat(DebugUtil.IS_DEBUG).isNotNull();
+    public void testIsDebug() {
+        assertThat(DebugUtil.IS_DEBUG).isNotNull(); // will be true if running from Intellij IDEA and false from command line
+    }
+
+    @Test
+    public void testIsIdePresent() throws MalformedURLException {
+        ClassLoader classLoaderWithIdeaDebugger = Mockito.mock(ClassLoader.class);
+        when(classLoaderWithIdeaDebugger.getResource(eq("com/intellij")))
+                .thenReturn(new URL("jar:file:/path/to/debugger-agent-storage.jar!/com/intellij"));
+
+        assertThat(DebugUtil.isIdePresent(classLoaderWithIdeaDebugger)).isTrue();
+    }
+
+    @Test
+    public void testIsMavenDebug() {
+        String debugPropName = "maven.surefire.debug";
+        boolean originalSurefireDebugProp = Boolean.getBoolean(debugPropName);
+        System.setProperty(debugPropName, "true");
+
+        assertThat(DebugUtil.isMavenDebug()).isTrue();
+
+        // Clean up
+        System.setProperty(debugPropName, String.valueOf(originalSurefireDebugProp));
     }
 }


### PR DESCRIPTION
…ing if we are debugging

* to make debugging a more seamless process if started from command line using `maven`.
* trying to improve test coverage for "DebugUtil" by covering both branches for `isIdePresent` method.

(squashed previous 3 commits and want to check if the coverage/complexity checks pass)