### PR TITLE
Add @PostConstruct and @PreDestroy support

### DIFF
--- a/binding/pom.xml
+++ b/binding/pom.xml
@@ -30,6 +30,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+
+		<dependency>
 			<groupId>se.fortnox.reactivewizard</groupId>
 			<artifactId>reactivewizard-utils</artifactId>
 			<version>1.0.0-SNAPSHOT</version>

--- a/binding/src/main/java/se/fortnox/reactivewizard/binding/AutoBindModules.java
+++ b/binding/src/main/java/se/fortnox/reactivewizard/binding/AutoBindModules.java
@@ -69,7 +69,8 @@ public class AutoBindModules implements Module {
 
     @Override
     public void configure(Binder binder) {
-        Injector bootstrapInjector = Guice.createInjector(bootstrapBindings);
+        Injector bootstrapInjector = Guice.createInjector(bootstrapBindings,
+            internalBinder -> internalBinder.bind(Runtime.class).toProvider(Runtime::getRuntime));
 
         List<AutoBindModule> autoBindModules = createAutoBindModules(bootstrapInjector);
 

--- a/binding/src/main/java/se/fortnox/reactivewizard/binding/PostConstructModule.java
+++ b/binding/src/main/java/se/fortnox/reactivewizard/binding/PostConstructModule.java
@@ -1,0 +1,77 @@
+package se.fortnox.reactivewizard.binding;
+
+import com.google.inject.Binder;
+import com.google.inject.ProvisionException;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.InjectionListener;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static com.google.inject.matcher.Matchers.any;
+
+/**
+ * Finds methods annotated with {@link PostConstruct} and invokes them after injection is done.
+ */
+public class PostConstructModule implements AutoBindModule {
+    private static final Logger LOG = LoggerFactory.getLogger(PostConstructModule.class);
+
+    @Override
+    public void configure(Binder binder) {
+        binder.bindListener(any(), new PostConstructTypeListener());
+    }
+
+    private static class PostConstructTypeListener implements TypeListener {
+        @Override
+        public <I> void hear(TypeLiteral<I> type, TypeEncounter<I> encounter) {
+            hear(type.getRawType(), encounter);
+        }
+
+        private <I> void hear(Class<? super I> type, TypeEncounter<I> encounter) {
+            if (type == null || type.getPackage() == null || type.getPackage().getName().startsWith("java")) {
+                return;
+            }
+
+            for (Method method : type.getDeclaredMethods()) {
+                if (method.isAnnotationPresent(PostConstruct.class)) {
+                    if (method.getParameterTypes().length != 0) {
+                        encounter.addError("@PostConstruct annotated methods must not accept any argument");
+                    }
+
+                    encounter.register(new PostConstructInjectionListener<>(method));
+                }
+            }
+
+            hear(type.getSuperclass(), encounter);
+        }
+    }
+
+    private static class PostConstructInjectionListener<I> implements InjectionListener<I> {
+        private final Method method;
+
+        private PostConstructInjectionListener(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public void afterInjection(I injectee) {
+            LOG.debug("Invoking @PostConstruct method {}", method);
+            try {
+                method.invoke(injectee);
+            } catch (IllegalAccessException e) {
+                throw new ProvisionException(String.format("Could not access @PostConstruct %s on %s",
+                    method,
+                    injectee), e);
+            } catch (InvocationTargetException e) {
+                throw new ProvisionException(String.format("Could not invoke @PostConstruct %s on %s",
+                    method,
+                    injectee), e.getTargetException());
+            }
+        }
+    }
+}

--- a/binding/src/main/java/se/fortnox/reactivewizard/binding/PreDestroyModule.java
+++ b/binding/src/main/java/se/fortnox/reactivewizard/binding/PreDestroyModule.java
@@ -1,0 +1,105 @@
+package se.fortnox.reactivewizard.binding;
+
+import com.google.inject.Binder;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.InjectionListener;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.inject.matcher.Matchers.any;
+
+/**
+ * Finds methods annotated with @{@link PreDestroy} and adds them to a shutdown hook.
+ */
+public class PreDestroyModule implements AutoBindModule {
+    private static final Logger LOG = LoggerFactory.getLogger(PreDestroyModule.class);
+
+    private final Runtime runtime;
+
+    @Inject
+    PreDestroyModule(Runtime runtime) {
+        this.runtime = runtime;
+    }
+
+    @Override
+    public void configure(Binder binder) {
+        final PreDestroyCallbacks callbacks = new PreDestroyCallbacks();
+        binder.bind(PreDestroyCallbacks.class).toInstance(callbacks);
+        binder.bindListener(any(), new PreDestroyTypeListener(callbacks));
+
+        runtime.addShutdownHook(new Thread(callbacks));
+    }
+
+    static class PreDestroyCallbacks implements Runnable {
+        private final List<Runnable> preDestroyCallbacks = new ArrayList<>();
+
+        void add(Runnable runnable) {
+            preDestroyCallbacks.add(runnable);
+        }
+
+        @Override
+        public void run() {
+            preDestroyCallbacks.forEach(Runnable::run);
+        }
+    }
+
+    private static class PreDestroyTypeListener implements TypeListener {
+        private final PreDestroyCallbacks callbacks;
+
+        PreDestroyTypeListener(PreDestroyCallbacks callbacks) {
+            this.callbacks = callbacks;
+        }
+
+        @Override
+        public <I> void hear(TypeLiteral<I> type, TypeEncounter<I> encounter) {
+            hear(type.getRawType(), encounter);
+        }
+
+        private <I> void hear(Class<? super I> type, TypeEncounter<I> encounter) {
+            if (type == null || type.getPackage() == null || type.getPackage().getName().startsWith("java")) {
+                return;
+            }
+
+            for (Method method : type.getDeclaredMethods()) {
+                if (method.isAnnotationPresent(PreDestroy.class)) {
+                    if (method.getParameterTypes().length != 0) {
+                        encounter.addError("@PreDestroy annotated methods must not accept any argument");
+                    }
+
+                    encounter.register(injectionListener(method));
+                }
+            }
+
+            hear(type.getSuperclass(), encounter);
+        }
+
+        private <I> InjectionListener<I> injectionListener(Method method) {
+            return injectee -> callbacks.add(createCallback(injectee, method));
+        }
+
+        private Runnable createCallback(Object instance, Method method) {
+            return () -> {
+                LOG.debug("Invoking @PreDestroy method {}", method);
+                try {
+                    method.invoke(instance);
+                } catch (IllegalAccessException e) {
+                    LOG.warn(String.format("Could not access @PreDestroy %s on %s", method, instance), e);
+                } catch (InvocationTargetException e) {
+                    LOG.warn(String.format("Could not invoke @PreDestroy %s on %s", method, instance),
+                        e.getTargetException());
+                } catch (Exception e) {
+                    LOG.warn(String.format("Could not invoke @PreDestroy %s on %s", method, instance), e);
+                }
+            };
+        }
+    }
+}

--- a/binding/src/test/java/se/fortnox/reactivewizard/binding/PostConstructModuleTest.java
+++ b/binding/src/test/java/se/fortnox/reactivewizard/binding/PostConstructModuleTest.java
@@ -1,0 +1,50 @@
+package se.fortnox.reactivewizard.binding;
+
+import com.google.inject.*;
+import org.junit.Test;
+
+import javax.annotation.PostConstruct;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class PostConstructModuleTest {
+    private Injector injector = Guice.createInjector(new PostConstructModule());
+
+    @Test
+    public void shouldCallMethodsAnnotatedWithPostConstruct() {
+        TestModule test = injector.getInstance(TestModule.class);
+        assertThat(test.constructed).isTrue();
+    }
+
+    @Test(expected = ProvisionException.class)
+    public void shouldFailIfUncheckedExceptionIsThrown() {
+        injector.getInstance(ExceptionThrowingTestModule.class);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void shouldFailOnMethodWithArgument() {
+        injector.getInstance(MethodWithArgmuentTestModule.class);
+    }
+
+    private static class TestModule {
+        private boolean constructed;
+
+        @PostConstruct
+        public void postConstruct() {
+            constructed = true;
+        }
+    }
+
+    private static class ExceptionThrowingTestModule {
+        @PostConstruct
+        public void postConstruct() {
+            throw new RuntimeException("derp");
+        }
+    }
+
+    private static class MethodWithArgmuentTestModule {
+        @PostConstruct
+        public void postConstruct(String foo) {
+        }
+    }
+}

--- a/binding/src/test/java/se/fortnox/reactivewizard/binding/PreDestroyModuleTest.java
+++ b/binding/src/test/java/se/fortnox/reactivewizard/binding/PreDestroyModuleTest.java
@@ -1,0 +1,82 @@
+package se.fortnox.reactivewizard.binding;
+
+import com.google.inject.ConfigurationException;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.annotation.PreDestroy;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PreDestroyModuleTest {
+    @Mock
+    private Runtime runtime;
+
+    private Injector injector;
+
+    @Before
+    public void setUp() {
+        injector = Guice.createInjector(new PreDestroyModule(runtime));
+    }
+
+    @Test
+    public void shouldRegisterShutdownHook() {
+        injector.getInstance(TestModule.class);
+        verify(runtime).addShutdownHook(any());
+    }
+
+    @Test
+    public void shouldCallAnnotatedMethod() {
+        PreDestroyModule.PreDestroyCallbacks callbacks = injector.getInstance(PreDestroyModule.PreDestroyCallbacks.class);
+        TestModule test = injector.getInstance(TestModule.class);
+        callbacks.run();
+        assertThat(test.preDestroyCalled).isTrue();
+    }
+
+    @Test
+    public void shouldIgnoreUncheckedExceptions() {
+        PreDestroyModule.PreDestroyCallbacks callbacks = injector.getInstance(PreDestroyModule.PreDestroyCallbacks.class);
+        injector.getInstance(ExceptionThrowingTestModule.class);
+        try {
+            callbacks.run();
+        } catch (Exception e) {
+            fail("Should not throw exceptions");
+        }
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void shouldFailOnMethodWithArgument() {
+        injector.getInstance(MethodWithArgumentTestModule.class);
+    }
+
+    private static class TestModule {
+        boolean preDestroyCalled = false;
+
+        @PreDestroy
+        public void preDestroy() {
+            preDestroyCalled = true;
+        }
+    }
+
+    private static class ExceptionThrowingTestModule {
+        @PreDestroy
+        public void preDestroy() {
+            throw new RuntimeException("testing @PreDestroy with exceptions");
+        }
+    }
+
+    private static class MethodWithArgumentTestModule {
+        @PreDestroy
+        public void preDestroy(String foo) {
+        }
+    }
+}


### PR DESCRIPTION
To simplify separating instance construction and initialization/cleanup we can support javax.annotation.PostConstruct and javax.annotation.PreDestroy.