### PR TITLE
Add host in headers in http client requests

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.netflix.servo.util.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.timeout.ReadTimeoutException;

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -420,6 +420,10 @@ public class HttpClient implements InvocationHandler {
                 }
             }
         }
+
+        if (!request.getHeaders().containsKey("Host") || request.getHeaders().containsKey("Host") && request.getHeaders().get("Host").isEmpty()) {
+            request.addHeader("Host", this.config.getHost());
+        }
     }
 
     protected Observable<Object> deserialize(Method method, String string) {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -422,9 +422,9 @@ public class HttpClient implements InvocationHandler {
             }
         }
         
-        if (Strings.isNullOrEmpty(request.getHeaders().get("Host"))) {
+       if (isNullOrEmpty(request.getHeaders().get("Host"))) {
             request.addHeader("Host", this.config.getHost());
-        }
+       }
     }
 
     protected Observable<Object> deserialize(Method method, String string) {
@@ -513,6 +513,10 @@ public class HttpClient implements InvocationHandler {
             return stringBuilder.toString();
         }
         return value.toString();
+    }
+    
+    protected boolean isNullOrEmpty(String string) {
+        return string == null || str.isEmpty();
     }
 
     public static class DetailedError extends Throwable {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -516,7 +516,7 @@ public class HttpClient implements InvocationHandler {
     }
     
     protected boolean isNullOrEmpty(String string) {
-        return string == null || str.isEmpty();
+        return string == null || string.isEmpty();
     }
 
     public static class DetailedError extends Throwable {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -422,9 +422,9 @@ public class HttpClient implements InvocationHandler {
             }
         }
         
-       if (isNullOrEmpty(request.getHeaders().get("Host"))) {
+        if (isNullOrEmpty(request.getHeaders().get("Host"))) {
             request.addHeader("Host", this.config.getHost());
-       }
+        }
     }
 
     protected Observable<Object> deserialize(Method method, String string) {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.netflix.servo.util.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.timeout.ReadTimeoutException;
@@ -420,8 +421,8 @@ public class HttpClient implements InvocationHandler {
                 }
             }
         }
-
-        if (!request.getHeaders().containsKey("Host") || request.getHeaders().containsKey("Host") && request.getHeaders().get("Host").isEmpty()) {
+        
+        if (Strings.isNullOrEmpty(request.getHeaders().get("Host"))) {
             request.addHeader("Host", this.config.getHost());
         }
     }


### PR DESCRIPTION
All request in HttpClient are sent with a host header. When a header param "Host" is specified, it is used,
otherwise the host from the http client config is used