### PR TITLE
fix liquibase migrations

### DIFF
--- a/config/src/test/java/se/fortnox/reactivewizard/config/TestInjector.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/TestInjector.java
@@ -6,6 +6,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
+import org.apache.commons.lang.ArrayUtils;
 import se.fortnox.reactivewizard.binding.AutoBindModules;
 
 import javax.annotation.Nullable;
@@ -26,16 +27,21 @@ public class TestInjector {
     }
 
     public static Injector create(Consumer<Binder> binderConsumer, @Nullable String configFile) {
+        return create(binderConsumer, configFile, new String[0]);
+    }
+
+    public static Injector create(Consumer<Binder> binderConsumer, @Nullable String configFile, String[] args) {
         Module module = new AbstractModule() {
             @Override
             protected void configure() {
 
                 if (configFile == null) {
                     bind(ConfigFactory.class).toInstance(MockConfigFactory.create());
-                    bind(String[].class).annotatedWith(Names.named("args")).toInstance(new String[]{""});
+                    bind(String[].class).annotatedWith(Names.named("args")).toInstance(args);
                     bind(ConfigAutoBindModule.class).to(MockConfigAutoBindModule.class);
                 } else {
-                    bind(String[].class).annotatedWith(Names.named("args")).toInstance(new String[]{configFile});
+
+                    bind(String[].class).annotatedWith(Names.named("args")).toInstance((String[])ArrayUtils.addAll(args, new String[]{configFile}));
                 }
 
                 binderConsumer.accept(binder());

--- a/config/src/test/java/se/fortnox/reactivewizard/config/TestTestInjector.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/TestTestInjector.java
@@ -17,8 +17,7 @@ public class TestTestInjector {
         assertThat(injector.getInstance(ConfigFactory.class).getClass().getName()).isNotEqualTo(ConfigFactory.class.getName());
 
         String[] args = injector.getInstance(Key.get(String[].class, Names.named("args")));
-        assertThat(args.length).isEqualTo(1);
-        assertThat(args[0]).isEqualTo("");
+        assertThat(args.length).isEqualTo(0);
     }
 
     @Test

--- a/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModule.java
+++ b/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModule.java
@@ -1,7 +1,6 @@
 package se.fortnox.reactivewizard.dbmigrate;
 
 import com.google.inject.Binder;
-import com.google.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.fortnox.reactivewizard.binding.AutoBindModule;
@@ -19,12 +18,12 @@ import javax.inject.Named;
  * </ul>
  */
 public class LiquibaseAutoBindModule implements AutoBindModule {
-    private static final Logger LOG = LoggerFactory.getLogger(LiquibaseAutoBindModule.class);
-    private final String           startCommand;
-    private final Provider<LiquibaseMigrate> liquibaseMigrateProvider;
+    private static final Logger                     LOG = LoggerFactory.getLogger(LiquibaseAutoBindModule.class);
+    private final        String                     startCommand;
+    private final        LiquibaseMigrateProvider liquibaseMigrateProvider;
 
     @Inject
-    public LiquibaseAutoBindModule(@Named("args") String[] args, Provider<LiquibaseMigrate> liquibaseMigrateProvider) {
+    public LiquibaseAutoBindModule(@Named("args") String[] args, LiquibaseMigrateProvider liquibaseMigrateProvider) {
         this.liquibaseMigrateProvider = liquibaseMigrateProvider;
         if (args.length < 2) {
             this.startCommand = "";

--- a/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
+++ b/dbmigrate/src/main/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProvider.java
@@ -1,7 +1,6 @@
 package se.fortnox.reactivewizard.dbmigrate;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import liquibase.exception.LiquibaseException;
 import se.fortnox.reactivewizard.config.ConfigFactory;
@@ -9,7 +8,7 @@ import se.fortnox.reactivewizard.config.ConfigFactory;
 import java.io.IOException;
 
 @Singleton
-public class LiquibaseMigrateProvider implements Provider<LiquibaseMigrate> {
+public class LiquibaseMigrateProvider {
     private LiquibaseMigrate liquibaseMigrate;
     private final LiquibaseConfig liquibaseConfig;
 
@@ -18,7 +17,7 @@ public class LiquibaseMigrateProvider implements Provider<LiquibaseMigrate> {
         liquibaseConfig = configFactory.get(LiquibaseConfig.class);
     }
 
-    public LiquibaseMigrate get() {
+    LiquibaseMigrate get() {
         if (liquibaseMigrate == null) {
             try {
                 liquibaseMigrate = new LiquibaseMigrate(liquibaseConfig);

--- a/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
+++ b/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
@@ -5,10 +5,11 @@ import com.google.inject.Guice;
 import com.google.inject.name.Names;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
+import org.junit.Assert;
 import org.junit.Test;
 import se.fortnox.reactivewizard.binding.AutoBindModules;
 import se.fortnox.reactivewizard.config.ConfigFactory;
-import se.fortnox.reactivewizard.config.MockConfigFactory;
+import se.fortnox.reactivewizard.config.TestInjector;
 import se.fortnox.reactivewizard.server.ServerConfig;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -98,6 +99,18 @@ public class LiquibaseAutoBindModuleTest {
         verify(liquibaseMigrateMock, never()).exit();
     }
 
+    @Test
+    public void shouldBeAbleToRunLiquibaseMigrationsOnStartup() {
+
+        try {
+            TestInjector.create(binder -> {
+            }, "test.bind.yml", new String[]{"db-migrate-run"});
+        } catch (Exception e) {
+            Assert.fail("Running liquibase migrations from file should not fail:" + e.getMessage());
+        }
+
+    }
+
     private LiquibaseMigrate getInjectedLiquibaseMock(String...arg) {
         LiquibaseMigrate liquibaseMigrateMock = mock(LiquibaseMigrate.class);
 
@@ -126,10 +139,9 @@ public class LiquibaseAutoBindModuleTest {
 
             LiquibaseMigrateProvider liquibaseMigrateProvider = mock(LiquibaseMigrateProvider.class);
             when(liquibaseMigrateProvider.get()).thenReturn(liquibaseMigrateMock);
-            binder.bind(LiquibaseMigrate.class).toProvider(liquibaseMigrateProvider);
+            binder.bind(LiquibaseMigrateProvider.class).toInstance(liquibaseMigrateProvider);
         }));
 
         return liquibaseMigrateMock;
     }
-
 }

--- a/dbmigrate/test.bind.yml
+++ b/dbmigrate/test.bind.yml
@@ -1,0 +1,12 @@
+database:
+    url: jdbc:h2:testliquibase:test
+    user: sa
+    schema: TESTSCHEMA
+
+liquibase-database:
+    url: jdbc:h2:mem:testliquibase;INIT=CREATE SCHEMA IF NOT EXISTS TESTSCHEMA AUTHORIZATION SA
+    user: sa
+    schema: TESTSCHEMA
+
+server:
+    enabled: false


### PR DESCRIPTION
The provider strategy did not work since providers are not automatically bound just by implementing Provider interface.
And since the migrations are run in the preBind step of the AutoBindModule I am reverting to good old class injection.

Also added a test that will fail if we break this functionality again.