### PR TITLE
exclude jackson-core dependency

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -47,6 +47,10 @@
                     <groupId>com.netflix.servo</groupId>
                     <artifactId>servo-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
blitz4j has a version of jackson-core that conflicts with other version that we ourselfes define so this excludes this dependency from blitz4j