### PR TITLE
Do not measure time including backpressure for DAO calls

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ObservableStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ObservableStatementFactory.java
@@ -83,8 +83,8 @@ public class ObservableStatementFactory {
         }
 
         result = pagingOutput.apply(result, args);
-        result = result.onBackpressureBuffer(RECORD_BUFFER_SIZE);
         result = metrics.measure(result, time -> logSlowQuery(transactionHolder.get(), time, args));
+        result = result.onBackpressureBuffer(RECORD_BUFFER_SIZE);
         result = LoggingContext.transfer(result);
         result = result.subscribeOn(scheduler);
 

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/MockDb.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/MockDb.java
@@ -106,6 +106,8 @@ public class MockDb {
             when(rs.getString(column)).thenReturn((String)value);
         } else if (type.equals(Long.class)) {
             when(rs.getLong(column)).thenReturn((Long)value);
+        } else if (type.equals(Integer.class)) {
+            when(rs.getInt(column)).thenReturn((Integer)value);
         } else {
             throw new RuntimeException("Unsupported type " + type);
         }


### PR DESCRIPTION
Before this change of order, a caller of DAO that uses backpressure would affect the measured time of the db statement.