### PR TITLE
making the database accept a set of void DaoObservables.

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
@@ -48,7 +48,7 @@ public class DaoTransactionsImpl implements DaoTransactions {
             return empty();
         }
         createTransaction(daoCalls);
-        return merge(daoCalls).last().flatMap(e -> empty());
+        return merge(daoCalls).ignoreElements().cast(Void.class);
     }
 
     @Override


### PR DESCRIPTION
A call to .last (expecting at least 1 element in the stream) prevented that.

Switching to .ignoreElements().cast(Void.class)