### PR TITLE
Use log4j to log startup errors

### DIFF
--- a/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
+++ b/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
@@ -4,9 +4,12 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
+import org.slf4j.LoggerFactory;
 import se.fortnox.reactivewizard.binding.AutoBindModules;
 import se.fortnox.reactivewizard.config.ConfigFactory;
 import se.fortnox.reactivewizard.logging.LoggingFactory;
+
+import java.nio.file.NoSuchFileException;
 
 /**
  * Main application entry point. Will scan for all modules on the classpath and run them.
@@ -17,9 +20,9 @@ import se.fortnox.reactivewizard.logging.LoggingFactory;
 public class Main {
     public static void main(String[] args) {
         try {
-            ConfigFactory configFactory = new ConfigFactory(args);
-            configFactory.get(LoggingFactory.class).init();
-
+            ConfigFactory configFactory = createConfigFactory(args);
+            LoggingFactory loggingFactory = configFactory.get(LoggingFactory.class);
+            loggingFactory.init();
             Module bootstrap = new AbstractModule() {
                 @Override
                 protected void configure() {
@@ -29,8 +32,35 @@ public class Main {
             };
             Guice.createInjector(new AutoBindModules(bootstrap));
         } catch (Exception e) {
-            e.printStackTrace();
+            // Since logging is configured at runtime we cant have a static logger.
+            LoggerFactory
+                .getLogger(Main.class)
+                .error("Caught exception at startup.", e);
             System.exit(-1);
+        }
+    }
+
+    /**
+     * Prepares a ConfigFactory before setting up Guice.
+     *
+     * As logging can be part of the configuration file and the configuration file
+     * could be missing, we have a side effect of setting up and initializing a LoggingFactory
+     * that doesn't depend on ConfigFactory, if the configuration file is missing.
+     *
+     * @param args commandline arguments
+     * @return A ConfigFactory based on a configuration file.
+     * @throws NoSuchFileException If the configuration file cannot be found.
+     */
+    private static ConfigFactory createConfigFactory(String[] args) throws NoSuchFileException {
+        try {
+            return new ConfigFactory(args);
+        } catch (RuntimeException runtimeException) {
+            if(runtimeException.getCause().getClass().isAssignableFrom(NoSuchFileException.class)) {
+                LoggingFactory loggingFactory = new LoggingFactory();
+                loggingFactory.init();
+                throw (NoSuchFileException) runtimeException.getCause();
+            }
+            throw runtimeException;
         }
     }
 }

--- a/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
+++ b/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
@@ -18,9 +18,14 @@ import java.nio.file.NoSuchFileException;
  * Requires a config file as last parameter.
  */
 public class Main {
+    /**
+     * Main application entry point.
+     *
+     * @param args Commandline arguments
+     */
     public static void main(String[] args) {
         try {
-            ConfigFactory configFactory = createConfigFactory(args);
+            ConfigFactory  configFactory  = createConfigFactory(args);
             LoggingFactory loggingFactory = configFactory.get(LoggingFactory.class);
             loggingFactory.init();
             Module bootstrap = new AbstractModule() {
@@ -42,7 +47,7 @@ public class Main {
 
     /**
      * Prepares a ConfigFactory before setting up Guice.
-     *
+     * <p>
      * As logging can be part of the configuration file and the configuration file
      * could be missing, we have a side effect of setting up and initializing a LoggingFactory
      * that doesn't depend on ConfigFactory, if the configuration file is missing.
@@ -55,10 +60,10 @@ public class Main {
         try {
             return new ConfigFactory(args);
         } catch (RuntimeException runtimeException) {
-            if(runtimeException.getCause().getClass().isAssignableFrom(NoSuchFileException.class)) {
+            if (runtimeException.getCause().getClass().isAssignableFrom(NoSuchFileException.class)) {
                 LoggingFactory loggingFactory = new LoggingFactory();
                 loggingFactory.init();
-                throw (NoSuchFileException) runtimeException.getCause();
+                throw (NoSuchFileException)runtimeException.getCause();
             }
             throw runtimeException;
         }

--- a/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
+++ b/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
@@ -60,10 +60,11 @@ public class Main {
         try {
             return new ConfigFactory(args);
         } catch (RuntimeException runtimeException) {
-            if (runtimeException.getCause().getClass().isAssignableFrom(NoSuchFileException.class)) {
+            Throwable cause = runtimeException.getCause();
+            if (cause != null && cause.getClass().isAssignableFrom(NoSuchFileException.class)) {
                 LoggingFactory loggingFactory = new LoggingFactory();
                 loggingFactory.init();
-                throw (NoSuchFileException)runtimeException.getCause();
+                throw (NoSuchFileException)cause;
             }
             throw runtimeException;
         }


### PR DESCRIPTION
Effectively replace e.printStackTrace() with a logger call.