### PR TITLE
Making the liquibase migration lazy

### DIFF
--- a/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModule.java
+++ b/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModule.java
@@ -1,6 +1,7 @@
 package se.fortnox.reactivewizard.dbmigrate;
 
 import com.google.inject.Binder;
+import com.google.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.fortnox.reactivewizard.binding.AutoBindModule;
@@ -20,10 +21,10 @@ import javax.inject.Named;
 public class LiquibaseAutoBindModule implements AutoBindModule {
     private static final Logger LOG = LoggerFactory.getLogger(LiquibaseAutoBindModule.class);
     private final String           startCommand;
-    private final LiquibaseMigrateProvider liquibaseMigrateProvider;
+    private final Provider<LiquibaseMigrate> liquibaseMigrateProvider;
 
     @Inject
-    public LiquibaseAutoBindModule(@Named("args") String[] args, LiquibaseMigrateProvider liquibaseMigrateProvider) {
+    public LiquibaseAutoBindModule(@Named("args") String[] args, Provider<LiquibaseMigrate> liquibaseMigrateProvider) {
         this.liquibaseMigrateProvider = liquibaseMigrateProvider;
         if (args.length < 2) {
             this.startCommand = "";

--- a/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModule.java
+++ b/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModule.java
@@ -19,13 +19,12 @@ import javax.inject.Named;
  */
 public class LiquibaseAutoBindModule implements AutoBindModule {
     private static final Logger LOG = LoggerFactory.getLogger(LiquibaseAutoBindModule.class);
-
     private final String           startCommand;
-    private final LiquibaseMigrate liquibaseMigrate;
+    private final LiquibaseMigrateProvider liquibaseMigrateProvider;
 
     @Inject
     public LiquibaseAutoBindModule(@Named("args") String[] args, LiquibaseMigrateProvider liquibaseMigrateProvider) {
-        this.liquibaseMigrate = liquibaseMigrateProvider.get();
+        this.liquibaseMigrateProvider = liquibaseMigrateProvider;
         if (args.length < 2) {
             this.startCommand = "";
         } else {
@@ -36,6 +35,7 @@ public class LiquibaseAutoBindModule implements AutoBindModule {
     @Override
     public void preBind() {
         if (startCommand.startsWith("db-")) {
+            LiquibaseMigrate liquibaseMigrate = liquibaseMigrateProvider.get();
             try {
                 if (startCommand.startsWith("db-drop")) {
                     try {

--- a/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
+++ b/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
@@ -21,7 +21,7 @@ public class LiquibaseMigrateProvider {
             try {
                 liquibaseMigrate.set(new LiquibaseMigrate(liquibaseConfig));
             } catch (LiquibaseException | IOException e) {
-                throw new RuntimeException(e);
+                throw new IllegalStateException(e);
             }
         }
         return liquibaseMigrate.get();

--- a/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
+++ b/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
@@ -1,6 +1,7 @@
 package se.fortnox.reactivewizard.dbmigrate;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import liquibase.exception.LiquibaseException;
 import se.fortnox.reactivewizard.config.ConfigFactory;
@@ -8,7 +9,7 @@ import se.fortnox.reactivewizard.config.ConfigFactory;
 import java.io.IOException;
 
 @Singleton
-public class LiquibaseMigrateProvider {
+public class LiquibaseMigrateProvider implements Provider<LiquibaseMigrate> {
     private LiquibaseMigrate liquibaseMigrate;
     private final LiquibaseConfig liquibaseConfig;
 

--- a/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
+++ b/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
@@ -1,14 +1,15 @@
 package se.fortnox.reactivewizard.dbmigrate;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import liquibase.exception.LiquibaseException;
 import se.fortnox.reactivewizard.config.ConfigFactory;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
 
+@Singleton
 public class LiquibaseMigrateProvider {
-    private final AtomicReference<LiquibaseMigrate> liquibaseMigrate = new AtomicReference<>();
+    private LiquibaseMigrate liquibaseMigrate;
     private final LiquibaseConfig liquibaseConfig;
 
     @Inject
@@ -17,13 +18,13 @@ public class LiquibaseMigrateProvider {
     }
 
     public LiquibaseMigrate get() {
-        if (liquibaseMigrate.get() == null) {
+        if (liquibaseMigrate == null) {
             try {
-                liquibaseMigrate.set(new LiquibaseMigrate(liquibaseConfig));
+                liquibaseMigrate = new LiquibaseMigrate(liquibaseConfig);
             } catch (LiquibaseException | IOException e) {
                 throw new IllegalStateException(e);
             }
         }
-        return liquibaseMigrate.get();
+        return liquibaseMigrate;
     }
 }

--- a/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
+++ b/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
@@ -5,17 +5,25 @@ import liquibase.exception.LiquibaseException;
 import se.fortnox.reactivewizard.config.ConfigFactory;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class LiquibaseMigrateProvider {
-    private final LiquibaseMigrate liquibaseMigrate;
+    private final AtomicReference<LiquibaseMigrate> liquibaseMigrate = new AtomicReference<>();
+    private final LiquibaseConfig liquibaseConfig;
 
     @Inject
-    public LiquibaseMigrateProvider(ConfigFactory configFactory) throws IOException, LiquibaseException {
-        LiquibaseConfig liquibaseConfig = configFactory.get(LiquibaseConfig.class);
-        liquibaseMigrate = new LiquibaseMigrate(liquibaseConfig);
+    public LiquibaseMigrateProvider(ConfigFactory configFactory) {
+        liquibaseConfig = configFactory.get(LiquibaseConfig.class);
     }
 
     public LiquibaseMigrate get() {
-        return liquibaseMigrate;
+        if (liquibaseMigrate.get() == null) {
+            try {
+                liquibaseMigrate.set(new LiquibaseMigrate(liquibaseConfig));
+            } catch (LiquibaseException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return liquibaseMigrate.get();
     }
 }

--- a/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
+++ b/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
@@ -78,7 +78,6 @@ public class LiquibaseAutoBindModuleTest {
             getInjectedLiquibaseMock(liquibaseMigrateMock, "db-migrate", "config.yml");
             fail("Expected CreationException, but none was thrown");
         } catch (CreationException e) {
-            e.printStackTrace();
             assertThat(e.getCause()).isInstanceOf(RuntimeException.class);
             assertThat(e.getCause().getCause()).isInstanceOf(LiquibaseException.class);
         }

--- a/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
+++ b/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
@@ -78,6 +78,7 @@ public class LiquibaseAutoBindModuleTest {
             getInjectedLiquibaseMock(liquibaseMigrateMock, "db-migrate", "config.yml");
             fail("Expected CreationException, but none was thrown");
         } catch (CreationException e) {
+            e.printStackTrace();
             assertThat(e.getCause()).isInstanceOf(RuntimeException.class);
             assertThat(e.getCause().getCause()).isInstanceOf(LiquibaseException.class);
         }
@@ -122,7 +123,7 @@ public class LiquibaseAutoBindModuleTest {
 
             LiquibaseMigrateProvider liquibaseMigrateProvider = mock(LiquibaseMigrateProvider.class);
             when(liquibaseMigrateProvider.get()).thenReturn(liquibaseMigrateMock);
-            binder.bind(LiquibaseMigrateProvider.class).toInstance(liquibaseMigrateProvider);
+            binder.bind(LiquibaseMigrate.class).toProvider(liquibaseMigrateProvider);
         }));
 
         return liquibaseMigrateMock;

--- a/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProviderTest.java
+++ b/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProviderTest.java
@@ -1,26 +1,34 @@
 package se.fortnox.reactivewizard.dbmigrate;
 
-import liquibase.exception.LiquibaseException;
 import org.junit.Test;
 import se.fortnox.reactivewizard.config.ConfigFactory;
 
-import java.io.IOException;
-
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class LiquibaseMigrateProviderTest {
 
     @Test
-    public void shouldGetLiquibaseMigrateInstance() throws IOException, LiquibaseException {
-        LiquibaseConfig liquibaseConfig = new LiquibaseConfig();
-        liquibaseConfig.setUrl("jdbc:h2:mem:test");
+    public void shouldGetLiquibaseMigrateInstance() {
+        LiquibaseConfig liquibaseConfig = mock(LiquibaseConfig.class);
+
+        when(liquibaseConfig.getUrl()).thenReturn("jdbc:h2:mem:test");
+        when(liquibaseConfig.getMigrationsFile()).thenReturn("migrations.xml");
 
         ConfigFactory configFactory = mock(ConfigFactory.class);
         when(configFactory.get(LiquibaseConfig.class)).thenReturn(liquibaseConfig);
 
         LiquibaseMigrateProvider liquibaseMigrateProvider = new LiquibaseMigrateProvider(configFactory);
 
+        //Assert the liquibaseMigrateProvider is lazy
+        verify(liquibaseConfig, never()).getUrl();
+
         LiquibaseMigrate liquibaseMigrate = liquibaseMigrateProvider.get();
+
+        //Assert the url is used when we get the liquibaseMigrate objet
+        verify(liquibaseConfig, atLeastOnce()).getUrl();
     }
 }


### PR DESCRIPTION
The eager creation of LiquibaseMigrate led to problems when creating injectors in tests where the dbmigration wasn't supposed to run.
Making it lazy fixed the problem