### PR TITLE
No var args constructor

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestHandler.java
@@ -35,7 +35,7 @@ public class JaxRsRequestHandler implements RequestHandler<ByteBuf, ByteBuf> {
             null);
     }
 
-    public JaxRsRequestHandler(Object... services) {
+    public JaxRsRequestHandler(Object[] services) {
         this(services, new JaxRsResourceFactory(), new ExceptionHandler(), new ByteBufCollector(), null);
     }
 


### PR DESCRIPTION
Removed the varargs constructor to avoid accidentally hitting that constructor when adding new fields in the other constructors.