### PR TITLE
Better error handling when streaming observables.

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/response/JaxRsStreamingResult.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/response/JaxRsStreamingResult.java
@@ -1,12 +1,19 @@
 package se.fortnox.reactivewizard.jaxrs.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
 import rx.Observable;
 import rx.functions.Func1;
+import se.fortnox.reactivewizard.jaxrs.WebException;
 
 import java.util.Map;
+
+import static rx.Observable.empty;
+import static rx.Observable.just;
+import static se.fortnox.reactivewizard.util.rx.FirstThen.first;
 
 public class JaxRsStreamingResult<T> extends JaxRsResult<T> {
     public JaxRsStreamingResult(Observable<T> output, HttpResponseStatus responseStatus, Func1<T, byte[]> serializer, Map<String, Object> headers) {
@@ -15,8 +22,34 @@ public class JaxRsStreamingResult<T> extends JaxRsResult<T> {
 
     @Override
     public Observable<Void> write(HttpServerResponse<ByteBuf> response) {
-        response.setStatus(responseStatus);
-        headers.forEach(response::addHeader);
-        return response.writeBytesAndFlushOnEach(output.map(serializer));
+
+        return output
+            .first()
+            .onErrorResumeNext(throwable -> {
+
+                if (throwable instanceof WebException) {
+                    response.setStatus(((WebException)throwable).getStatus());
+                } else {
+                    response.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                }
+
+                ObjectMapper objectMapper = new ObjectMapper();
+
+                headers.forEach(response::addHeader);
+
+                byte[] bytes;
+                try {
+                    bytes = objectMapper.writeValueAsBytes(throwable);
+                    return first(response.writeBytes(just(bytes))).thenReturn(empty());
+                } catch (JsonProcessingException e) {
+                    e.printStackTrace();
+                    return empty();
+                }
+            })
+            .flatMap(t -> {
+                response.setStatus(responseStatus);
+                headers.forEach(response::addHeader);
+                return response.writeBytesAndFlushOnEach(output.map(serializer));
+            });
     }
 }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/response/JaxRsStreamingResult.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/response/JaxRsStreamingResult.java
@@ -5,17 +5,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.functions.Func1;
 import se.fortnox.reactivewizard.jaxrs.WebException;
 
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static rx.Observable.empty;
 import static rx.Observable.just;
 import static se.fortnox.reactivewizard.util.rx.FirstThen.first;
 
 public class JaxRsStreamingResult<T> extends JaxRsResult<T> {
+
+    public static final Logger LOG = LoggerFactory.getLogger(JaxRsStreamingResult.class);
+
     public JaxRsStreamingResult(Observable<T> output, HttpResponseStatus responseStatus, Func1<T, byte[]> serializer, Map<String, Object> headers) {
         super(output, responseStatus, serializer, headers);
     }
@@ -24,25 +30,31 @@ public class JaxRsStreamingResult<T> extends JaxRsResult<T> {
     public Observable<Void> write(HttpServerResponse<ByteBuf> response) {
 
         return output
+
             .first()
             .onErrorResumeNext(throwable -> {
 
+                headers.forEach(response::addHeader);
+
                 if (throwable instanceof WebException) {
                     response.setStatus(((WebException)throwable).getStatus());
-                } else {
+                } else if (throwable instanceof NoSuchElementException) {
+                    //Empty content
+                    response.setStatus(HttpResponseStatus.NO_CONTENT);
+                    return first(response.writeBytes(empty())).thenReturn(empty());
+                }
+                else {
                     response.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
                 }
 
                 ObjectMapper objectMapper = new ObjectMapper();
-
-                headers.forEach(response::addHeader);
 
                 byte[] bytes;
                 try {
                     bytes = objectMapper.writeValueAsBytes(throwable);
                     return first(response.writeBytes(just(bytes))).thenReturn(empty());
                 } catch (JsonProcessingException e) {
-                    e.printStackTrace();
+                    LOG.error("Could not transform exception {} to bytes", throwable, e);
                     return empty();
                 }
             })

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/StreamingDataTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/StreamingDataTest.java
@@ -100,7 +100,7 @@ public class StreamingDataTest {
                 .toBlocking()
                 .single();
 
-            assertThat(single.contains("badrequest"));
+            assertThat(single.contains("badrequest")).isTrue();
 
         } finally {
             server.shutdown();


### PR DESCRIPTION
If there is an error in the observable that should be streamed then the headers are already written and can't be written again. 
In this pr I'll take the first element out of the stream and if that is ok then there is a good chance all the other elements will come as well. But if I cannot even get the first item I'll handle the error and writing the exception to the response instead.