### PR TITLE
WIP: Fix so that we are validating configurations

### DIFF
--- a/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
+++ b/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
@@ -24,7 +24,6 @@ public class Main {
                 @Override
                 protected void configure() {
                     bind(String[].class).annotatedWith(Names.named("args")).toInstance(args);
-                    bind(ConfigFactory.class).toInstance(configFactory);
                 }
             };
             Guice.createInjector(new AutoBindModules(bootstrap));

--- a/validation/src/main/java/se/fortnox/reactivewizard/validation/ValidationModule.java
+++ b/validation/src/main/java/se/fortnox/reactivewizard/validation/ValidationModule.java
@@ -56,4 +56,13 @@ public class ValidationModule implements AutoBindModule {
     private <T> Provider<T> validatingProvider(Class<T> iface, Provider<T> wrappedProvider, Provider<ValidatorUtil> validatorUtilProvider) {
         return () -> ValidatingProxy.create(iface, wrappedProvider.get(), validatorUtilProvider.get());
     }
+
+    /**
+     * Shall be executed before the @{@link se.fortnox.reactivewizard.config.ConfigAutoBindModule}
+     * @return
+     */
+    @Override
+    public Integer getPrio() {
+        return 99;
+    }
 }

--- a/validation/src/test/java/se/fortnox/reactivewizard/validation/ConfigValidationTest.java
+++ b/validation/src/test/java/se/fortnox/reactivewizard/validation/ConfigValidationTest.java
@@ -1,9 +1,11 @@
 package se.fortnox.reactivewizard.validation;
 
 import com.google.inject.Injector;
+import com.google.inject.Provider;
 import com.google.inject.ProvisionException;
 import org.junit.Test;
 import se.fortnox.reactivewizard.config.Config;
+import se.fortnox.reactivewizard.config.ConfigFactory;
 import se.fortnox.reactivewizard.config.TestInjector;
 
 import javax.validation.constraints.NotEmpty;
@@ -29,6 +31,8 @@ public class ConfigValidationTest {
     public void shouldReturnConfigForCorrectConfig() {
         Injector injector = TestInjector.create("src/test/resources/correctconfig.yml");
         injector.getInstance(ValidatedConfig.class);
+        ConfigFactory configFactory = injector.getInstance(ConfigFactory.class);
+        assertThat(configFactory).isInstanceOf(ValidatingConfigFactory.class);
     }
 
     @Config("myconfig")


### PR DESCRIPTION
I found out that validation was not working on config object. The problem was that in Main.java in the bootstrap module, we define a configFactory that should be bound. We do the same in the autobind modules, but there we bind it to a configFactory with validation abilities. The AutoBindModules class says that the bootstrap bindings shall override the application bindings. The only way to get around the problem was to remove the binding from the bootstrap module.