### PR TITLE
urlEncode query parameters

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -446,7 +446,7 @@ public class HttpClient implements InvocationHandler {
                     }
                     query.append(((QueryParam)annotation).value());
                     query.append('=');
-                    query.append(encode(serialize(value)));
+                    query.append(urlEncode(serialize(value)));
                 } else if (annotation instanceof PathParam) {
                     if (path.contains("{" + ((PathParam)annotation).value() + ":.*}")) {
                         path = path.replaceAll("\\{" + ((PathParam)annotation).value() + ":.*\\}", this.encode(this.serialize(value)));

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -320,7 +320,7 @@ public class HttpClientTest {
         HttpClient client = new HttpClient(new HttpClientConfig("localhost"));
         Method     method = TestResource.class.getMethod("withRegExpPathAndQueryParam", String.class, String.class);
         String     path   = client.getPath(method, new Object[]{"key/with/Slash", "value/with/slash"}, new JaxRsMeta(method, null));
-        assertThat(path).isEqualTo("/hello/{fid}/key/with/Slash?value=value/with/slash");
+        assertThat(path).isEqualTo("/hello/{fid}/key/with/Slash?value=value%2Fwith%2Fslash");
     }
 
     @Test
@@ -328,7 +328,15 @@ public class HttpClientTest {
         HttpClient client = new HttpClient(new HttpClientConfig("localhost"));
         Method     method = TestResource.class.getMethod("withPathAndQueryParam", String.class, String.class);
         String     path   = client.getPath(method, new Object[]{"key/with/Slash", "value/with/slash"}, new JaxRsMeta(method, null));
-        assertThat(path).isEqualTo("/hello/{fid}/key%2Fwith%2FSlash?value=value/with/slash");
+        assertThat(path).isEqualTo("/hello/{fid}/key%2Fwith%2FSlash?value=value%2Fwith%2Fslash");
+    }
+
+    @Test
+    public void shouldEncodePathAndQueryWithColon() throws Exception {
+        HttpClient client = new HttpClient(new HttpClientConfig("localhost"));
+        Method     method = TestResource.class.getMethod("withPathAndQueryParam", String.class, String.class);
+        String     path   = client.getPath(method, new Object[]{"path:param", "query-param-with:colon"}, new JaxRsMeta(method, null));
+        assertThat(path).isEqualTo("/hello/{fid}/path%3Aparam?value=query-param-with%3Acolon");
     }
 
     @Test


### PR DESCRIPTION
Description:
We've experienced weird HttpClient errors when using HttpClientProvider to access external third party api's, in all environments. It's hard to recreate error in tests, succeeded a couple of times then error magically disappeared. 
URISyntaxException are thrown in encode(...) when having colon (:) in query parameters since query parameters are parsed through java.net.URI. Colon are not permitted in paths. In most cases it works fine but in deployed environments it's not working for us.

Error:
java.net.URISyntaxException: Illegal character in scheme name at index ...

Fix:
Always use existing urlEncode(...) for all annotation of QueryParam instance.