### PR TITLE
Check dao classes to be compiled with -parameters flag

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxyFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxyFactory.java
@@ -14,14 +14,11 @@ import java.lang.reflect.Parameter;
 
 public class DbProxyFactory implements AutoBindModule {
     private static Logger LOG = LoggerFactory.getLogger(DbProxyFactory.class);
-
     private final DaoClassScanner daoClassScanner;
 
     @Inject
     public DbProxyFactory(DaoClassScanner daoClassScanner) {
         this.daoClassScanner = daoClassScanner;
-
-        performCompilerCheck();
     }
 
     private <T> Provider<T> provider(Class<T> iface, Provider<DbProxy> dbProxyProvider) {
@@ -33,6 +30,9 @@ public class DbProxyFactory implements AutoBindModule {
     public void configure(Binder binder) {
         Provider<DbProxy> dbProxyProvider = binder.getProvider(DbProxy.class);
         daoClassScanner.getClasses().forEach(cls -> {
+
+            checkCompiledWithParameters(cls);
+
             binder.bind((Class)cls)
                 .toProvider(provider(cls, dbProxyProvider))
                 .in(Scopes.SINGLETON);
@@ -40,19 +40,24 @@ public class DbProxyFactory implements AutoBindModule {
     }
 
     /**
-     * Checks that we can access the name of a method parameter, and thereby
-     * verifying that the compilation whas run with -parameters.
+     * Checks if the -parameters flag was used to compile the dao class
+     * @param cls the class to use when checking for parameters
+     * @return null if no method with parameters was found, true if method found and -parameters flag was used
+     *         Will log error and System.exit(1) if it turns out parameters flag was not used.
      */
-    private void performCompilerCheck() {
-        try {
-            Method    method         = DbProxyFactory.class.getMethod("configure", Binder.class);
-            Parameter firstParameter = method.getParameters()[0];
-            if (!firstParameter.isNamePresent()) {
-                LOG.error("The project was not compiled with the -parameters option which is required for DAO parameter resolving. " +
-                    "Please see https://github.com/FortnoxAB/reactive-wizard/wiki/CompilerParameters for more information.");
-                System.exit(1);
+    private void checkCompiledWithParameters(Class<?> cls) {
+
+        for (Method method : cls.getMethods()) {
+            if (method.getParameterCount() > 0) {
+
+                Parameter firstParameter = method.getParameters()[0];
+
+                if (!firstParameter.isNamePresent()) {
+                    System.err.println("The project was not compiled with the -parameters option which is required for DAO parameter resolving. " +
+                        "Please see https://github.com/FortnoxAB/reactive-wizard/wiki/CompilerParameters for more information.");
+                    System.exit(1);
+                }
             }
-        } catch (NoSuchMethodException ignored) {
         }
     }
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxyFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxyFactory.java
@@ -41,9 +41,10 @@ public class DbProxyFactory implements AutoBindModule {
 
     /**
      * Checks if the -parameters flag was used to compile the dao class
+     * Exists system if daoclass if found not compiled with parameters.
+     *
      * @param cls the class to use when checking for parameters
-     * @return null if no method with parameters was found, true if method found and -parameters flag was used
-     *         Will log error and System.exit(1) if it turns out parameters flag was not used.
+     *
      */
     private void checkCompiledWithParameters(Class<?> cls) {
 


### PR DESCRIPTION
Changed to System.err.println since it will be more visible to the developer when running mvn commands. 