### PR TITLE
cache metadata for outgoing requests

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -87,6 +87,7 @@ public class HttpClient implements InvocationHandler {
     private         int                         timeout = 10;
     private         TimeUnit                    timeoutUnit = TimeUnit.SECONDS;
     private final Map<Class<?>, List<BeanParamProperty>> beanParamCache = new HashMap<>();
+    private final Map<Method, JaxRsMeta>        jaxRsMetaMap = new HashMap<>();
 
     @Inject
     public HttpClient(HttpClientConfig config,
@@ -413,8 +414,14 @@ public class HttpClient implements InvocationHandler {
         return detailedError;
     }
 
+    protected JaxRsMeta getJaxRsMeta(Method method) {
+        jaxRsMetaMap.computeIfAbsent(method, JaxRsMeta::new);
+        return jaxRsMetaMap.get(method);
+    }
+
     protected RequestBuilder createRequest(Method method, Object[] arguments) {
-        JaxRsMeta meta = new JaxRsMeta(method);
+
+        JaxRsMeta meta = getJaxRsMeta(method);
 
         RequestBuilder request = new RequestBuilder(serverInfo, meta.getHttpMethod(), meta.getFullPath());
         request.setUri(getPath(method, arguments, meta));

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -87,7 +88,7 @@ public class HttpClient implements InvocationHandler {
     private         int                         timeout = 10;
     private         TimeUnit                    timeoutUnit = TimeUnit.SECONDS;
     private final Map<Class<?>, List<BeanParamProperty>> beanParamCache = new HashMap<>();
-    private final Map<Method, JaxRsMeta>        jaxRsMetaMap = new HashMap<>();
+    private final Map<Method, JaxRsMeta>        jaxRsMetaMap = new ConcurrentHashMap<>();
 
     @Inject
     public HttpClient(HttpClientConfig config,

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -415,8 +415,7 @@ public class HttpClient implements InvocationHandler {
     }
 
     protected JaxRsMeta getJaxRsMeta(Method method) {
-        jaxRsMetaMap.computeIfAbsent(method, JaxRsMeta::new);
-        return jaxRsMetaMap.get(method);
+        return jaxRsMetaMap.computeIfAbsent(method, JaxRsMeta::new);
     }
 
     protected RequestBuilder createRequest(Method method, Object[] arguments) {

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -287,11 +287,16 @@ public class HttpClientTest {
         };
 
         Method getHello = TestResource.class.getMethod("getHello");
+        Method postHello = TestResource.class.getMethod("postHello");
 
         httpClient.createRequest(getHello,new Object[0]);
         httpClient.createRequest(getHello,new Object[0]);
+
+        httpClient.createRequest(postHello,new Object[0]);
+        httpClient.createRequest(postHello,new Object[0]);
 
         assertThat(jaxRsMetas.get(0)).isSameAs(jaxRsMetas.get(1));
+        assertThat(jaxRsMetas.get(2)).isSameAs(jaxRsMetas.get(3));
     }
 
     @Test

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -30,7 +30,6 @@ import org.apache.log4j.Appender;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import rx.Observable;
@@ -272,6 +271,27 @@ public class HttpClientTest {
             }
 
         });
+    }
+
+    @Test
+    public void shouldReuseJaxRsMetaObjectsToAvoidReflection() throws URISyntaxException, NoSuchMethodException {
+
+        List<JaxRsMeta> jaxRsMetas = new ArrayList<>();
+        HttpClient httpClient = new HttpClient(new HttpClientConfig("localhost")) {
+            @Override
+            protected JaxRsMeta getJaxRsMeta(Method method) {
+                JaxRsMeta jaxRsMeta = super.getJaxRsMeta(method);
+                jaxRsMetas.add(jaxRsMeta);
+                return jaxRsMeta;
+            }
+        };
+
+        Method getHello = TestResource.class.getMethod("getHello");
+
+        httpClient.createRequest(getHello,new Object[0]);
+        httpClient.createRequest(getHello,new Object[0]);
+
+        assertThat(jaxRsMetas.get(0)).isSameAs(jaxRsMetas.get(1));
     }
 
     @Test


### PR DESCRIPTION
Since the JaxRsMeta is always the same for a particular method it seems wise to cache this and avoid a lot of processing and annotation parsing in each and every outgoing request.