### PR TITLE
Make ReflectionUtil.getOverriddenMethod play nice with cglib

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -77,5 +77,14 @@
 			<version>${netty.version}</version>
 		</dependency>
 
+        <!-- Test dependencies -->
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>4.2.2</version>
+            <scope>test</scope>
+        </dependency>
+
 	</dependencies>
 </project>


### PR DESCRIPTION
When using method interceptors in Guice a dynamic subclass is
created of the intercepted class. This causes getOverriddenMethod to
not find the correct interface method. This is solved by simply
skipping the generated subclasses when traversing the class tree.

For example, before this, using a class interceptor on the implementation of a jax rs resource will result in the framework not finding parameter annotations such as @QueryParam on method parameters due to the resource interface not being declared on the generated subclass.