### PR TITLE
PLAT-1578 - Make readTimeout configurable

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -69,8 +69,8 @@ public class HttpClient implements InvocationHandler {
     private final   Set<PreRequestHook>         preRequestHooks;
     private         RxClientProvider            clientProvider;
     private         ObjectMapper                objectMapper;
-    private         int                         timeout = 10000;
-    private         TimeUnit                    timeoutUnit = TimeUnit.MILLISECONDS;
+    private         int                         timeout = 10;
+    private         TimeUnit                    timeoutUnit = TimeUnit.SECONDS;
 
     @Inject
     public HttpClient(HttpClientConfig config,

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -87,7 +87,7 @@ public class HttpClient implements InvocationHandler {
         serverInfo = new InetSocketAddress(config.getHost(), config.getPort());
         this.preRequestHooks = preRequestHooks;
 
-        this.timeout = config.getMaxRequestTime();
+        this.timeout = config.getMaxRequestTimeMs();
 
     }
 

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -70,8 +69,8 @@ public class HttpClient implements InvocationHandler {
     private final   Set<PreRequestHook>         preRequestHooks;
     private         RxClientProvider            clientProvider;
     private         ObjectMapper                objectMapper;
-    private         int                         timeout     = 10;
-    private         TimeUnit                    timeoutUnit = TimeUnit.SECONDS;
+    private         int                         timeout;
+    private         TimeUnit                    timeoutUnit = TimeUnit.MILLISECONDS;
 
     @Inject
     public HttpClient(HttpClientConfig config,
@@ -87,6 +86,9 @@ public class HttpClient implements InvocationHandler {
 
         serverInfo = new InetSocketAddress(config.getHost(), config.getPort());
         this.preRequestHooks = preRequestHooks;
+
+        this.timeout = config.getMaxRequestTime();
+
     }
 
     public HttpClient(HttpClientConfig config) {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -69,7 +69,7 @@ public class HttpClient implements InvocationHandler {
     private final   Set<PreRequestHook>         preRequestHooks;
     private         RxClientProvider            clientProvider;
     private         ObjectMapper                objectMapper;
-    private         int                         timeout;
+    private         int                         timeout = 10000;
     private         TimeUnit                    timeoutUnit = TimeUnit.MILLISECONDS;
 
     @Inject
@@ -86,9 +86,6 @@ public class HttpClient implements InvocationHandler {
 
         serverInfo = new InetSocketAddress(config.getHost(), config.getPort());
         this.preRequestHooks = preRequestHooks;
-
-        this.timeout = config.getMaxRequestTimeMs();
-
     }
 
     public HttpClient(HttpClientConfig config) {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -42,7 +42,7 @@ public class HttpClientConfig {
     private int maxResponseSize = 10 * 1024 * 1024;
 
     private long poolAutoCleanupInterval = TimeUnit.MILLISECONDS.convert(10, MINUTES);
-    private int  maxRequestTimeMs        = 10000;
+    private long maxRequestTime          = TimeUnit.MILLISECONDS.convert(1, MINUTES);
 
     private boolean isHttps;
     private int     retryCount    = 3;

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -41,11 +41,13 @@ public class HttpClientConfig {
 
     private int maxResponseSize = 10 * 1024 * 1024;
 
-    private long    poolAutoCleanupInterval = TimeUnit.MILLISECONDS.convert(10, MINUTES);
-    private long    maxRequestTime          = TimeUnit.MILLISECONDS.convert(1, MINUTES);
+    private long poolAutoCleanupInterval = TimeUnit.MILLISECONDS.convert(10, MINUTES);
+    private int  maxRequestTime          = 10000;
+
     private boolean isHttps;
-    private int     retryCount              = 3;
-    private int     retryDelayMs            = 1000;
+    private int     retryCount   = 3;
+    private int     retryDelayMs = 1000;
+
 
     public HttpClientConfig() {
     }
@@ -152,5 +154,13 @@ public class HttpClientConfig {
         } catch (UnknownHostException e) {
             throw new RuntimeException("Cannot resolve host for httpClient: " + host, e);
         }
+    }
+
+    public int getMaxRequestTime() {
+        return maxRequestTime;
+    }
+
+    public void setMaxRequestTime(int maxRequestTime) {
+        this.maxRequestTime = maxRequestTime;
     }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -42,7 +42,7 @@ public class HttpClientConfig {
     private int maxResponseSize = 10 * 1024 * 1024;
 
     private long poolAutoCleanupInterval = TimeUnit.MILLISECONDS.convert(10, MINUTES);
-    private int  maxRequestTime          = 10000;
+    private int  maxRequestTimeMs        = 10000;
 
     private boolean isHttps;
     private int     retryCount   = 3;
@@ -156,11 +156,11 @@ public class HttpClientConfig {
         }
     }
 
-    public int getMaxRequestTime() {
-        return maxRequestTime;
+    public int getMaxRequestTimeMs() {
+        return maxRequestTimeMs;
     }
 
-    public void setMaxRequestTime(int maxRequestTime) {
-        this.maxRequestTime = maxRequestTime;
+    public void setMaxRequestTimeMs(int maxRequestTimeMs) {
+        this.maxRequestTimeMs = maxRequestTimeMs;
     }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -45,9 +45,9 @@ public class HttpClientConfig {
     private int  maxRequestTimeMs        = 10000;
 
     private boolean isHttps;
-    private int     retryCount   = 3;
-    private int     retryDelayMs = 1000;
-
+    private int     retryCount    = 3;
+    private int     retryDelayMs  = 1000;
+    private int     readTimeoutMs = 10000;
 
     public HttpClientConfig() {
     }
@@ -156,11 +156,11 @@ public class HttpClientConfig {
         }
     }
 
-    public int getMaxRequestTimeMs() {
-        return maxRequestTimeMs;
+    public int getReadTimeoutMs() {
+        return readTimeoutMs;
     }
 
-    public void setMaxRequestTimeMs(int maxRequestTimeMs) {
-        this.maxRequestTimeMs = maxRequestTimeMs;
+    public void setReadTimeoutMs(int readTimeoutMs) {
+        this.readTimeoutMs = readTimeoutMs;
     }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
@@ -49,7 +49,7 @@ public class RxClientProvider {
         ConnectionProviderFactory<ByteBuf, ByteBuf> pool = new UnsubscribeAwareConnectionProviderFactory(connectionProviderFactory, poolConfig);
 
         HttpClient<ByteBuf, ByteBuf> client = HttpClient.newClient(pool, just(new Host(socketAddress)))
-            .readTimeOut(10, TimeUnit.SECONDS)
+            .readTimeOut(config.getMaxRequestTime(), TimeUnit.MILLISECONDS)
             .followRedirects(false)
             .pipelineConfigurator(UnsubscribeAwareHttpClientToConnectionBridge::configurePipeline);
 

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
@@ -49,7 +49,7 @@ public class RxClientProvider {
         ConnectionProviderFactory<ByteBuf, ByteBuf> pool = new UnsubscribeAwareConnectionProviderFactory(connectionProviderFactory, poolConfig);
 
         HttpClient<ByteBuf, ByteBuf> client = HttpClient.newClient(pool, just(new Host(socketAddress)))
-            .readTimeOut(config.getMaxRequestTimeMs(), TimeUnit.MILLISECONDS)
+            .readTimeOut(config.getReadTimeoutMs(), TimeUnit.MILLISECONDS)
             .followRedirects(false)
             .pipelineConfigurator(UnsubscribeAwareHttpClientToConnectionBridge::configurePipeline);
 

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
@@ -49,7 +49,7 @@ public class RxClientProvider {
         ConnectionProviderFactory<ByteBuf, ByteBuf> pool = new UnsubscribeAwareConnectionProviderFactory(connectionProviderFactory, poolConfig);
 
         HttpClient<ByteBuf, ByteBuf> client = HttpClient.newClient(pool, just(new Host(socketAddress)))
-            .readTimeOut(config.getMaxRequestTime(), TimeUnit.MILLISECONDS)
+            .readTimeOut(config.getMaxRequestTimeMs(), TimeUnit.MILLISECONDS)
             .followRedirects(false)
             .pipelineConfigurator(UnsubscribeAwareHttpClientToConnectionBridge::configurePipeline);
 

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -111,13 +111,18 @@ public class HttpClientTest {
     }
 
     protected TestResource getHttpProxy(int port) {
-        return getHttpProxy(port, 1);
+        return getHttpProxy(port, 1, 10000);
     }
 
     protected TestResource getHttpProxy(int port, int maxConn) {
+        return getHttpProxy(port, maxConn, 10000);
+    }
+
+    protected TestResource getHttpProxy(int port, int maxConn, int maxRequestTime) {
         try {
             HttpClientConfig config = new HttpClientConfig("localhost:" + port);
             config.setMaxConnections(maxConn);
+            config.setMaxRequestTime(maxRequestTime);
             return getHttpProxy(config);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
@@ -443,6 +448,55 @@ public class HttpClientTest {
             assertThat(e.getCause()).isInstanceOf(TimeoutException.class);
         }
         assertThat(callCount.get()).isEqualTo(1);
+
+        server.shutdown();
+    }
+
+    @Test
+    public void shouldHandleLongerRequestsThan10SecondsWhenRequested() {
+        // Slow server
+        HttpServer<ByteBuf, ByteBuf> server = HttpServer.newServer(0)
+            .start((request, response) -> {
+
+                return Observable.defer(() -> {
+                    response.setStatus(HttpResponseStatus.NOT_FOUND);
+                    return Observable.<Void>empty();
+                }).delaySubscription(20000, TimeUnit.MILLISECONDS);
+            });
+
+        TestResource resource = getHttpProxy(server.getServerPort(), 1, 30000);
+        HttpClient.setTimeout(resource, 15000, TimeUnit.MILLISECONDS);
+        try {
+            resource.getHello().toBlocking().singleOrDefault(null);
+            fail("expected exception");
+        } catch (RuntimeException e) {
+            assertThat(e.getCause()).isInstanceOf(TimeoutException.class);
+        }
+
+        server.shutdown();
+    }
+
+    @Test
+    public void shouldThrowNettyReadTimeoutIfRequestTakesLongerThanClientIsConfigured() {
+        // Slow server
+        HttpServer<ByteBuf, ByteBuf> server = HttpServer.newServer(0)
+            .start((request, response) -> Observable.defer(() -> {
+                response.setStatus(HttpResponseStatus.NOT_FOUND);
+                return Observable.<Void>empty();
+            }).delaySubscription(1000, TimeUnit.MILLISECONDS));
+
+        //Create a resource with 500ms limit
+        TestResource resource = getHttpProxy(server.getServerPort(), 1, 500);
+
+        //Lets set the observable timeout higher than the httpproxy readTimeout
+        HttpClient.setTimeout(resource, 1000, TimeUnit.MILLISECONDS);
+
+        try {
+            resource.getHello().toBlocking().singleOrDefault(null);
+            fail("expected exception");
+        } catch (RuntimeException e) {
+            assertThat(e).isInstanceOf(io.netty.handler.timeout.TimeoutException.class);
+        }
 
         server.shutdown();
     }

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -122,7 +122,7 @@ public class HttpClientTest {
         try {
             HttpClientConfig config = new HttpClientConfig("localhost:" + port);
             config.setMaxConnections(maxConn);
-            config.setMaxRequestTime(maxRequestTime);
+            config.setMaxRequestTimeMs(maxRequestTime);
             return getHttpProxy(config);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -122,7 +122,7 @@ public class HttpClientTest {
         try {
             HttpClientConfig config = new HttpClientConfig("localhost:" + port);
             config.setMaxConnections(maxConn);
-            config.setMaxRequestTimeMs(maxRequestTime);
+            config.setReadTimeoutMs(maxRequestTime);
             return getHttpProxy(config);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
1. Making the readTimeout on nettys HttpClient configurable instead of always 10 seconds
2. Making the HttpClient using the configured timeout as the default observable timeout.

