### PR TITLE
Fixed so that retry will work together with transactional dao calls

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/AbstractDbStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/AbstractDbStatementFactory.java
@@ -66,7 +66,6 @@ public abstract class AbstractDbStatementFactory implements DbStatementFactory {
             if (!(statement instanceof StatementImpl)) {
                 return false;
             }
-
             return AbstractDbStatementFactory.this.sameBatch(((StatementImpl)statement).parameterizedQuery);
         }
 

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/TransactionStatement.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/TransactionStatement.java
@@ -8,42 +8,54 @@ import java.sql.SQLException;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TransactionStatement implements Batchable {
-    private final AtomicReference<Statement> statement;
-    private final Transaction                transaction;
+	private final AtomicReference<Statement> statement;
+	private final Transaction                transaction;
 
-    public TransactionStatement(Transaction transaction) {
-        this.transaction = transaction;
-        this.statement = new AtomicReference<>();
-    }
+	public TransactionStatement(Transaction transaction) {
+		this.transaction = transaction;
+		this.statement = new AtomicReference<>();
+	}
 
-    public boolean isSubscribed() {
-        return statement.get() != null;
-    }
+	public boolean isSubscribed() {
+		return statement.get() != null;
+	}
 
-    public void executeStatement(Statement statement) {
-        if (this.statement.compareAndSet(null, statement)) {
-            transaction.subscribed();
-        } else {
-            throw new TransactionAlreadyExecutedException();
-        }
-    }
+	public void executeStatement(Statement statement) {
+		if (this.statement.compareAndSet(null, statement)) {
+			transaction.subscribed();
+		} else {
+			throw new TransactionAlreadyExecutedException();
+		}
+	}
 
-    public Statement getStatement() {
-        return statement.get();
-    }
+	public Statement getStatement() {
+		return statement.get();
+	}
 
-    public void setConnectionProvider(ConnectionProvider connectionProvider) {
-        transaction.setConnectionProvider(connectionProvider);
-    }
+	public void removeStatement() {
+		statement.set(null);
+	}
 
-    @Override
-    public boolean sameBatch(Batchable batchable) {
-        return batchable instanceof TransactionStatement
-            && getStatement().sameBatch(((TransactionStatement)batchable).getStatement());
-    }
+	public void setConnectionProvider(ConnectionProvider connectionProvider) {
+		transaction.setConnectionProvider(connectionProvider);
+	}
 
-    @Override
-    public void execute(Connection connection) throws SQLException {
-        getStatement().execute(connection);
-    }
+	public Transaction getTransaction() {
+		return transaction;
+	}
+
+	public AtomicReference<Statement> getAtomicStatement() {
+		return statement;
+	}
+
+	@Override
+	public boolean sameBatch(Batchable batchable) {
+		return batchable instanceof TransactionStatement
+			&& getStatement().sameBatch(((TransactionStatement)batchable).getStatement());
+	}
+
+	@Override
+	public void execute(Connection connection) throws SQLException {
+		getStatement().execute(connection);
+	}
 }


### PR DESCRIPTION
I discovered that the DaoTransactions could not be retried. The implementation was throwing an "alreadyExecutedException" instead of doing a retry.  Now we will reset the state on error. 