### PR TITLE
Presence of a logging property will attempt to reconfigure JUL

### DIFF
--- a/logging/src/main/java/se/fortnox/reactivewizard/logging/LoggingFactory.java
+++ b/logging/src/main/java/se/fortnox/reactivewizard/logging/LoggingFactory.java
@@ -42,6 +42,9 @@ public class LoggingFactory {
     @JsonProperty("julLoggingActivation")
     Boolean julLoggingActivation = false;
 
+    /**
+     * Configure logging framework(s) and supply defaults.
+     */
     public void init() {
         if (appenders == null) {
             appenders = new HashMap<>();
@@ -61,17 +64,15 @@ public class LoggingFactory {
         }
         LoggingConfiguration.getInstance().configure(props);
 
-        /*
-        Provides a facility to reconfigure JUL via a reactivewizard config.
-         */
-        if(julLoggingActivation) {
-	        configureJUL();
+        // Provides a facility to reconfigure JUL via a reactivewizard config.
+        if (julLoggingActivation) {
+            configureJavaUtilLogging();
         }
     }
 
-    private void configureJUL() {
+    private void configureJavaUtilLogging() {
         final InputStream stream = LoggingFactory.class.getClassLoader().getResourceAsStream("rw-jul-logging.properties");
-        if(stream != null) {
+        if (stream != null) {
             try {
                 getLogManager().readConfiguration(stream);
             } catch (IOException e) {

--- a/logging/src/main/java/se/fortnox/reactivewizard/logging/LoggingFactory.java
+++ b/logging/src/main/java/se/fortnox/reactivewizard/logging/LoggingFactory.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 
+import static java.util.logging.LogManager.getLogManager;
+
 /**
  * Factory for initializing logging configuration and also container of logging configuration from YAML.
  */
@@ -36,6 +38,10 @@ public class LoggingFactory {
     @JsonProperty("levels")
     Map<String, String> levels = new HashMap<>();
 
+    @Valid
+    @JsonProperty("julLoggingActivation")
+    Boolean julLoggingActivation = false;
+
     public void init() {
         if (appenders == null) {
             appenders = new HashMap<>();
@@ -54,6 +60,22 @@ public class LoggingFactory {
             props.setProperty("log4j.logger." + e.getKey(), e.getValue());
         }
         LoggingConfiguration.getInstance().configure(props);
+
+        /*
+        Provides a facility to reconfigure JUL via a reactivewizard config.
+         */
+        if(julLoggingActivation) {
+	        configureJUL();
+        }
+    }
+
+    private void configureJUL() {
+        final InputStream stream = LoggingFactory.class.getClassLoader().getResourceAsStream("rw-jul-logging.properties");
+        try {
+            getLogManager().readConfiguration(stream);
+        } catch (IOException | NullPointerException e) {
+            e.printStackTrace();
+        }
     }
 
     private void loadConfigurationsFromFiles(Properties props) {

--- a/logging/src/main/java/se/fortnox/reactivewizard/logging/LoggingFactory.java
+++ b/logging/src/main/java/se/fortnox/reactivewizard/logging/LoggingFactory.java
@@ -71,10 +71,12 @@ public class LoggingFactory {
 
     private void configureJUL() {
         final InputStream stream = LoggingFactory.class.getClassLoader().getResourceAsStream("rw-jul-logging.properties");
-        try {
-            getLogManager().readConfiguration(stream);
-        } catch (IOException | NullPointerException e) {
-            e.printStackTrace();
+        if(stream != null) {
+            try {
+                getLogManager().readConfiguration(stream);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
A truthy julLoggingActivation will attempt to reconfigure Java utils logging from an configuration file, with a preset name, on the classpath.