### PR TITLE
Add support for sending basic auth to consumed services

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/BasicAuthConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/BasicAuthConfig.java
@@ -1,0 +1,27 @@
+package se.fortnox.reactivewizard.client;
+
+public class BasicAuthConfig {
+    private String username;
+    private String password;
+
+    public BasicAuthConfig() {
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public BasicAuthConfig setUsername(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public BasicAuthConfig setPassword(String password) {
+        this.password = password;
+        return this;
+    }
+}

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -51,7 +51,7 @@ public class HttpClientConfig {
     @JsonProperty("validateCertificates")
     private boolean isValidateCertificates = true;
 
-    private BasicAuth basicAuth;
+    private BasicAuthConfig basicAuth;
 
     public HttpClientConfig() {
     }
@@ -176,40 +176,18 @@ public class HttpClientConfig {
         isValidateCertificates = value;
     }
 
-    public BasicAuth getBasicAuth() {
+    public BasicAuthConfig getBasicAuth() {
         return basicAuth;
     }
 
-    public void setBasicAuth(BasicAuth basicAuth) {
+    public void setBasicAuth(BasicAuthConfig basicAuth) {
         this.basicAuth = basicAuth;
     }
 
     public void setBasicAuth(String username, String password) {
-        this.basicAuth = new BasicAuth()
+        this.basicAuth = new BasicAuthConfig()
             .setUsername(username)
             .setPassword(password);
     }
 
-    public class BasicAuth {
-        private String username;
-        private String password;
-
-        public String getUsername() {
-            return username;
-        }
-
-        public BasicAuth setUsername(String username) {
-            this.username = username;
-            return this;
-        }
-
-        public String getPassword() {
-            return password;
-        }
-
-        public BasicAuth setPassword(String password) {
-            this.password = password;
-            return this;
-        }
-    }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -51,6 +51,8 @@ public class HttpClientConfig {
     @JsonProperty("validateCertificates")
     private boolean isValidateCertificates = true;
 
+    private BasicAuth basicAuth;
+
     public HttpClientConfig() {
     }
 
@@ -172,5 +174,42 @@ public class HttpClientConfig {
 
     public void setValidateCertificates(boolean value) {
         isValidateCertificates = value;
+    }
+
+    public BasicAuth getBasicAuth() {
+        return basicAuth;
+    }
+
+    public void setBasicAuth(BasicAuth basicAuth) {
+        this.basicAuth = basicAuth;
+    }
+
+    public void setBasicAuth(String username, String password) {
+        this.basicAuth = new BasicAuth()
+            .setUsername(username)
+            .setPassword(password);
+    }
+
+    public class BasicAuth {
+        private String username;
+        private String password;
+
+        public String getUsername() {
+            return username;
+        }
+
+        public BasicAuth setUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public BasicAuth setPassword(String password) {
+            this.password = password;
+            return this;
+        }
     }
 }

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -31,9 +31,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.slf4j.event.LoggingEvent;
 import rx.Observable;
 import rx.Single;
 import rx.functions.Func0;
@@ -64,8 +62,6 @@ import javax.ws.rs.core.MediaType;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
@@ -229,6 +225,7 @@ public class HttpClientTest {
     }
 
     //@Test
+
     /**
      * This test will fail occationally and is therefore commented out.
      * This should be used to try to pin down the bug probably residing in rxnetty
@@ -237,7 +234,7 @@ public class HttpClientTest {
 
         withServer(server -> {
 
-                try {
+            try {
                 HttpClientConfig config = new HttpClientConfig("127.0.0.1:" + server.getServerPort());
                 config.setRetryCount(1);
                 config.setRetryDelayMs(1000);
@@ -245,12 +242,11 @@ public class HttpClientTest {
 
                 TestResource resource = getHttpProxy(config);
 
-
-                for(int j = 0; j < 300; j++) {
+                for (int j = 0; j < 300; j++) {
                     List<Observable<String>> results = new ArrayList<>();
 
                     Thread.sleep(100);
-                    int  numberOfRequests = 10;
+                    int numberOfRequests = 10;
                     for (int i = 0; i < numberOfRequests; i++) {
                         results.add(resource
                             .getHello()
@@ -262,7 +258,8 @@ public class HttpClientTest {
                     test.assertNoErrors();
                 }
 
-            } catch (Exception ignore) {}
+            } catch (Exception ignore) {
+            }
 
         });
     }
@@ -479,10 +476,10 @@ public class HttpClientTest {
 
     @Test
     public void shouldLogErrorOnTooLargeResponse() throws NoSuchFieldException, IllegalAccessException {
-        Appender mockAppender = LoggingMockUtil.createMockedLogAppender(HttpClient.class);
-        final HttpServer<ByteBuf, ByteBuf> server   = startServer(HttpResponseStatus.OK, generateLargeString(11));
-        TestResource                       resource = getHttpProxy(server.getServerPort());
-        WebException e = null;
+        Appender                           mockAppender = LoggingMockUtil.createMockedLogAppender(HttpClient.class);
+        final HttpServer<ByteBuf, ByteBuf> server       = startServer(HttpResponseStatus.OK, generateLargeString(11));
+        TestResource                       resource     = getHttpProxy(server.getServerPort());
+        WebException                       e            = null;
         try {
             resource.getHello().toBlocking().single();
         } catch (WebException we) {
@@ -502,10 +499,10 @@ public class HttpClientTest {
 
     @Test
     public void shouldReturnBadRequestOnTooLargeResponses() throws URISyntaxException {
-        final HttpServer<ByteBuf, ByteBuf> server   = startServer(HttpResponseStatus.OK, "\"derp\"");
-        HttpClientConfig config                     = new HttpClientConfig("127.0.0.1:" + server.getServerPort());
+        final HttpServer<ByteBuf, ByteBuf> server = startServer(HttpResponseStatus.OK, "\"derp\"");
+        HttpClientConfig                   config = new HttpClientConfig("127.0.0.1:" + server.getServerPort());
         config.setMaxResponseSize(5);
-        TestResource                       resource = getHttpProxy(config);
+        TestResource resource = getHttpProxy(config);
         try {
             resource.getHello().toBlocking().single();
             fail("expected exception");
@@ -581,8 +578,8 @@ public class HttpClientTest {
 
     @Test
     public void shouldParseWebExceptions() {
-        AtomicLong                   callCount = new AtomicLong();
-        HttpServer<ByteBuf, ByteBuf> server    = startServer(BAD_REQUEST,
+        AtomicLong callCount = new AtomicLong();
+        HttpServer<ByteBuf, ByteBuf> server = startServer(BAD_REQUEST,
             "{\"id\":\"f3872d6a-43b9-41c2-a302-f1fc89621f68\",\"error\":\"validation\",\"fields\":[{\"field\":\"phoneNumber\",\"error\":\"validation.invalid.phone.number\"}]}",
             r -> callCount.incrementAndGet());
 
@@ -592,7 +589,7 @@ public class HttpClientTest {
             fail("expected exception");
         } catch (WebException e) {
             assertThat(e.getError()).isEqualTo("validation");
-            HttpClient.DetailedError cause = (HttpClient.DetailedError) e.getCause();
+            HttpClient.DetailedError cause = (HttpClient.DetailedError)e.getCause();
             assertThat(cause.getFields()).isNotNull();
             assertThat(cause.getFields()).hasSize(1);
             FieldError error = cause.getFields()[0];
@@ -975,6 +972,38 @@ public class HttpClientTest {
         server.shutdown();
     }
 
+    @Test
+    public void shouldSendBasicAuthHeaderIfConfigured() throws URISyntaxException {
+        AtomicReference<HttpServerRequest<ByteBuf>> recordedRequest = new AtomicReference<>();
+        HttpServer<ByteBuf, ByteBuf>                server          = startServer(OK, "", recordedRequest::set);
+
+        HttpClientConfig httpClientConfig = new HttpClientConfig("localhost:" + server.getServerPort());
+        httpClientConfig.setBasicAuth("root", "hunter2");
+
+        TestResource resource = getHttpProxy(httpClientConfig);
+        resource.getHello().test().awaitTerminalEvent();
+
+        assertThat(recordedRequest.get().containsHeader("Authorization")).isTrue();
+        assertThat(recordedRequest.get().getHeader("Authorization")).isEqualTo("Basic cm9vdDpodW50ZXIy");
+
+        server.shutdown();
+    }
+
+
+    @Test
+    public void shouldNotSendAuthorizationHeadersUnlessConfigured() throws URISyntaxException {
+        AtomicReference<HttpServerRequest<ByteBuf>> recordedRequest = new AtomicReference<>();
+        HttpServer<ByteBuf, ByteBuf>                server          = startServer(OK, "", recordedRequest::set);
+
+        HttpClientConfig httpClientConfig = new HttpClientConfig("localhost:" + server.getServerPort());
+
+        TestResource resource = getHttpProxy(httpClientConfig);
+        resource.getHello().test().awaitTerminalEvent();
+
+        assertThat(recordedRequest.get().containsHeader("Authorization")).isFalse();
+
+        server.shutdown();
+    }
 
     @Test
     public void shouldSetDevParams() throws URISyntaxException {
@@ -1020,11 +1049,9 @@ public class HttpClientTest {
         assertThat(recordedRequestBody.get()).isEqualTo("\"test\"");
         assertThat(recordedRequest.get().getHttpMethod()).isEqualTo(HttpMethod.DELETE);
 
-
         resource.put("test").toBlocking().lastOrDefault(null);
         assertThat(recordedRequestBody.get()).isEqualTo("\"test\"");
         assertThat(recordedRequest.get().getHttpMethod()).isEqualTo(HttpMethod.PUT);
-
 
         resource.post("test").toBlocking().lastOrDefault(null);
         assertThat(recordedRequestBody.get()).isEqualTo("\"test\"");
@@ -1066,12 +1093,11 @@ public class HttpClientTest {
         server.shutdown();
     }
 
-
     @Test
     public void shouldHandleSimpleGetRequests() {
-        HttpServer<ByteBuf, ByteBuf> server   = startServer(OK, "this is my response");
+        HttpServer<ByteBuf, ByteBuf> server = startServer(OK, "this is my response");
 
-        String url = "http://localhost:" + server.getServerPort();
+        String url      = "http://localhost:" + server.getServerPort();
         String response = HttpClient.get(url).toBlocking().single();
 
         assertThat(response).isEqualTo("this is my response");
@@ -1081,7 +1107,7 @@ public class HttpClientTest {
 
     @Test
     public void shouldErrorHandleSimpleGetRequestsWithBadUrl() {
-        HttpServer<ByteBuf, ByteBuf> server   = startServer(OK, "this is my response");
+        HttpServer<ByteBuf, ByteBuf> server = startServer(OK, "this is my response");
 
         String url = "htp://localhost:" + server.getServerPort();
 
@@ -1137,7 +1163,7 @@ public class HttpClientTest {
     @Test
     public void shouldErrorOnUntrustedHost() throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig("https://untrusted-root.badssl.com");
-        Injector injector = injectorWithProgrammaticHttpClientConfig(httpClientConfig);
+        Injector         injector         = injectorWithProgrammaticHttpClientConfig(httpClientConfig);
         RxClientProvider rxClientProvider = injector.getInstance(RxClientProvider.class);
 
         try {
@@ -1157,7 +1183,7 @@ public class HttpClientTest {
     public void shouldHandleUnsafeSecureOnUntrustedHost() throws URISyntaxException {
         HttpClientConfig httpClientConfig = new HttpClientConfig("https://untrusted-root.badssl.com");
         httpClientConfig.setValidateCertificates(false);
-        Injector injector = injectorWithProgrammaticHttpClientConfig(httpClientConfig);
+        Injector         injector         = injectorWithProgrammaticHttpClientConfig(httpClientConfig);
         RxClientProvider rxClientProvider = injector.getInstance(RxClientProvider.class);
 
         rxClientProvider
@@ -1170,7 +1196,8 @@ public class HttpClientTest {
 
     @Test
     public void shouldLogRequestDetailsOnTimeout() {
-        HttpServer<ByteBuf, ByteBuf> server   = startServer(OK, Observable.never(), r->{});
+        HttpServer<ByteBuf, ByteBuf> server = startServer(OK, Observable.never(), r -> {
+        });
 
         try {
             TestResource resource = getHttpProxy(server.getServerPort());
@@ -1178,15 +1205,14 @@ public class HttpClientTest {
             resource.servertest("mode").toBlocking().single();
             fail("expected timeout");
         } catch (Exception e) {
-            OutputStream baos = new ByteArrayOutputStream();
-            PrintStream stream = new PrintStream(baos, true);
+            OutputStream baos   = new ByteArrayOutputStream();
+            PrintStream  stream = new PrintStream(baos, true);
             e.printStackTrace(stream);
-            assertThat(baos.toString()).contains("Timeout after 10 ms calling localhost:"+server.getServerPort()+"/hello/servertest/mode");
+            assertThat(baos.toString()).contains("Timeout after 10 ms calling localhost:" + server.getServerPort() + "/hello/servertest/mode");
         } finally {
             server.shutdown();
         }
     }
-
 
     private String generateLargeString(int sizeInMB) {
         char[] resp = new char[sizeInMB * 1024 * 1024];


### PR DESCRIPTION
I've been sending auth headers with @HeaderParam on each endpoint for a while and realized it would make sense to actually add this to the framework :) 

It simply works by adding basicAuth to your config:
```
httpClient:
  url: myhost.com
  basicAuth:
    username: root
    password: hunter2
```

This will add an Authorization-header with Basic <base64-encoded auth>