### PR TITLE
Properly escape replacement string when replacing config variables

### DIFF
--- a/config/src/main/java/se/fortnox/reactivewizard/config/ConfigReader.java
+++ b/config/src/main/java/se/fortnox/reactivewizard/config/ConfigReader.java
@@ -56,7 +56,7 @@ public class ConfigReader {
         StringBuffer        stringBuffer = new StringBuffer();
         do {
             String value = env.get(matcher.group(1));
-            matcher.appendReplacement(stringBuffer, value == null ? "" : value);
+            matcher.appendReplacement(stringBuffer, value == null ? "" : Matcher.quoteReplacement(value));
         }
         while (matcher.find());
         matcher.appendTail(stringBuffer);

--- a/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
@@ -100,6 +100,17 @@ public class ConfigReaderTest {
     }
 
     @Test
+    public void shouldQuoteReplacementString() {
+        Map<String, String> env = new HashMap<>(System.getenv());
+        env.put("CUSTOM_ENV_VAR", "^THIS.IS.A.\\d{6}T\\d{7}.REGEX1$");
+        setEnv(env);
+
+        TestConfig testConfig = ConfigReader.fromFile("src/test/resources/testconfig.yml", TestConfig.class);
+        assertThat(testConfig.getConfigWithEnvPlaceholder()).isEqualTo("^THIS.IS.A.\\d{6}T\\d{7}.REGEX1$");
+
+    }
+
+    @Test
     public void shouldReplaceEnvPlaceholderWithEmptyStringIfEnvNotSet() {
         TestConfig testConfig = ConfigReader.fromFile("src/test/resources/testconfig-missing-value.yml", TestConfig.class);
         assertThat(testConfig.getConfigWithEnvPlaceholder()).isNull();


### PR DESCRIPTION
The replacement string (coming from an env var) needs to be treated as
a literal string. If it contains a regex (or any \ or $) and is not quoted it will be
treated as a regex when replacing the value.