### PR TITLE
Log cause(s) of CreationException

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>4.1.0</version>
+			<version>${guice.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
         <rxjava.version>1.2.10</rxjava.version>
         <jackson.version>2.8.8</jackson.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <guice.version>4.1.0</guice.version>
-        <guava.version>23.0</guava.version>
+        <guice.version>4.2.2</guice.version>
+        <guava.version>27.0.1-jre</guava.version>
 
         <junit.version>4.12</junit.version>
         <fest.version>1.4</fest.version>


### PR DESCRIPTION
CreationException has a method getMessage which nicely formats the cause of why an instance couldn't be created by the injector. Calling this method leads to an com.google.common.util.concurrent.UncheckedExecutionException:

> Caused by: java.lang.IllegalArgumentException: null
        at com.google.inject.internal.asm.$ClassReader.<init>(Unknown Source)
        at com.google.inject.internal.asm.$ClassReader.<init>(Unknown Source)
        at com.google.inject.internal.asm.$ClassReader.<init>(Unknown Source)
        at com.google.inject.internal.util.LineNumbers.<init>(LineNumbers.java:66)
        at com.google.inject.internal.util.StackTraceElements$1.load(StackTraceElements.java:46)
        at com.google.inject.internal.util.StackTraceElements$1.load(StackTraceElements.java:43)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3527)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2276)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2154)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2044)
        at com.google.common.cache.LocalCache.get(LocalCache.java:3951)
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3973)
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4957)
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4963)
        at com.google.inject.internal.util.StackTraceElements.forMember(StackTraceElements.java:70)
        at com.google.inject.internal.Errors.formatParameter(Errors.java:859)
        at com.google.inject.internal.Errors.formatInjectionPoint(Errors.java:846)
        at com.google.inject.internal.Errors.formatSource(Errors.java:805)
        at com.google.inject.internal.Errors.formatSource(Errors.java:796)
        at com.google.inject.internal.Errors.format(Errors.java:590)
        at com.google.inject.CreationException.getMessage(CreationException.java:50)

So getMessage() *should* work, but isn't. So instead we grab each causes from each Message and print them out.

Error was found when using "httpClient: x" in the config. HttpClientConfig throws a runtime exception in the constructor since "x" cannot be resolved to an ip.