### PR TITLE
Shutdown Netty server gracefully.

### DIFF
--- a/server/src/main/java/se/fortnox/reactivewizard/server/RxNettyServer.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/RxNettyServer.java
@@ -1,6 +1,9 @@
 package se.fortnox.reactivewizard.server;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.protocol.http.server.HttpServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,18 +22,25 @@ public class RxNettyServer extends Thread {
     private final ServerConfig config;
     private final ConnectionCounter connectionCounter;
     public static final int MAX_CHUNK_SIZE_DEFAULT = 8192;
+    private final EventLoopGroup eventLoopGroup;
     private final HttpServer<ByteBuf, ByteBuf> server;
+    private static Runnable blockShutdownUntil;
 
     @Inject
     public RxNettyServer(ServerConfig config, CompositeRequestHandler compositeRequestHandler, ConnectionCounter connectionCounter) {
-        this(config, connectionCounter, createHttpServer(config), compositeRequestHandler);
+        this(config, compositeRequestHandler, connectionCounter, RxNetty.getRxEventLoopProvider().globalServerEventLoop(true));
+    }
+
+    RxNettyServer(ServerConfig config, CompositeRequestHandler compositeRequestHandler, ConnectionCounter connectionCounter, EventLoopGroup eventLoopGroup) {
+        this(config, connectionCounter, createHttpServer(config, eventLoopGroup), compositeRequestHandler, eventLoopGroup);
     }
 
     RxNettyServer(ServerConfig config, ConnectionCounter connectionCounter, HttpServer<ByteBuf, ByteBuf> httpServer,
-                  CompositeRequestHandler compositeRequestHandler) {
+                  CompositeRequestHandler compositeRequestHandler, EventLoopGroup eventLoopGroup) {
         super("RxNettyServerMain");
         this.config = config;
         this.connectionCounter = connectionCounter;
+        this.eventLoopGroup = eventLoopGroup;
 
         if (config.isEnabled()) {
             server = httpServer.start(compositeRequestHandler);
@@ -41,11 +51,11 @@ public class RxNettyServer extends Thread {
         }
     }
 
-    private static HttpServer<ByteBuf, ByteBuf> createHttpServer(ServerConfig config) {
+    private static HttpServer<ByteBuf, ByteBuf> createHttpServer(ServerConfig config, EventLoopGroup eventLoopGroup) {
         if (!config.isEnabled()) {
             return null;
         }
-        return HttpServer.newServer(config.getPort())
+        return HttpServer.newServer(config.getPort(), eventLoopGroup, NioServerSocketChannel.class)
             .<ByteBuf, ByteBuf>pipelineConfigurator(
                 new NoContentFixConfigurator(
                     config.getMaxInitialLineLengthDefault(),
@@ -65,12 +75,21 @@ public class RxNettyServer extends Thread {
     }
 
     private void registerShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdownHook(config, server, connectionCounter)));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdownHook(config, server, eventLoopGroup, connectionCounter)));
     }
 
-    static void shutdownHook(ServerConfig config, HttpServer server, ConnectionCounter connectionCounter) {
-        LOG.info("Shutdown requested. Will wait up to {} seconds...", config.getShutdownTimeoutSeconds());
-        server.shutdown();
+    public static void registerShutdownDependency(Runnable blockShutdownUntil) {
+        if (RxNettyServer.blockShutdownUntil != null && blockShutdownUntil != null) {
+            throw new IllegalStateException("Shutdown dependency is already registered");
+        }
+        RxNettyServer.blockShutdownUntil = blockShutdownUntil;
+    }
+
+    static void shutdownHook(ServerConfig config, HttpServer server, EventLoopGroup eventLoopGroup, ConnectionCounter connectionCounter) {
+        LOG.info("Shutdown requested.");
+        awaitShutdownDependency();
+        LOG.info("Will wait up to {} seconds...", config.getShutdownTimeoutSeconds());
+        shutdownEventLoopGracefully(config, eventLoopGroup);
         if (!connectionCounter.awaitZero(config.getShutdownTimeoutSeconds(), TimeUnit.SECONDS)) {
             LOG.error("Shutdown proceeded while connection count was not zero: " + connectionCounter.getCount());
         }
@@ -78,4 +97,28 @@ public class RxNettyServer extends Thread {
         LOG.info("Shutdown complete");
     }
 
+    static void awaitShutdownDependency() {
+        if (blockShutdownUntil == null) {
+            return;
+        }
+
+        LOG.info("Wait for completion of shutdown dependency");
+        Thread thread = new Thread(blockShutdownUntil);
+        thread.start();
+        try {
+            thread.join();
+        } catch (InterruptedException e) {
+            LOG.error("Fail while waiting shutdown dependency", e);
+        }
+        LOG.info("Shutdown dependency completed, continue...");
+    }
+
+    static void shutdownEventLoopGracefully(ServerConfig config, EventLoopGroup eventLoopGroup) {
+        try {
+            int shutdownQuietPeriodSeconds = 0;
+            eventLoopGroup.shutdownGracefully(shutdownQuietPeriodSeconds, config.getShutdownTimeoutSeconds(), TimeUnit.SECONDS).await();
+        } catch (InterruptedException e) {
+            LOG.error("Graceful shutdown failed" + e);
+        }
+    }
 }

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RxNettyServerTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RxNettyServerTest.java
@@ -1,22 +1,30 @@
 package se.fortnox.reactivewizard.server;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.Future;
 import io.reactivex.netty.protocol.http.server.HttpServer;
 import org.apache.log4j.Appender;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import se.fortnox.reactivewizard.test.LoggingMockUtil;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,6 +37,9 @@ public class RxNettyServerTest {
     HttpServer<ByteBuf, ByteBuf> server;
 
     @Mock
+    EventLoopGroup eventLoopGroup;
+
+    @Mock
     ConnectionCounter connectionCounter;
 
     @Mock
@@ -36,7 +47,10 @@ public class RxNettyServerTest {
 
     @Before
     public void before() {
+        RxNettyServer.registerShutdownDependency(null);
         when(server.start(compositeRequestHandler)).thenReturn(server);
+        Future future = Mockito.mock(Future.class);
+        when(eventLoopGroup.shutdownGracefully(anyLong(), anyLong(), any())).thenReturn(future);
     }
 
     @Test
@@ -44,7 +58,7 @@ public class RxNettyServerTest {
         ServerConfig serverConfig = new ServerConfig();
         serverConfig.setEnabled(false);
 
-        RxNettyServer rxNettyServer = new RxNettyServer(serverConfig, connectionCounter, server, compositeRequestHandler);
+        RxNettyServer rxNettyServer = new RxNettyServer(serverConfig, connectionCounter, server, compositeRequestHandler, eventLoopGroup);
         rxNettyServer.join();
 
         assertNull(rxNettyServer.getServer());
@@ -55,7 +69,7 @@ public class RxNettyServerTest {
         ServerConfig  serverConfig              = new ServerConfig();
         AtomicInteger startInvocedNumberOfTimes = new AtomicInteger(0);
 
-        RxNettyServer rxNettyServer = new RxNettyServer(serverConfig, connectionCounter, server, compositeRequestHandler) {
+        RxNettyServer rxNettyServer = new RxNettyServer(serverConfig, connectionCounter, server, compositeRequestHandler, eventLoopGroup) {
             @Override
             public void start() {
                 startInvocedNumberOfTimes.incrementAndGet();
@@ -71,7 +85,7 @@ public class RxNettyServerTest {
     public void shouldAwaitShutDown() throws InterruptedException {
         ServerConfig serverConfig = new ServerConfig();
 
-        RxNettyServer rxNettyServer = new RxNettyServer(serverConfig, connectionCounter, server, compositeRequestHandler) {};
+        RxNettyServer rxNettyServer = new RxNettyServer(serverConfig, connectionCounter, server, compositeRequestHandler, eventLoopGroup) {};
         rxNettyServer.join();
 
         verify(server, times(1)).awaitShutdown();
@@ -81,10 +95,14 @@ public class RxNettyServerTest {
     public void shouldLogThatShutDownIsRegistered() throws NoSuchFieldException, IllegalAccessException {
         Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RxNettyServer.class);
 
-        RxNettyServer.shutdownHook(new ServerConfig(), server, connectionCounter);
+        RxNettyServer.shutdownHook(new ServerConfig(), server, eventLoopGroup, connectionCounter);
 
         verify(mockAppender).doAppend(matches(log ->
-            assertThat(log.getMessage().toString()).matches("Shutdown requested. Will wait up to 20 seconds...")
+            assertThat(log.getMessage().toString()).matches("Shutdown requested.")
+        ));
+
+        verify(mockAppender).doAppend(matches(log ->
+            assertThat(log.getMessage().toString()).matches("Will wait up to 20 seconds...")
         ));
 
         verify(mockAppender).doAppend(matches(log ->
@@ -96,9 +114,9 @@ public class RxNettyServerTest {
 
     @Test
     public void shouldCallServerShutDownWhenShutdownHookIsInvoked() {
-        RxNettyServer.shutdownHook(new ServerConfig(), server, connectionCounter);
+        RxNettyServer.shutdownHook(new ServerConfig(), server, eventLoopGroup, connectionCounter);
 
-        verify(server, times(1)).shutdown();
+        verify(eventLoopGroup, times(1)).shutdownGracefully(anyLong(), anyLong(), any());
         verify(server, times(1)).awaitShutdown();
     }
 
@@ -109,10 +127,14 @@ public class RxNettyServerTest {
         when(connectionCounter.awaitZero(anyInt(), any(TimeUnit.class))).thenReturn(false);
         when(connectionCounter.getCount()).thenReturn(4L);
 
-        RxNettyServer.shutdownHook(new ServerConfig(), server, connectionCounter);
+        RxNettyServer.shutdownHook(new ServerConfig(), server, eventLoopGroup, connectionCounter);
 
         verify(mockAppender).doAppend(matches(log ->
-            assertThat(log.getMessage().toString()).matches("Shutdown requested. Will wait up to 20 seconds...")
+            assertThat(log.getMessage().toString()).matches("Shutdown requested.")
+        ));
+
+        verify(mockAppender).doAppend(matches(log ->
+            assertThat(log.getMessage().toString()).matches("Will wait up to 20 seconds...")
         ));
 
         verify(mockAppender).doAppend(matches(log ->
@@ -122,4 +144,40 @@ public class RxNettyServerTest {
         LoggingMockUtil.destroyMockedAppender(mockAppender, RxNettyServer.class);
     }
 
+    @Test
+    public void shouldNotOverrideShutdownDependency() {
+        RxNettyServer.registerShutdownDependency(() -> {});
+        try {
+            RxNettyServer.registerShutdownDependency(() -> {});
+            fail();
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage()).isEqualTo("Shutdown dependency is already registered");
+        }
+    }
+
+    @Test
+    public void shouldSkipAwaitingShutdownDependencyIfNotSet() throws NoSuchFieldException, IllegalAccessException {
+        Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RxNettyServer.class);
+        RxNettyServer.awaitShutdownDependency();
+        verify(mockAppender, never()).doAppend(any());
+    }
+
+    @Test
+    public void shouldAwaitShutdownDependency() throws NoSuchFieldException, IllegalAccessException {
+        Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RxNettyServer.class);
+        Supplier supplier = mock(Supplier.class);
+
+        RxNettyServer.registerShutdownDependency(supplier::get);
+        verify(supplier, never()).get();
+
+        RxNettyServer.awaitShutdownDependency();
+
+        verify(mockAppender).doAppend(matches(log ->
+            assertThat(log.getMessage().toString()).matches("Wait for completion of shutdown dependency")
+        ));
+        verify(supplier, times(1)).get();
+        verify(mockAppender).doAppend(matches(log ->
+            assertThat(log.getMessage().toString()).matches("Shutdown dependency completed, continue...")
+        ));
+    }
 }

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RxNettyServerTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RxNettyServerTest.java
@@ -98,11 +98,7 @@ public class RxNettyServerTest {
         RxNettyServer.shutdownHook(new ServerConfig(), server, eventLoopGroup, connectionCounter);
 
         verify(mockAppender).doAppend(matches(log ->
-            assertThat(log.getMessage().toString()).matches("Shutdown requested.")
-        ));
-
-        verify(mockAppender).doAppend(matches(log ->
-            assertThat(log.getMessage().toString()).matches("Will wait up to 20 seconds...")
+            assertThat(log.getMessage().toString()).matches("Shutdown requested. Will wait up to 20 seconds...")
         ));
 
         verify(mockAppender).doAppend(matches(log ->
@@ -130,11 +126,7 @@ public class RxNettyServerTest {
         RxNettyServer.shutdownHook(new ServerConfig(), server, eventLoopGroup, connectionCounter);
 
         verify(mockAppender).doAppend(matches(log ->
-            assertThat(log.getMessage().toString()).matches("Shutdown requested.")
-        ));
-
-        verify(mockAppender).doAppend(matches(log ->
-            assertThat(log.getMessage().toString()).matches("Will wait up to 20 seconds...")
+            assertThat(log.getMessage().toString()).matches("Shutdown requested. Will wait up to 20 seconds...")
         ));
 
         verify(mockAppender).doAppend(matches(log ->
@@ -158,7 +150,7 @@ public class RxNettyServerTest {
     @Test
     public void shouldSkipAwaitingShutdownDependencyIfNotSet() throws NoSuchFieldException, IllegalAccessException {
         Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RxNettyServer.class);
-        RxNettyServer.awaitShutdownDependency();
+        RxNettyServer.awaitShutdownDependency(new ServerConfig().getShutdownTimeoutSeconds());
         verify(mockAppender, never()).doAppend(any());
     }
 
@@ -170,7 +162,7 @@ public class RxNettyServerTest {
         RxNettyServer.registerShutdownDependency(supplier::get);
         verify(supplier, never()).get();
 
-        RxNettyServer.awaitShutdownDependency();
+        RxNettyServer.awaitShutdownDependency(new ServerConfig().getShutdownTimeoutSeconds());
 
         verify(mockAppender).doAppend(matches(log ->
             assertThat(log.getMessage().toString()).matches("Wait for completion of shutdown dependency")


### PR DESCRIPTION
Shutdown Netty server gracefully.
Delay Netty shutdown before resolving shutdown dependency (if there is one).

> Shutting down a Netty application is usually as simple as shutting down all EventLoopGroups you created via shutdownGracefully(). It returns a Future that notifies you when the EventLoopGroup has been terminated completely and all Channels that belong to the group have been closed.