### PR TITLE
Bugfix: RequestParameterSerializers method filtering

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -247,7 +247,7 @@ public class HttpClient implements InvocationHandler {
     }
 
     protected void addContent(Method method, Object[] arguments, RequestBuilder requestBuilder) {
-        if (!requestBuilder.canHaveBody()) {
+        if (!requestBuilder.canHaveBody() || requestBuilder.hasContent()) {
             return;
         }
         Class<?>[]     types       = method.getParameterTypes();

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RequestBuilder.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RequestBuilder.java
@@ -84,6 +84,10 @@ public class RequestBuilder {
             || method.equals(HttpMethod.PATCH);
     }
 
+    public boolean hasContent() {
+        return content != null;
+    }
+
     public void setContent(String content) {
         setContent(content.getBytes(charset));
     }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RequestParameterSerializers.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RequestParameterSerializers.java
@@ -1,6 +1,7 @@
 package se.fortnox.reactivewizard.client;
 
 import javax.inject.Inject;
+import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -26,16 +27,7 @@ public class RequestParameterSerializers {
     }
 
     private Class<?> getAppliedClass(RequestParameterSerializer serializer) {
-        Optional<? extends Class<?>> cls = Arrays.stream(serializer.getClass().getDeclaredMethods())
-            .filter(method -> method.getName().equals("addParameter"))
-            .map(method -> method.getParameterTypes()[0])
-            .findFirst();
-
-        if (!cls.isPresent()) {
-            throw new RuntimeException(cls + " is missing addParameter");
-        }
-
-        return cls.get();
+        return (Class)((ParameterizedType)serializer.getClass().getGenericInterfaces()[0]).getActualTypeArguments()[0];
     }
 
     public RequestParameterSerializer<?> getSerializer(Class<?> type) {

--- a/client/src/test/java/se/fortnox/reactivewizard/client/RequestParameterSerializersTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/RequestParameterSerializersTest.java
@@ -1,0 +1,36 @@
+package se.fortnox.reactivewizard.client;
+
+import org.fest.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class RequestParameterSerializersTest {
+    private RequestParameterSerializers serializers;
+
+    @Before
+    public void setUp() {
+        serializers = new RequestParameterSerializers(Collections.set(new Foo(), new Bar()));
+    }
+
+    @Test
+    public void shouldProvideSerializerByClass() {
+        assertThat(serializers.getSerializer(Foo.class)).isInstanceOf(Foo.class);
+        assertThat(serializers.getSerializer(Bar.class)).isInstanceOf(Bar.class);
+    }
+
+    private class Foo implements RequestParameterSerializer<Foo> {
+        @Override
+        public void addParameter(Foo param, RequestBuilder request) {
+
+        }
+    }
+
+    private class Bar implements RequestParameterSerializer<Bar> {
+        @Override
+        public void addParameter(Bar param, RequestBuilder request) {
+
+        }
+    }
+}

--- a/config/src/main/java/se/fortnox/reactivewizard/config/ConfigReader.java
+++ b/config/src/main/java/se/fortnox/reactivewizard/config/ConfigReader.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 public class ConfigReader {
     private static final Charset      UTF_8           = Charset.forName("UTF-8");
     private static final ObjectMapper mapper          = new ObjectMapper(new YAMLFactory()).configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    private static final Pattern      ENV_PLACEHOLDER = Pattern.compile("\\{\\{([a-zA-Z_-]+)\\}\\}");
+    private static final Pattern      ENV_PLACEHOLDER = Pattern.compile("\\{\\{([a-zA-Z_]\\w+)\\}\\}");
 
     /**
      * Create an instance of a configuration from a file path.

--- a/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
@@ -85,14 +85,17 @@ public class ConfigReaderTest {
     public void shouldReplaceEnvPlaceholderWithValue() {
         Map<String, String> env = new HashMap<>(System.getenv());
         env.put("CUSTOM_ENV_VAR", "hello");
+        env.put("CUSTOM_ENV_VAR2", "hello again");
         setEnv(env);
 
         TestConfig testConfig = ConfigReader.fromFile("src/test/resources/testconfig.yml", TestConfig.class);
         assertThat(testConfig.getConfigWithEnvPlaceholder()).isEqualTo("hello");
+        assertThat(testConfig.getConfigWithEnvPlaceholder2()).isEqualTo("hello again");
         assertThat(testConfig.getConfigWithEnvPlaceholderInMiddle()).isEqualTo("beforehelloafter");
 
         testConfig = ConfigReader.fromTree(ConfigReader.readTree("src/test/resources/testconfig.yml"), TestConfig.class);
         assertThat(testConfig.getConfigWithEnvPlaceholder()).isEqualTo("hello");
+        assertThat(testConfig.getConfigWithEnvPlaceholder2()).isEqualTo("hello again");
         assertThat(testConfig.getConfigWithEnvPlaceholderInMiddle()).isEqualTo("beforehelloafter");
     }
 

--- a/config/src/test/java/se/fortnox/reactivewizard/config/TestConfig.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/TestConfig.java
@@ -4,6 +4,7 @@ package se.fortnox.reactivewizard.config;
 public class TestConfig {
     private String myKey;
     private String configWithEnvPlaceholder;
+    private String configWithEnvPlaceholder2;
     private String configWithEnvPlaceholderInMiddle;
     private String url;
 
@@ -21,6 +22,14 @@ public class TestConfig {
 
     public void setConfigWithEnvPlaceholder(String configWithEnvPlaceholder) {
         this.configWithEnvPlaceholder = configWithEnvPlaceholder;
+    }
+
+    public String getConfigWithEnvPlaceholder2() {
+        return configWithEnvPlaceholder2;
+    }
+
+    public void setConfigWithEnvPlaceholder2(String configWithEnvPlaceholder2) {
+        this.configWithEnvPlaceholder2 = configWithEnvPlaceholder2;
     }
 
     public String getConfigWithEnvPlaceholderInMiddle() {

--- a/config/src/test/resources/testconfig.yml
+++ b/config/src/test/resources/testconfig.yml
@@ -1,6 +1,7 @@
 myTestConfig:
   myKey: myValue
   configWithEnvPlaceholder: {{CUSTOM_ENV_VAR}}
+  configWithEnvPlaceholder2: {{CUSTOM_ENV_VAR2}}
   configWithEnvPlaceholderInMiddle: before{{CUSTOM_ENV_VAR}}after
   url: http://{{HOST}}:{{PORT}}/test
 


### PR DESCRIPTION
Using Class.getDeclaredMethods() can return multiple methods for
addParameter (one taking the type argument as first argument and one
taking Object as the first argument) and since the order is unspecified
findFirst cannot be used.

Oh, the fix for reading all allowed environment variables in ConfigReader snuck in as well. I meant to separate that into another PR...