### PR TITLE
expose path

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestHandler.java
@@ -11,6 +11,9 @@ import se.fortnox.reactivewizard.util.DebugUtil;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * Handles incoming requests. If the request matches a resource an Observable which completes the request is returned.
@@ -91,6 +94,12 @@ public class JaxRsRequestHandler implements RequestHandler<ByteBuf, ByteBuf> {
             .onErrorResumeNext(e -> exceptionHandler.handleException(request, response, e))
             .doAfterTerminate(() -> resource.log(request, response, requestStartTime));
     }
+
+    public Optional<String> getPathFor(JaxRsRequest jaxRsRequest) {
+        return ofNullable(resources.findResource(jaxRsRequest))
+            .map(JaxRsResource::getPath);
+    }
+
 
     private Observable<Void> writeResult(HttpServerResponse<ByteBuf> response, JaxRsResult<?> result) {
         if (result != null) {

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequestHandler.java
@@ -11,9 +11,6 @@ import se.fortnox.reactivewizard.util.DebugUtil;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Optional;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * Handles incoming requests. If the request matches a resource an Observable which completes the request is returned.
@@ -86,6 +83,8 @@ public class JaxRsRequestHandler implements RequestHandler<ByteBuf, ByteBuf> {
             return null;
         }
 
+        preHandle(request, resource);
+
         long requestStartTime = System.currentTimeMillis();
 
         return resource.call(jaxRsRequest)
@@ -95,11 +94,14 @@ public class JaxRsRequestHandler implements RequestHandler<ByteBuf, ByteBuf> {
             .doAfterTerminate(() -> resource.log(request, response, requestStartTime));
     }
 
-    public Optional<String> getPathFor(JaxRsRequest jaxRsRequest) {
-        return ofNullable(resources.findResource(jaxRsRequest))
-            .map(JaxRsResource::getPath);
+    /**
+     * Pre handling hook for classes extending this class
+     *
+     * @param request the current request
+     * @param resource the resource that will we handling the request
+     */
+    protected void preHandle(HttpServerRequest<ByteBuf> request, JaxRsResource<?> resource) {
     }
-
 
     private Observable<Void> writeResult(HttpServerResponse<ByteBuf> response, JaxRsResult<?> result) {
         if (result != null) {

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -66,7 +66,6 @@ import static rx.Observable.just;
 import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.body;
 import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.delete;
 import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.get;
-import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.getJaxRsRequestHandler;
 import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.getWithHeaders;
 import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.patch;
 import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.post;
@@ -622,22 +621,6 @@ public class JaxRsResourceTest {
     public void shouldSupportReturningNullFromResource() {
         assertThat(get(new Testresource(), "/test/returnsNull").getStatus())
             .isEqualTo(HttpResponseStatus.NO_CONTENT);
-    }
-
-    @Test
-    public void shouldReturnPathForJaxRsRequest() {
-
-        JaxRsRequestHandler jaxRsRequestHandler = getJaxRsRequestHandler(new TestresourceImpl());
-
-        MockHttpServerRequest mockHttpServerRequest = new MockHttpServerRequest("/test/acceptsString/test");
-        JaxRsRequest jaxRsRequest = new JaxRsRequest(mockHttpServerRequest);
-
-        MockHttpServerRequest notFoundRequest = new MockHttpServerRequest("/not_found");
-        JaxRsRequest notFoundJaxRsRequest = new JaxRsRequest(notFoundRequest);
-
-
-        assertThat(jaxRsRequestHandler.getPathFor(jaxRsRequest)).isPresent().hasValue("/test/acceptsString/{myarg}");
-        assertThat(jaxRsRequestHandler.getPathFor(notFoundJaxRsRequest)).isNotPresent();
     }
 
     @Test

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -58,12 +58,19 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
-import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.*;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 import static rx.Observable.just;
+import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.body;
+import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.delete;
+import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.get;
+import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.getJaxRsRequestHandler;
+import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.getWithHeaders;
+import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.patch;
+import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.post;
+import static se.fortnox.reactivewizard.utils.JaxRsTestUtil.put;
 
 public class JaxRsResourceTest {
 
@@ -615,6 +622,22 @@ public class JaxRsResourceTest {
     public void shouldSupportReturningNullFromResource() {
         assertThat(get(new Testresource(), "/test/returnsNull").getStatus())
             .isEqualTo(HttpResponseStatus.NO_CONTENT);
+    }
+
+    @Test
+    public void shouldReturnPathForJaxRsRequest() {
+
+        JaxRsRequestHandler jaxRsRequestHandler = getJaxRsRequestHandler(new TestresourceImpl());
+
+        MockHttpServerRequest mockHttpServerRequest = new MockHttpServerRequest("/test/acceptsString/test");
+        JaxRsRequest jaxRsRequest = new JaxRsRequest(mockHttpServerRequest);
+
+        MockHttpServerRequest notFoundRequest = new MockHttpServerRequest("/not_found");
+        JaxRsRequest notFoundJaxRsRequest = new JaxRsRequest(notFoundRequest);
+
+
+        assertThat(jaxRsRequestHandler.getPathFor(jaxRsRequest)).isPresent().hasValue("/test/acceptsString/{myarg}");
+        assertThat(jaxRsRequestHandler.getPathFor(notFoundJaxRsRequest)).isNotPresent();
     }
 
     @Test

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
@@ -1,10 +1,5 @@
 package se.fortnox.reactivewizard.utils;
 
-import se.fortnox.reactivewizard.ExceptionHandler;
-import se.fortnox.reactivewizard.jaxrs.*;
-import se.fortnox.reactivewizard.mocks.MockHttpServerResponse;
-import se.fortnox.reactivewizard.jaxrs.params.ParamResolverFactories;
-import se.fortnox.reactivewizard.jaxrs.response.JaxRsResultFactoryFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -15,6 +10,11 @@ import io.reactivex.netty.protocol.http.server.HttpServerRequest;
 import io.reactivex.netty.protocol.http.server.MockHttpServerRequest;
 import io.reactivex.netty.protocol.http.server.RequestHandler;
 import rx.Observable;
+import se.fortnox.reactivewizard.ExceptionHandler;
+import se.fortnox.reactivewizard.jaxrs.JaxRsRequestHandler;
+import se.fortnox.reactivewizard.jaxrs.JaxRsResourceFactory;
+import se.fortnox.reactivewizard.jaxrs.JaxRsResources;
+import se.fortnox.reactivewizard.mocks.MockHttpServerResponse;
 
 import java.nio.charset.Charset;
 import java.util.List;
@@ -74,7 +74,7 @@ public class JaxRsTestUtil {
         return processRequestWithHandler(handler, request);
     }
 
-    private static JaxRsRequestHandler getJaxRsRequestHandler(Object... services) {
+    public static JaxRsRequestHandler getJaxRsRequestHandler(Object... services) {
         return new JaxRsRequestHandler(services);
     }
 

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/utils/JaxRsTestUtil.java
@@ -74,7 +74,7 @@ public class JaxRsTestUtil {
         return processRequestWithHandler(handler, request);
     }
 
-    public static JaxRsRequestHandler getJaxRsRequestHandler(Object... services) {
+    private static JaxRsRequestHandler getJaxRsRequestHandler(Object... services) {
         return new JaxRsRequestHandler(services);
     }
 


### PR DESCRIPTION
There is information about the full path when making a request.
But when answering a request the full path is not to be found.
This pr solves that so that you can get the path of the resource that will answer the request