### PR TITLE
Add database socket timeout

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>2.4.5</version>
+            <version>3.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ConnectionProviderImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ConnectionProviderImpl.java
@@ -30,6 +30,8 @@ public class ConnectionProviderImpl implements ConnectionProvider {
         connectionPool.setMaxLifetime(databaseConfig.getMaxLifetime());
         connectionPool.setMetricRegistry(Metrics.registry());
 
+        connectionPool.addDataSourceProperty("socketTimeout", databaseConfig.getSocketTimeout());
+
         DbDriver.loadDriver(databaseConfig.getUrl());
 
         ds = new HikariDataSource(connectionPool);

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/config/DatabaseConfig.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/config/DatabaseConfig.java
@@ -2,6 +2,8 @@ package se.fortnox.reactivewizard.db.config;
 
 import se.fortnox.reactivewizard.config.Config;
 
+import java.util.concurrent.Executor;
+
 @Config("database")
 public class DatabaseConfig {
 
@@ -15,6 +17,7 @@ public class DatabaseConfig {
     private long   maxLifetime           = 1800000;
     private int    minimumIdle           = 1;
     private long   slowQueryLogThreshold = 5000;
+    private long   socketTimeout         = 300;
 
     public String getSchema() {
         return schema;
@@ -94,5 +97,21 @@ public class DatabaseConfig {
 
     public void setSlowQueryLogThreshold(long slowQueryLogThreshold) {
         this.slowQueryLogThreshold = slowQueryLogThreshold;
+    }
+
+    /**
+     * Get the configured socket timeout.
+     * The socket timeout will be passed on to the jdbc driver and is a global timeout to stop absurdly long queries
+     * or strange network partition problems. If the value is 0 the timeout is disabled.
+     *
+     * @see java.sql.Connection#setNetworkTimeout(Executor, int)
+     * @return The socket timeout in seconds
+     */
+    public long getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public void setSocketTimeout(long socketTimeout) {
+        this.socketTimeout = socketTimeout;
     }
 }

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/config/DatabaseConfigTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/config/DatabaseConfigTest.java
@@ -1,0 +1,36 @@
+package se.fortnox.reactivewizard.db.config;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class DatabaseConfigTest {
+    @Test
+    public void shouldProvideDatabaseConfig() {
+        // this is a bit absurd, but it pleases the coverage check gods
+        DatabaseConfig config = new DatabaseConfig();
+        config.setConnectionTimeout(1);
+        config.setIdleTimeout(2);
+        config.setMaxLifetime(3);
+        config.setMinimumIdle(4);
+        config.setPassword("pass");
+        config.setPoolSize(5);
+        config.setSchema("schema");
+        config.setSlowQueryLogThreshold(6);
+        config.setSocketTimeout(7);
+        config.setUrl("url");
+        config.setUser("user");
+
+        assertThat(config.getConnectionTimeout()).isEqualTo(1);
+        assertThat(config.getIdleTimeout()).isEqualTo(2);
+        assertThat(config.getMaxLifetime()).isEqualTo(3);
+        assertThat(config.getMinimumIdle()).isEqualTo(4);
+        assertThat(config.getPassword()).isEqualTo("pass");
+        assertThat(config.getPoolSize()).isEqualTo(5);
+        assertThat(config.getSchema()).isEqualTo("schema");
+        assertThat(config.getSlowQueryLogThreshold()).isEqualTo(6);
+        assertThat(config.getSocketTimeout()).isEqualTo(7);
+        assertThat(config.getUrl()).isEqualTo("url");
+        assertThat(config.getUser()).isEqualTo("user");
+    }
+}


### PR DESCRIPTION
These changes update the version of HikariCP and add a DatabaseConfig option to configure a socket timeout.

Is the default timeout of 5 minutes reasonable or should we perhaps use 10 minutes? 
If any query takes longer to execute than this timeout the connection will be closed.