### PR TITLE
Prefer a secure HTTP client when calling https services

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -45,9 +45,11 @@ public class HttpClientConfig {
     private long maxRequestTime          = TimeUnit.MILLISECONDS.convert(1, MINUTES);
 
     private boolean isHttps;
-    private int     retryCount    = 3;
-    private int     retryDelayMs  = 1000;
-    private int     readTimeoutMs = 10000;
+    private int     retryCount     = 3;
+    private int     retryDelayMs   = 1000;
+    private int     readTimeoutMs  = 10000;
+    @JsonProperty("unsafeSecure")
+    private boolean isUnsafeSecure = false;
 
     public HttpClientConfig() {
     }
@@ -162,5 +164,13 @@ public class HttpClientConfig {
 
     public void setReadTimeoutMs(int readTimeoutMs) {
         this.readTimeoutMs = readTimeoutMs;
+    }
+
+    public boolean isUnsafeSecure() {
+        return isHttps() && isUnsafeSecure;
+    }
+
+    public void setUnsafeSecure(boolean value) {
+        isUnsafeSecure = value;
     }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -45,11 +45,11 @@ public class HttpClientConfig {
     private long maxRequestTime          = TimeUnit.MILLISECONDS.convert(1, MINUTES);
 
     private boolean isHttps;
-    private int     retryCount     = 3;
-    private int     retryDelayMs   = 1000;
-    private int     readTimeoutMs  = 10000;
-    @JsonProperty("unsafeSecure")
-    private boolean isUnsafeSecure = false;
+    private int     retryCount    = 3;
+    private int     retryDelayMs  = 1000;
+    private int     readTimeoutMs = 10000;
+    @JsonProperty("insecure")
+    private boolean isInsecure    = false;
 
     public HttpClientConfig() {
     }
@@ -166,11 +166,11 @@ public class HttpClientConfig {
         this.readTimeoutMs = readTimeoutMs;
     }
 
-    public boolean isUnsafeSecure() {
-        return isHttps() && isUnsafeSecure;
+    public boolean isInsecure() {
+        return isHttps() && isInsecure;
     }
 
-    public void setUnsafeSecure(boolean value) {
-        isUnsafeSecure = value;
+    public void setInsecure(boolean value) {
+        isInsecure = value;
     }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -45,11 +45,11 @@ public class HttpClientConfig {
     private long maxRequestTime          = TimeUnit.MILLISECONDS.convert(1, MINUTES);
 
     private boolean isHttps;
-    private int     retryCount    = 3;
-    private int     retryDelayMs  = 1000;
-    private int     readTimeoutMs = 10000;
-    @JsonProperty("insecure")
-    private boolean isInsecure    = false;
+    private int     retryCount             = 3;
+    private int     retryDelayMs           = 1000;
+    private int     readTimeoutMs          = 10000;
+    @JsonProperty("validateCertificates")
+    private boolean isValidateCertificates = true;
 
     public HttpClientConfig() {
     }
@@ -166,11 +166,11 @@ public class HttpClientConfig {
         this.readTimeoutMs = readTimeoutMs;
     }
 
-    public boolean isInsecure() {
-        return isHttps() && isInsecure;
+    public boolean isValidateCertificates() {
+        return isHttps() && isValidateCertificates;
     }
 
-    public void setInsecure(boolean value) {
-        isInsecure = value;
+    public void setValidateCertificates(boolean value) {
+        isValidateCertificates = value;
     }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
@@ -44,8 +44,8 @@ public class RxClientProvider {
         return clients.computeIfAbsent(serverInfo, this::buildClient);
     }
 
-    private HttpClient<ByteBuf, ByteBuf> configureSsl(HttpClient<ByteBuf, ByteBuf> client, String host, int port, boolean isUnsafeSecure) {
-        if (isUnsafeSecure) {
+    private HttpClient<ByteBuf, ByteBuf> configureSsl(HttpClient<ByteBuf, ByteBuf> client, String host, int port, boolean isValidateCertificates) {
+        if (!isValidateCertificates) {
             return client.unsafeSecure();
         }
 
@@ -75,7 +75,7 @@ public class RxClientProvider {
             .pipelineConfigurator(UnsubscribeAwareHttpClientToConnectionBridge::configurePipeline);
 
         if (config.isHttps()) {
-            return configureSsl(client, config.getHost(), config.getPort(), config.isInsecure());
+            return configureSsl(client, config.getHost(), config.getPort(), config.isValidateCertificates());
         }
         return client;
     }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
@@ -58,7 +58,7 @@ public class RxClientProvider {
 
             return client.secure(sslEngine);
         } catch (Throwable e) {
-            throw new RuntimeException("Unable to create secure client.", e);
+            throw new RuntimeException("Unable to create secure https client.", e);
         }
     }
 

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
@@ -14,6 +14,8 @@ import se.fortnox.reactivewizard.metrics.Metrics;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -27,7 +29,8 @@ import static rx.Observable.just;
  */
 @Singleton
 public class RxClientProvider {
-    private final ConcurrentHashMap<InetSocketAddress, HttpClient<ByteBuf, ByteBuf>> clients = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<InetSocketAddress, HttpClient<ByteBuf, ByteBuf>> clients    = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, SSLEngine>                               sslEngines = new ConcurrentHashMap<>();
     private final HttpClientConfig                                                   config;
     private final HealthRecorder                                                     healthRecorder;
 
@@ -39,6 +42,24 @@ public class RxClientProvider {
 
     public HttpClient<ByteBuf, ByteBuf> clientFor(InetSocketAddress serverInfo) {
         return clients.computeIfAbsent(serverInfo, this::buildClient);
+    }
+
+    private HttpClient<ByteBuf, ByteBuf> configureSsl(HttpClient<ByteBuf, ByteBuf> client, String host, int port, boolean isUnsafeSecure) {
+        if (isUnsafeSecure) {
+            return client.unsafeSecure();
+        }
+
+        try {
+            SSLEngine sslEngine = sslEngines.computeIfAbsent(host + ":" + port, s -> {
+                SSLEngine innerSslEngine = configureSslEngine(host, port);
+                innerSslEngine.setUseClientMode(true);
+                return innerSslEngine;
+            });
+
+            return client.secure(sslEngine);
+        } catch (Throwable e) {
+            throw new RuntimeException("Unable to create secure client.", e);
+        }
     }
 
     private HttpClient<ByteBuf, ByteBuf> buildClient(InetSocketAddress socketAddress) {
@@ -54,9 +75,22 @@ public class RxClientProvider {
             .pipelineConfigurator(UnsubscribeAwareHttpClientToConnectionBridge::configurePipeline);
 
         if (config.isHttps()) {
-            client = client.unsafeSecure();
+            return configureSsl(client, config.getHost(), config.getPort(), config.isUnsafeSecure());
         }
         return client;
+    }
+
+    /**
+     * Allows for customization of the SSLEngine
+     *
+     * @return An configured SSLEngine
+     */
+    protected SSLEngine configureSslEngine(String host, int port) {
+        try {
+            return SSLContext.getDefault().createSSLEngine(host, port);
+        } catch (Throwable e) {
+            throw new RuntimeException("Unable to configure secure client", e);
+        }
     }
 
     protected ConnectionProviderFactory<ByteBuf, ByteBuf> createConnectionProviderFactory(PoolConfig<ByteBuf, ByteBuf> poolConfig) {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
@@ -75,7 +75,7 @@ public class RxClientProvider {
             .pipelineConfigurator(UnsubscribeAwareHttpClientToConnectionBridge::configurePipeline);
 
         if (config.isHttps()) {
-            return configureSsl(client, config.getHost(), config.getPort(), config.isUnsafeSecure());
+            return configureSsl(client, config.getHost(), config.getPort(), config.isInsecure());
         }
         return client;
     }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
@@ -85,7 +85,7 @@ public class RxClientProvider {
      *
      * @return An configured SSLEngine
      */
-    protected SSLEngine configureSslEngine(String host, int port) {
+    SSLEngine configureSslEngine(String host, int port) {
         try {
             return SSLContext.getDefault().createSSLEngine(host, port);
         } catch (Throwable e) {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RxClientProvider.java
@@ -50,7 +50,7 @@ public class RxClientProvider {
         }
 
         try {
-            SSLEngine sslEngine = sslEngines.computeIfAbsent(host + ":" + port, s -> {
+            SSLEngine sslEngine = sslEngines.computeIfAbsent(host + ":" + port, hostPortValue -> {
                 SSLEngine innerSslEngine = configureSslEngine(host, port);
                 innerSslEngine.setUseClientMode(true);
                 return innerSslEngine;

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientConfigTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientConfigTest.java
@@ -114,4 +114,11 @@ public class HttpClientConfigTest {
             assertThat(e.getCause()).isInstanceOf(UnknownHostException.class);
         }
     }
+
+    @Test
+    public void shouldNotBeInsecureByDefault() throws URISyntaxException {
+        HttpClientConfig httpClientConfig = new HttpClientConfig("https://example.com");
+        assertThat(httpClientConfig.isHttps()).isTrue();
+        assertThat(httpClientConfig.isInsecure()).isFalse();
+    }
 }

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientConfigTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientConfigTest.java
@@ -119,6 +119,6 @@ public class HttpClientConfigTest {
     public void shouldNotBeInsecureByDefault() throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig("https://example.com");
         assertThat(httpClientConfig.isHttps()).isTrue();
-        assertThat(httpClientConfig.isInsecure()).isFalse();
+        assertThat(httpClientConfig.isValidateCertificates()).isTrue();
     }
 }

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -942,12 +942,7 @@ public class HttpClientTest {
     @Test
     public void shouldHandleHttpsAgainstKnownHost() throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig("https://sha512.badssl.com/");
-        Injector injector = TestInjector.create(binder -> {
-            binder.bind(ServerConfig.class).toInstance(new ServerConfig() {{
-                setEnabled(false);
-            }});
-            binder.bind(HttpClientConfig.class).toInstance(httpClientConfig);
-        });
+        Injector         injector         = injectorWithProgrammaticHttpClientConfig(httpClientConfig);
         RxClientProvider rxClientProvider = injector.getInstance(RxClientProvider.class);
 
         rxClientProvider
@@ -961,12 +956,7 @@ public class HttpClientTest {
     @Test
     public void shouldErrorOnUntrustedHost() throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig("https://untrusted-root.badssl.com");
-        Injector injector = TestInjector.create(binder -> {
-            binder.bind(ServerConfig.class).toInstance(new ServerConfig() {{
-                setEnabled(false);
-            }});
-            binder.bind(HttpClientConfig.class).toInstance(httpClientConfig);
-        });
+        Injector injector = injectorWithProgrammaticHttpClientConfig(httpClientConfig);
         RxClientProvider rxClientProvider = injector.getInstance(RxClientProvider.class);
 
         try {
@@ -986,12 +976,7 @@ public class HttpClientTest {
     public void shouldHandleUnsafeSecureOnUntrustedHost() throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig("https://untrusted-root.badssl.com");
         httpClientConfig.setValidateCertificates(false);
-        Injector injector = TestInjector.create(binder -> {
-            binder.bind(ServerConfig.class).toInstance(new ServerConfig() {{
-                setEnabled(false);
-            }});
-            binder.bind(HttpClientConfig.class).toInstance(httpClientConfig);
-        });
+        Injector injector = injectorWithProgrammaticHttpClientConfig(httpClientConfig);
         RxClientProvider rxClientProvider = injector.getInstance(RxClientProvider.class);
 
         rxClientProvider
@@ -1010,6 +995,15 @@ public class HttpClientTest {
         resp[0] = '\"';
         resp[resp.length - 1] = '\"';
         return new String(resp);
+    }
+
+    private Injector injectorWithProgrammaticHttpClientConfig(HttpClientConfig httpClientConfig) {
+        return TestInjector.create(binder -> {
+            binder.bind(ServerConfig.class).toInstance(new ServerConfig() {{
+                setEnabled(false);
+            }});
+            binder.bind(HttpClientConfig.class).toInstance(httpClientConfig);
+        });
     }
 
     @Path("/hello")

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -976,6 +976,7 @@ public class HttpClientTest {
                 .flatMap(HttpClientResponse::discardContent)
                 .toBlocking()
                 .singleOrDefault(null);
+            fail("Expected SSLHandshakeException");
         } catch (RuntimeException runtimeException) {
             assertThat(runtimeException.getCause()).isInstanceOf(SSLHandshakeException.class);
         }

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -985,7 +985,7 @@ public class HttpClientTest {
     @Test
     public void shouldHandleUnsafeSecureOnUntrustedHost() throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig("https://untrusted-root.badssl.com");
-        httpClientConfig.setInsecure(true);
+        httpClientConfig.setValidateCertificates(false);
         Injector injector = TestInjector.create(binder -> {
             binder.bind(ServerConfig.class).toInstance(new ServerConfig() {{
                 setEnabled(false);

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -985,7 +985,7 @@ public class HttpClientTest {
     @Test
     public void shouldHandleUnsafeSecureOnUntrustedHost() throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig("https://untrusted-root.badssl.com");
-        httpClientConfig.setUnsafeSecure(true);
+        httpClientConfig.setInsecure(true);
         Injector injector = TestInjector.create(binder -> {
             binder.bind(ServerConfig.class).toInstance(new ServerConfig() {{
                 setEnabled(false);


### PR DESCRIPTION
- Introduces an option "unsafeSecure" (default false) to make insecure requests.
- Allow the user to somewhat configure the SSL engine when there is
  a need to do so (custom trustmanagers, not having a keystore on
  file, etc).