### PR TITLE
Cannot read multidimensional lists in configmap

### DIFF
--- a/config/src/main/java/se/fortnox/reactivewizard/config/ConfigReader.java
+++ b/config/src/main/java/se/fortnox/reactivewizard/config/ConfigReader.java
@@ -56,6 +56,9 @@ public class ConfigReader {
         StringBuffer        stringBuffer = new StringBuffer();
         do {
             String value = env.get(matcher.group(1));
+            if (value != null) {
+                value = value.replace("\\n", "\n");
+            }
             matcher.appendReplacement(stringBuffer, value == null ? "" : Matcher.quoteReplacement(value));
         }
         while (matcher.find());

--- a/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
@@ -159,4 +159,22 @@ public class ConfigReaderTest {
             assertThat(exception).hasRootCauseInstanceOf(MarkedYAMLException.class);
         }
     }
+
+    @Test
+    public void shouldReplaceEscapedNewLines() {
+        Map<String, String> env = new HashMap<>(System.getenv());
+        env.put("CLIENTS", "" +
+            "clients:\\n" +
+            "    client1:\\n" +
+            "      - key41\\n" +
+            "      - key24\\n" +
+            "    client2:\\n" +
+            "      - key55");
+        setEnv(env);
+
+        TestConfigNewLine testConfig = ConfigReader.fromFile("src/test/resources/testconfig-newline.yml", TestConfigNewLine.class);
+        assertThat(testConfig.getClients().get("client1").get(0)).isEqualTo("key41");
+        assertThat(testConfig.getClients().get("client1").get(1)).isEqualTo("key24");
+        assertThat(testConfig.getClients().get("client2").get(0)).isEqualTo("key55");
+    }
 }

--- a/config/src/test/java/se/fortnox/reactivewizard/config/TestConfigNewLine.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/TestConfigNewLine.java
@@ -1,0 +1,18 @@
+package se.fortnox.reactivewizard.config;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Config("myTestConfigNewLine")
+public class TestConfigNewLine {
+    private HashMap<String, List<String>> clients;
+
+    public HashMap<String, List<String>> getClients() {
+        return clients;
+    }
+
+    public TestConfigNewLine setClients(HashMap<String, List<String>> clients) {
+        this.clients = clients;
+        return this;
+    }
+}

--- a/config/src/test/resources/testconfig-newline.yml
+++ b/config/src/test/resources/testconfig-newline.yml
@@ -1,0 +1,2 @@
+myTestConfigNewLine:
+  {{CLIENTS}}


### PR DESCRIPTION
Newlines are read as strings if a multidimensional list is added to configmap.

Example of YAML structure that dont work in configmap:
`nicheBanks:  clients:    - testclient      - "12345"`
 
Error message:
`ERRO[2020-07-08T10:19:01.954502254+02:00] v1.ConfigMap.Data: ReadString: expects " or n, but found [, error found in #10 byte of ...|clients":[{"testclient|..., bigger context ...|3.8","database.port":"1234","nichebanks.clients":[ {"testclient":["12345"]}]},"kind":"Co|...`

 