### PR TITLE
Added maxRequestSize to ServerConfig to specify size of incoming req

### DIFF
--- a/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
+++ b/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
@@ -8,6 +8,7 @@ import liquibase.exception.LiquibaseException;
 import org.junit.Test;
 import se.fortnox.reactivewizard.binding.AutoBindModules;
 import se.fortnox.reactivewizard.config.ConfigFactory;
+import se.fortnox.reactivewizard.config.MockConfigFactory;
 import se.fortnox.reactivewizard.server.ServerConfig;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -105,14 +106,17 @@ public class LiquibaseAutoBindModuleTest {
 
     private LiquibaseMigrate getInjectedLiquibaseMock(LiquibaseMigrate liquibaseMigrateMock, String... arg) {
         Guice.createInjector(new AutoBindModules(binder -> {
-            binder.bind(ServerConfig.class).toInstance(new ServerConfig() {{
+            ConfigFactory configFactory = mock(ConfigFactory.class);
+
+            ServerConfig serverConfig = new ServerConfig() {{
                 setEnabled(false);
-            }});
+            }};
+            when(configFactory.get(eq(ServerConfig.class))).thenReturn(serverConfig);
+            binder.bind(ServerConfig.class).toInstance(serverConfig);
 
             LiquibaseConfig liquibaseConfig = new LiquibaseConfig();
             liquibaseConfig.setUrl("jdbc:h2:mem:test");
 
-            ConfigFactory configFactory = mock(ConfigFactory.class);
             when(configFactory.get(eq(LiquibaseConfig.class))).thenReturn(liquibaseConfig);
             binder.bind(ConfigFactory.class).toInstance(configFactory);
 

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/ByteBufCollector.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/ByteBufCollector.java
@@ -13,6 +13,10 @@ public class ByteBufCollector {
 
     private final int maxReqSize;
 
+    public ByteBufCollector() {
+        this.maxReqSize = 10 * 1024 * 1024;
+    }
+
     public ByteBufCollector(int maxReqSize) {
         this.maxReqSize = maxReqSize;
     }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/ByteBufCollector.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/ByteBufCollector.java
@@ -2,7 +2,6 @@ package se.fortnox.reactivewizard.jaxrs;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.reactivex.netty.channel.ContentSource;
 import rx.Observable;
 
 import java.io.ByteArrayOutputStream;

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequest.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequest.java
@@ -25,24 +25,26 @@ import static rx.Observable.just;
  * Represents an incoming request. Helps with extracting different types of data from the request.
  */
 public class JaxRsRequest {
-    private static final Logger           LOG       = LoggerFactory.getLogger(JaxRsResource.class);
-    private static final ByteBufCollector collector = new ByteBufCollector(10 * 1024 * 1024); // 10 MB
+    private static final Logger LOG = LoggerFactory.getLogger(JaxRsResource.class);
+
     private final HttpServerRequest<ByteBuf> req;
     private final byte[]                     body;
     private       Matcher                    matcher;
+    private final ByteBufCollector           collector;
 
-    protected JaxRsRequest(HttpServerRequest<ByteBuf> req, Matcher matcher, byte[] body) {
-        this.req = req;
-        this.matcher = matcher;
-        this.body = body;
+    protected JaxRsRequest(HttpServerRequest<ByteBuf> req, Matcher matcher, byte[] body, ByteBufCollector collector) {
+        this.req       = req;
+        this.matcher   = matcher;
+        this.body      = body;
+        this.collector = collector; // 10 MB as default
     }
 
-    public JaxRsRequest(HttpServerRequest<ByteBuf> request) {
-        this(request, null, null);
+    public JaxRsRequest(HttpServerRequest<ByteBuf> request, ByteBufCollector collector) {
+        this(request, null, null, collector);
     }
 
-    protected JaxRsRequest create(HttpServerRequest<ByteBuf> req, Matcher matcher, byte[] body) {
-        return new JaxRsRequest(req, matcher, body);
+    protected JaxRsRequest create(HttpServerRequest<ByteBuf> req, Matcher matcher, byte[] body, ByteBufCollector collector) {
+        return new JaxRsRequest(req, matcher, body, collector);
     }
 
     public boolean hasMethod(HttpMethod httpMethod) {
@@ -59,7 +61,7 @@ public class JaxRsRequest {
             return collector.collectBytes(req.getContent()
                 .doOnError(e -> LOG.error("Error reading data for request " + httpMethod + " " + req.getUri(), e)))
                 .lastOrDefault(null)
-                .map(body -> create(req, matcher, body));
+                .map(body -> create(req, matcher, body, collector));
         }
         return just(this);
     }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequest.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequest.java
@@ -61,7 +61,7 @@ public class JaxRsRequest {
             return collector.collectBytes(req.getContent()
                 .doOnError(e -> LOG.error("Error reading data for request " + httpMethod + " " + req.getUri(), e)))
                 .lastOrDefault(null)
-                .map(body -> create(req, matcher, body, collector));
+                .map(reqBody -> create(req, matcher, reqBody, collector));
         }
         return just(this);
     }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestHandler.java
@@ -18,9 +18,9 @@ import javax.inject.Singleton;
 @Singleton
 public class JaxRsRequestHandler implements RequestHandler<ByteBuf, ByteBuf> {
 
-    private JaxRsResources   resources;
-    private ExceptionHandler exceptionHandler;
-    private ByteBufCollector collector;
+    private final JaxRsResources   resources;
+    private final ExceptionHandler exceptionHandler;
+    private final ByteBufCollector collector;
 
     @Inject
     public JaxRsRequestHandler(JaxRsResourcesProvider services,
@@ -36,7 +36,7 @@ public class JaxRsRequestHandler implements RequestHandler<ByteBuf, ByteBuf> {
     }
 
     public JaxRsRequestHandler(Object... services) {
-        this(services, new JaxRsResourceFactory(), new ExceptionHandler(), new ByteBufCollector(10*1024*1024), null);
+        this(services, new JaxRsResourceFactory(), new ExceptionHandler(), new ByteBufCollector(), null);
     }
 
     public JaxRsRequestHandler(Object[] services,

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestTest.java
@@ -76,6 +76,8 @@ public class JaxRsRequestTest {
         assertThat(req.getFormParam("form")).isNull();
         assertThat(req.getHeader("header")).isNull();
         assertThat(req.getCookie("cookie")).isNull();
+        assertThat(req.getCookieValue("test")).isNull();
+        assertThat(req.getCookieValue("test", "default")).isEqualTo("default");
     }
 
 

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestTest.java
@@ -5,6 +5,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpMethod;
 import io.reactivex.netty.protocol.http.server.HttpServerRequest;
 import io.reactivex.netty.protocol.http.server.MockHttpServerRequest;
+import org.junit.Assert;
 import org.junit.Test;
 import rx.subjects.UnicastSubject;
 
@@ -21,7 +22,7 @@ public class JaxRsRequestTest {
         content.onNext(Unpooled.wrappedBuffer(new byte[]{byteArray[1]}));
         content.onCompleted();
         HttpServerRequest<ByteBuf> serverReq = new MockHttpServerRequest("/", HttpMethod.POST, content);
-        JaxRsRequest               req       = new JaxRsRequest(serverReq);
+        JaxRsRequest               req       = new JaxRsRequest(serverReq, new ByteBufCollector(10*1024*1024));
         String                     body      = new String(req.loadBody().toBlocking().single().getBody());
         assertThat(body).isEqualTo("ö");
     }
@@ -29,7 +30,7 @@ public class JaxRsRequestTest {
     @Test
     public void shouldDecodeSingleChunkBody() {
         HttpServerRequest<ByteBuf> serverReq = new MockHttpServerRequest("/", HttpMethod.POST, "ö");
-        JaxRsRequest               req       = new JaxRsRequest(serverReq);
+        JaxRsRequest               req       = new JaxRsRequest(serverReq, new ByteBufCollector(10*1024*1024));
         String                     body      = new String(req.loadBody().toBlocking().single().getBody());
         assertThat(body).isEqualTo("ö");
     }
@@ -37,19 +38,52 @@ public class JaxRsRequestTest {
     @Test
     public void shouldDecodeBodyForDeleteRequests() {
         HttpServerRequest<ByteBuf> serverReq = new MockHttpServerRequest("/", HttpMethod.DELETE, "test");
-        JaxRsRequest               req       = new JaxRsRequest(serverReq);
+        JaxRsRequest               req       = new JaxRsRequest(serverReq, new ByteBufCollector(10*1024*1024));
         String                     body      = new String(req.loadBody().toBlocking().single().getBody());
         assertThat(body).isEqualTo("test");
     }
 
     @Test
+    public void shouldDecodeBodyOfSpecifiedSize() {
+        String input = generateLargeString(5);
+        HttpServerRequest<ByteBuf> serverReq = new MockHttpServerRequest("/", HttpMethod.DELETE, input);
+        JaxRsRequest               req       = new JaxRsRequest(serverReq, new ByteBufCollector(5*1024*1024));
+        String                     body      = new String(req.loadBody().toBlocking().single().getBody());
+        assertThat(body).isEqualTo(input);
+    }
+
+    @Test
+    public void shouldFailWhenDecodingTooLargeBody() {
+        String input = generateLargeString(6);
+        HttpServerRequest<ByteBuf> serverReq = new MockHttpServerRequest("/", HttpMethod.DELETE, input);
+        JaxRsRequest               req       = new JaxRsRequest(serverReq, new ByteBufCollector(5*1024*1024));
+        try {
+            req.loadBody().toBlocking().single();
+            Assert.fail("Should throw exception");
+        } catch (WebException e) {
+            assertThat(e.getError()).isEqualTo("too.large.input");
+        }
+    }
+
+    @Test
     public void testParams() throws Exception {
         MockHttpServerRequest serverReq = new MockHttpServerRequest("/");
-        JaxRsRequest          req       = new JaxRsRequest(serverReq, null, new byte[0]);
+        JaxRsRequest          req       = new JaxRsRequest(serverReq, null, new byte[0], new ByteBufCollector(10*1024*1024));
         assertThat(req.getPathParam("path")).isNull();
         assertThat(req.getQueryParam("query")).isNull();
         assertThat(req.getFormParam("form")).isNull();
         assertThat(req.getHeader("header")).isNull();
         assertThat(req.getCookie("cookie")).isNull();
+    }
+
+
+    private String generateLargeString(int sizeInMB) {
+        char[] resp = new char[sizeInMB * 1024 * 1024];
+        for (int i = 0; i < resp.length; i++) {
+            resp[i] = 'b';
+        }
+        resp[0] = '\"';
+        resp[resp.length - 1] = '\"';
+        return new String(resp);
     }
 }

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -76,7 +76,7 @@ public class JaxRsResourceTest {
     @Test
     public void shouldConcatPaths() throws InvocationTargetException, IllegalAccessException {
         JaxRsResources resources    = new JaxRsResources(new Object[]{new Testresource()}, new JaxRsResourceFactory(), false);
-        JaxRsRequest   jaxRsRequest = new JaxRsRequest(new MockHttpServerRequest("/test/acceptsString"), new ByteBufCollector(10*1024*1024));
+        JaxRsRequest   jaxRsRequest = new JaxRsRequest(new MockHttpServerRequest("/test/acceptsString"), new ByteBufCollector());
         assertThat(resources.findResource(jaxRsRequest).call(jaxRsRequest)).isNotNull();
     }
 
@@ -136,7 +136,7 @@ public class JaxRsResourceTest {
                 new JaxRsResultFactoryFactory(),
                 new BlockingResourceScheduler()),
             false);
-        JaxRsRequest                         jaxRsRequest = new JaxRsRequest(req, new ByteBufCollector(10*1024*1024));
+        JaxRsRequest                         jaxRsRequest = new JaxRsRequest(req, new ByteBufCollector());
         Observable<? extends JaxRsResult<?>> result       = jaxRsResources.findResource(jaxRsRequest).call(jaxRsRequest);
 
         MockHttpServerResponse response = new MockHttpServerResponse();
@@ -425,7 +425,7 @@ public class JaxRsResourceTest {
             protected void configure() {
                 bind(DateFormat.class).toProvider(() -> new CustomDateFormat());
                 bind(JaxRsResourcesProvider.class).toInstance(() -> new Object[]{service});
-                bind(ByteBufCollector.class).toInstance(new ByteBufCollector(10*1024*1024));
+                bind(ByteBufCollector.class).toInstance(new ByteBufCollector());
                 bind(new TypeLiteral<Set<ParamResolver>>() {{
                 }}).toInstance(Collections.EMPTY_SET);
                 bind(new TypeLiteral<Set<ParamResolverFactory>>() {{

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -76,7 +76,7 @@ public class JaxRsResourceTest {
     @Test
     public void shouldConcatPaths() throws InvocationTargetException, IllegalAccessException {
         JaxRsResources resources    = new JaxRsResources(new Object[]{new Testresource()}, new JaxRsResourceFactory(), false);
-        JaxRsRequest   jaxRsRequest = new JaxRsRequest(new MockHttpServerRequest("/test/acceptsString"));
+        JaxRsRequest   jaxRsRequest = new JaxRsRequest(new MockHttpServerRequest("/test/acceptsString"), new ByteBufCollector(10*1024*1024));
         assertThat(resources.findResource(jaxRsRequest).call(jaxRsRequest)).isNotNull();
     }
 
@@ -136,7 +136,7 @@ public class JaxRsResourceTest {
                 new JaxRsResultFactoryFactory(),
                 new BlockingResourceScheduler()),
             false);
-        JaxRsRequest                         jaxRsRequest = new JaxRsRequest(req);
+        JaxRsRequest                         jaxRsRequest = new JaxRsRequest(req, new ByteBufCollector(10*1024*1024));
         Observable<? extends JaxRsResult<?>> result       = jaxRsResources.findResource(jaxRsRequest).call(jaxRsRequest);
 
         MockHttpServerResponse response = new MockHttpServerResponse();
@@ -425,6 +425,7 @@ public class JaxRsResourceTest {
             protected void configure() {
                 bind(DateFormat.class).toProvider(() -> new CustomDateFormat());
                 bind(JaxRsResourcesProvider.class).toInstance(() -> new Object[]{service});
+                bind(ByteBufCollector.class).toInstance(new ByteBufCollector(10*1024*1024));
                 bind(new TypeLiteral<Set<ParamResolver>>() {{
                 }}).toInstance(Collections.EMPTY_SET);
                 bind(new TypeLiteral<Set<ParamResolverFactory>>() {{

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/StatusTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/StatusTest.java
@@ -27,7 +27,7 @@ public class StatusTest {
             new Object[]{new TestresourceImpl()},
             new JaxRsResourceFactory(),
             exceptionHandler,
-            new ByteBufCollector(10*1024*1024),
+            new ByteBufCollector(),
             false
     );
 

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/StatusTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/StatusTest.java
@@ -23,10 +23,13 @@ import static rx.Observable.just;
 public class StatusTest {
 
     ExceptionHandler    exceptionHandler = new ExceptionHandler();
-    JaxRsRequestHandler handler          = new JaxRsRequestHandler(new Object[]{new TestresourceImpl()},
-        new JaxRsResourceFactory(),
-        exceptionHandler,
-        false);
+    JaxRsRequestHandler handler          = new JaxRsRequestHandler(
+            new Object[]{new TestresourceImpl()},
+            new JaxRsResourceFactory(),
+            exceptionHandler,
+            new ByteBufCollector(10*1024*1024),
+            false
+    );
 
     @Test
     public void shouldReturn200ForGetPutPatch() {

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/SynchronousResourcesTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/SynchronousResourcesTest.java
@@ -29,10 +29,12 @@ public class SynchronousResourcesTest {
     public void shouldRunOnConfiguredScheduler() {
         Scheduler scheduler = Schedulers.from(Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "customthread")));
         final RequestHandler handler = new JaxRsRequestHandler(
-            new Object[]{new TestRes()},
-            new JaxRsResourceFactory(new ParamResolverFactories(), new JaxRsResultFactoryFactory(), new BlockingResourceScheduler(scheduler)),
-            new ExceptionHandler(),
-            false);
+                new Object[]{new TestRes()},
+                new JaxRsResourceFactory(new ParamResolverFactories(), new JaxRsResultFactoryFactory(), new BlockingResourceScheduler(scheduler)),
+                new ExceptionHandler(),
+                new ByteBufCollector(10*1024*1024),
+                false
+        );
         JaxRsTestUtil.TestServer testServer = new JaxRsTestUtil.TestServer(handler);
         assertThat(testServer.get("/threadname"))
             .isEqualTo("\"customthread\"");

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/SynchronousResourcesTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/SynchronousResourcesTest.java
@@ -32,7 +32,7 @@ public class SynchronousResourcesTest {
                 new Object[]{new TestRes()},
                 new JaxRsResourceFactory(new ParamResolverFactories(), new JaxRsResultFactoryFactory(), new BlockingResourceScheduler(scheduler)),
                 new ExceptionHandler(),
-                new ByteBufCollector(10*1024*1024),
+                new ByteBufCollector(),
                 false
         );
         JaxRsTestUtil.TestServer testServer = new JaxRsTestUtil.TestServer(handler);

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/WrappedParamTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/WrappedParamTest.java
@@ -57,10 +57,13 @@ public class WrappedParamTest {
     }
 
     private JaxRsRequestHandler createHandler(Object service) {
-        return new JaxRsRequestHandler(new Object[]{service},
-            new JaxRsResourceFactory(),
-            new ExceptionHandler(),
-            false);
+        return new JaxRsRequestHandler(
+                new Object[]{service},
+                new JaxRsResourceFactory(),
+                new ExceptionHandler(),
+                new ByteBufCollector(10*1024*1024),
+                false
+        );
     }
 
     @Path("")

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/WrappedParamTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/WrappedParamTest.java
@@ -61,7 +61,7 @@ public class WrappedParamTest {
                 new Object[]{service},
                 new JaxRsResourceFactory(),
                 new ExceptionHandler(),
-                new ByteBufCollector(10*1024*1024),
+                new ByteBufCollector(),
                 false
         );
     }

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
@@ -75,13 +75,7 @@ public class JaxRsTestUtil {
     }
 
     private static JaxRsRequestHandler getJaxRsRequestHandler(Object... services) {
-        return new JaxRsRequestHandler(
-                services,
-                new JaxRsResourceFactory(new ParamResolverFactories(), new JaxRsResultFactoryFactory(), new BlockingResourceScheduler()),
-                new ExceptionHandler(),
-                new ByteBufCollector(),
-                false
-        );
+        return new JaxRsRequestHandler(services);
     }
 
     public static MockHttpServerResponse processRequestWithHandler(JaxRsRequestHandler handler, HttpServerRequest<ByteBuf> request) {

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
@@ -79,7 +79,7 @@ public class JaxRsTestUtil {
                 services,
                 new JaxRsResourceFactory(new ParamResolverFactories(), new JaxRsResultFactoryFactory(), new BlockingResourceScheduler()),
                 new ExceptionHandler(),
-                new ByteBufCollector(10*1024*1024),
+                new ByteBufCollector(),
                 false
         );
     }

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
@@ -1,10 +1,7 @@
 package se.fortnox.reactivewizard.utils;
 
 import se.fortnox.reactivewizard.ExceptionHandler;
-import se.fortnox.reactivewizard.jaxrs.BlockingResourceScheduler;
-import se.fortnox.reactivewizard.jaxrs.JaxRsRequestHandler;
-import se.fortnox.reactivewizard.jaxrs.JaxRsResourceFactory;
-import se.fortnox.reactivewizard.jaxrs.JaxRsResources;
+import se.fortnox.reactivewizard.jaxrs.*;
 import se.fortnox.reactivewizard.mocks.MockHttpServerResponse;
 import se.fortnox.reactivewizard.jaxrs.params.ParamResolverFactories;
 import se.fortnox.reactivewizard.jaxrs.response.JaxRsResultFactoryFactory;
@@ -78,10 +75,13 @@ public class JaxRsTestUtil {
     }
 
     private static JaxRsRequestHandler getJaxRsRequestHandler(Object... services) {
-        return new JaxRsRequestHandler(services,
-            new JaxRsResourceFactory(new ParamResolverFactories(), new JaxRsResultFactoryFactory(), new BlockingResourceScheduler()),
-            new ExceptionHandler(),
-            false);
+        return new JaxRsRequestHandler(
+                services,
+                new JaxRsResourceFactory(new ParamResolverFactories(), new JaxRsResultFactoryFactory(), new BlockingResourceScheduler()),
+                new ExceptionHandler(),
+                new ByteBufCollector(10*1024*1024),
+                false
+        );
     }
 
     public static MockHttpServerResponse processRequestWithHandler(JaxRsRequestHandler handler, HttpServerRequest<ByteBuf> request) {

--- a/server/src/main/java/se/fortnox/reactivewizard/server/ServerConfig.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/ServerConfig.java
@@ -7,11 +7,12 @@ import se.fortnox.reactivewizard.config.Config;
  */
 @Config("server")
 public class ServerConfig {
-    private int port = 8080;
-    private boolean enabled = true;
-    private int maxHeaderSize = 20 * 1024;
-    private int maxInitialLineLengthDefault = 4096;
-    private int shutdownTimeoutSeconds = 20;
+    private int     port                        = 8080;
+    private boolean enabled                     = true;
+    private int     maxHeaderSize               = 20 * 1024;
+    private int     maxInitialLineLengthDefault = 4096;
+    private int     maxRequestSize              = 10 * 1024 * 1024;
+    private int     shutdownTimeoutSeconds      = 20;
 
     public int getPort() {
         return port;
@@ -39,6 +40,14 @@ public class ServerConfig {
 
     public void setMaxInitialLineLengthDefault(int maxInitialLineLengthDefault) {
         this.maxInitialLineLengthDefault = maxInitialLineLengthDefault;
+    }
+
+    public int getMaxRequestSize() {
+        return maxRequestSize;
+    }
+
+    public void setMaxRequestSize(int maxRequestSize) {
+        this.maxRequestSize = maxRequestSize;
     }
 
     public void setEnabled(boolean enabled) {

--- a/server/src/test/java/se/fortnox/reactivewizard/server/ServerConfigTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/ServerConfigTest.java
@@ -15,7 +15,7 @@ public class ServerConfigTest {
         assertThat(serverConfig.getMaxHeaderSize()).isEqualTo(20480);
         assertThat(serverConfig.getShutdownTimeoutSeconds()).isEqualTo(20);
         assertThat(serverConfig.getMaxInitialLineLengthDefault()).isEqualTo(4096);
-
+        assertThat(serverConfig.getMaxRequestSize()).isEqualTo(10*1024*1024);
     }
 
     @Test
@@ -25,12 +25,14 @@ public class ServerConfigTest {
         serverConfig.setMaxHeaderSize(123);
         serverConfig.setShutdownTimeoutMs(4344);
         serverConfig.setMaxInitialLineLengthDefault(1344);
+        serverConfig.setMaxRequestSize(314159);
 
         assertThat(serverConfig.isEnabled()).isFalse();
         assertThat(serverConfig.getPort()).isEqualTo(1337);
         assertThat(serverConfig.getMaxHeaderSize()).isEqualTo(123);
         assertThat(serverConfig.getShutdownTimeoutSeconds()).isEqualTo(4344);
         assertThat(serverConfig.getMaxInitialLineLengthDefault()).isEqualTo(1344);
+        assertThat(serverConfig.getMaxRequestSize()).isEqualTo(314159);
     }
 
 }

--- a/server/src/test/java/se/fortnox/reactivewizard/server/ServerConfigTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/ServerConfigTest.java
@@ -34,5 +34,4 @@ public class ServerConfigTest {
         assertThat(serverConfig.getMaxInitialLineLengthDefault()).isEqualTo(1344);
         assertThat(serverConfig.getMaxRequestSize()).isEqualTo(314159);
     }
-
 }


### PR DESCRIPTION
It is currently possible to specify maxResponseSize in HttpClientConfig for responses. This PR lets you specify a maxRequestSize for _incoming_ requests. 