### PR TITLE
Improve ParamQueryPart.subPath error message

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/query/parts/ParamQueryPart.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/query/parts/ParamQueryPart.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,7 +62,8 @@ public class ParamQueryPart implements DynamicQueryPart {
     public DynamicQueryPart subPath(String[] subPath) throws SQLException {
         Optional<PropertyResolver> propertyResolver = argResolver.subPath(subPath);
         if (!propertyResolver.isPresent()) {
-            throw new RuntimeException("Properties " + subPath + " cannot be found in " + argResolver);
+            throw new RuntimeException(String.format("Properties %s cannot be found in %s",
+                Arrays.toString(subPath), argResolver.getPropertyType()));
         }
         return new ParamQueryPart(argIndex, propertyResolver.get());
     }

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/query/parts/ParamQueryPartTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/query/parts/ParamQueryPartTest.java
@@ -1,0 +1,49 @@
+package se.fortnox.reactivewizard.db.query.parts;
+
+import org.junit.Test;
+import se.fortnox.reactivewizard.util.ReflectionUtil;
+
+import java.sql.SQLException;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class ParamQueryPartTest {
+    @Test
+    public void shouldIncludePropertiesAndTypeOnSubPathError() throws SQLException {
+        ParamQueryPart paramQueryPart = new ParamQueryPart(0,
+            ReflectionUtil.getPropertyResolver(Foo.class).orElseThrow(IllegalArgumentException::new));
+
+        try {
+            paramQueryPart.subPath(new String[] { "bar", "zap" });
+            fail();
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo(String.format("Properties [bar, zap] cannot be found in class %s",
+                Foo.class.getName()));
+        }
+    }
+
+    public static class Foo {
+        private final Bar bar;
+
+        public Foo(Bar bar) {
+            this.bar = bar;
+        }
+
+        public Bar getBar() {
+            return bar;
+        }
+    }
+
+    public static class Bar {
+        private final String zip;
+
+        public Bar(String zip) {
+            this.zip = zip;
+        }
+
+        public String getZip() {
+            return zip;
+        }
+    }
+}


### PR DESCRIPTION
This has been bothering me for some time. 
The error is now for example "Properties [bar, zap] cannot be found in class se.fortnox.reactivewizard.db.query.parts.ParamQueryPartTest$Foo" instead of "Properties [Ljava.lang.String;@6ad82709 cannot be found in []"