### PR TITLE
Parse field errors from WebExceptions when handling errors in HttpClient

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -15,8 +15,10 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Single;
 import se.fortnox.reactivewizard.jaxrs.ByteBufCollector;
+import se.fortnox.reactivewizard.jaxrs.FieldError;
 import se.fortnox.reactivewizard.jaxrs.JaxRsMeta;
 import se.fortnox.reactivewizard.jaxrs.WebException;
+import se.fortnox.reactivewizard.json.JsonDeserializerFactory;
 import se.fortnox.reactivewizard.logging.LoggingContext;
 import se.fortnox.reactivewizard.metrics.HealthRecorder;
 import se.fortnox.reactivewizard.metrics.Metrics;
@@ -420,7 +422,7 @@ public class HttpClient implements InvocationHandler {
                 }
             }
         }
-        
+
         if (isNullOrEmpty(request.getHeaders().get("Host"))) {
             request.addHeader("Host", this.config.getHost());
         }
@@ -513,15 +515,16 @@ public class HttpClient implements InvocationHandler {
         }
         return value.toString();
     }
-    
+
     protected boolean isNullOrEmpty(String string) {
         return string == null || string.isEmpty();
     }
 
     public static class DetailedError extends Throwable {
-        private int    code;
-        private String error;
-        private String message;
+        private int          code;
+        private String       error;
+        private String       message;
+        private FieldError[] fields;
 
         public DetailedError() {
             this(null);
@@ -561,6 +564,14 @@ public class HttpClient implements InvocationHandler {
 
         public boolean hasReason() {
             return code == 0 && error != null;
+        }
+
+        public FieldError[] getFields() {
+            return fields;
+        }
+
+        public void setFields(FieldError[] fields) {
+            this.fields = fields;
         }
     }
 

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -18,7 +18,6 @@ import se.fortnox.reactivewizard.jaxrs.ByteBufCollector;
 import se.fortnox.reactivewizard.jaxrs.FieldError;
 import se.fortnox.reactivewizard.jaxrs.JaxRsMeta;
 import se.fortnox.reactivewizard.jaxrs.WebException;
-import se.fortnox.reactivewizard.json.JsonDeserializerFactory;
 import se.fortnox.reactivewizard.logging.LoggingContext;
 import se.fortnox.reactivewizard.metrics.HealthRecorder;
 import se.fortnox.reactivewizard.metrics.Metrics;

--- a/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/FieldError.java
+++ b/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/FieldError.java
@@ -3,10 +3,9 @@ package se.fortnox.reactivewizard.jaxrs;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
-import java.io.Serializable;
 import java.util.Map;
 
-public class FieldError implements Serializable {
+public class FieldError {
 
     protected static final String VALIDATION = "validation.";
     private String              field;

--- a/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/FieldError.java
+++ b/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/FieldError.java
@@ -3,9 +3,10 @@ package se.fortnox.reactivewizard.jaxrs;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+import java.io.Serializable;
 import java.util.Map;
 
-public class FieldError {
+public class FieldError implements Serializable {
 
     protected static final String VALIDATION = "validation.";
     private String              field;

--- a/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/FieldError.java
+++ b/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/FieldError.java
@@ -8,9 +8,12 @@ import java.util.Map;
 public class FieldError {
 
     protected static final String VALIDATION = "validation.";
-    private final String              field;
-    private final String              error;
-    private final Map<String, Object> errorParams;
+    private String              field;
+    private String              error;
+    private Map<String, Object> errorParams;
+
+    public FieldError() {
+    }
 
     public FieldError(String field, String validationErrorCode) {
         this(field, validationErrorCode, null);

--- a/jaxrs-api/src/test/java/se/fortnox/reactivewizard/jaxrs/FieldErrorTest.java
+++ b/jaxrs-api/src/test/java/se/fortnox/reactivewizard/jaxrs/FieldErrorTest.java
@@ -41,4 +41,12 @@ public class FieldErrorTest {
         assertThat(fieldError.getField()).isEqualTo("username");
         assertThat(fieldError.getErrorParams()).includes(MapAssert.entry("name", "a"));
     }
+
+    @Test
+    public void shouldNotInitializeValues() {
+        FieldError fieldError = new FieldError();
+        assertThat(fieldError.getError()).isNull();
+        assertThat(fieldError.getField()).isNull();
+        assertThat(fieldError.getErrorParams()).isNull();
+    }
 }


### PR DESCRIPTION
In case of a rw service calling another rw service that generates an error, the fielderrors from that error is lost when handling the error in HttpClient. 

This tries to make sure that the fielderrors are set on the DetailedError cause.