### PR TITLE
Making class public

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceInterceptors.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceInterceptors.java
@@ -8,7 +8,7 @@ import java.util.Set;
 /**
  * Composition of all registered JaxRsResourceInterceptor instances.
  */
-class JaxRsResourceInterceptors {
+public class JaxRsResourceInterceptors {
     private final Set<JaxRsResourceInterceptor> interceptors;
 
     @Inject


### PR DESCRIPTION
Since JaxRsRequestHandler is public and this class is an argument in the constructors this class must be public too