### PR TITLE
Disable Codecov patch checks due to being unreliable

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off


### PR DESCRIPTION
This causes more trouble than it gives value, so lets just disable this for now.

See #83 and #81 for examples.