### PR TITLE
Supporting getting the meta data from the response from an api call..

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -115,4 +115,21 @@
 		</dependency>
 	</dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -683,7 +683,7 @@ public class HttpClient implements InvocationHandler {
 
     /**
      * Class used when the full response is needed
-     * @param <T>
+     * @param <T> the type of data to be returned
      */
     public static class Response<T> {
         private final T data;
@@ -711,7 +711,7 @@ public class HttpClient implements InvocationHandler {
 
     /**
      * Internal class to help support getting the full response as return value when observable is returned
-     * @param <T>
+     * @param <T> the type of data to be returned
      */
     private static class ObservableWithResponse<T> extends Observable<T> {
 
@@ -732,7 +732,7 @@ public class HttpClient implements InvocationHandler {
 
     /**
      * Internal class to help support getting the full response as return value when Single is returned
-     * @param <T>
+     * @param <T> the type of data to be returned
      */
     private static class SingleWithResponse<T> extends Single<T> {
 

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -187,7 +187,7 @@ public class HttpClient implements InvocationHandler {
      * from the response.
      * @param source the source observable, must be observable returned from api call
      * @param <T> the type of data that should be returned in the call
-     * @return an observable that along with the data passes the response object from netty
+     * @return an observable that along with the data passes the response meta data
      */
     public static <T> Observable<Response<T>> fullResponse(Observable<T> source) {
         if (!(source instanceof ObservableWithResponse)) {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -715,16 +715,16 @@ public class HttpClient implements InvocationHandler {
      * Internal class to help support getting the full response as return value when observable is returned
      * @param <T> the type of data to be returned
      */
-    private static class ObservableWithResponse<T> extends Observable<T> {
+    static class ObservableWithResponse<T> extends Observable<T> {
 
         private final AtomicReference<HttpClientResponse> httpClientResponse;
 
-        protected ObservableWithResponse(Observable<T> inner, AtomicReference<HttpClientResponse> httpClientResponse) {
+        ObservableWithResponse(Observable<T> inner, AtomicReference<HttpClientResponse> httpClientResponse) {
             super(inner::unsafeSubscribe);
             this.httpClientResponse = httpClientResponse;
         }
 
-        public HttpClientResponse getResponse() {
+        HttpClientResponse getResponse() {
             if (httpClientResponse.get() == null) {
                 throw new IllegalStateException("This method can only be called after the response has been received");
             }
@@ -736,16 +736,16 @@ public class HttpClient implements InvocationHandler {
      * Internal class to help support getting the full response as return value when Single is returned
      * @param <T> the type of data to be returned
      */
-    private static class SingleWithResponse<T> extends Single<T> {
+    static class SingleWithResponse<T> extends Single<T> {
 
         private final AtomicReference<HttpClientResponse> httpClientResponse;
 
-        protected SingleWithResponse(Single<T> inner, AtomicReference<HttpClientResponse> httpClientResponse) {
+        SingleWithResponse(Single<T> inner, AtomicReference<HttpClientResponse> httpClientResponse) {
             super((OnSubscribe<T>)inner::subscribe);
             this.httpClientResponse = httpClientResponse;
         }
 
-        public HttpClientResponse getResponse() {
+        HttpClientResponse getResponse() {
             if (httpClientResponse.get() == null) {
                 throw new IllegalStateException("This method can only be called after the response has been received");
             }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -182,7 +182,9 @@ public class HttpClient implements InvocationHandler {
         return new ObservableWithResponse(RxReactiveStreams.toObservable(publisher), rawResponse);
     }
 
-    /** Should be used with
+    /**
+     * Should be used with an observable coming directly from another api-call to get access to meta data, such as status and headers
+     * from the response.
      * @param source the source observable, must be observable returned from api call
      * @param <T> the type of data that should be returned in the call
      * @return an observable that along with the data passes the response object from netty

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -189,7 +189,7 @@ public class HttpClient implements InvocationHandler {
      * @param <T> the type of data that should be returned in the call
      * @return an observable that along with the data passes the response meta data
      */
-    public static <T> Observable<Response<T>> fullResponse(Observable<T> source) {
+    public static <T> Observable<Response<T>> getFullResponse(Observable<T> source) {
         if (!(source instanceof ObservableWithResponse)) {
             throw new IllegalArgumentException("Must be used with observable returned from api call");
         }
@@ -202,7 +202,7 @@ public class HttpClient implements InvocationHandler {
      * @param <T> the type of data that should be returned in the call
      * @return an observable that along with the data passes the response object from netty
      */
-    public static <T> Single<Response<T>> fullResponse(Single<T> source) {
+    public static <T> Single<Response<T>> getFullResponse(Single<T> source) {
         if (!(source instanceof SingleWithResponse)) {
             throw new IllegalArgumentException("Must be used with single returned from api call");
         }
@@ -688,18 +688,18 @@ public class HttpClient implements InvocationHandler {
      * @param <T> the type of data to be returned
      */
     public static class Response<T> {
-        private final T data;
+        private final T                  body;
         private final HttpResponseStatus status;
         private final Map<String, String> headers;
 
-        public Response(HttpClientResponse httpClientResponse, T data) {
+        public Response(HttpClientResponse httpClientResponse, T body) {
             this.status = httpClientResponse.status();
             this.headers = ImmutableMap.copyOf(httpClientResponse.responseHeaders());
-            this.data = data;
+            this.body = body;
         }
 
-        public T getData() {
-            return data;
+        public T getBody() {
+            return body;
         }
 
         public HttpResponseStatus getStatus() {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/ObservableWithResponse.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/ObservableWithResponse.java
@@ -1,0 +1,27 @@
+package se.fortnox.reactivewizard.client;
+
+import reactor.netty.http.client.HttpClientResponse;
+import rx.Observable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Internal class to help support getting the full response as return value when observable is returned
+ * @param <T> the type of data to be returned
+ */
+class ObservableWithResponse<T> extends Observable<T> {
+
+    private final AtomicReference<HttpClientResponse> httpClientResponse;
+
+    ObservableWithResponse(Observable<T> inner, AtomicReference<HttpClientResponse> httpClientResponse) {
+        super(inner::unsafeSubscribe);
+        this.httpClientResponse = httpClientResponse;
+    }
+
+    HttpClientResponse getResponse() {
+        if (httpClientResponse.get() == null) {
+            throw new IllegalStateException("This method can only be called after the response has been received");
+        }
+        return httpClientResponse.get();
+    }
+}

--- a/client/src/main/java/se/fortnox/reactivewizard/client/Response.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/Response.java
@@ -1,0 +1,35 @@
+package se.fortnox.reactivewizard.client;
+
+import com.google.common.collect.ImmutableMap;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import reactor.netty.http.client.HttpClientResponse;
+
+import java.util.Map;
+
+/**
+ * Class used when the full response is needed
+ * @param <T> the type of data to be returned
+ */
+public class Response<T> {
+    private final T                   body;
+    private final HttpResponseStatus  status;
+    private final Map<String, String> headers;
+
+    public Response(HttpClientResponse httpClientResponse, T body) {
+        this.status = httpClientResponse.status();
+        this.headers = ImmutableMap.copyOf(httpClientResponse.responseHeaders());
+        this.body = body;
+    }
+
+    public T getBody() {
+        return body;
+    }
+
+    public HttpResponseStatus getStatus() {
+        return status;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+}

--- a/client/src/main/java/se/fortnox/reactivewizard/client/SingleWithResponse.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/SingleWithResponse.java
@@ -1,0 +1,27 @@
+package se.fortnox.reactivewizard.client;
+
+import reactor.netty.http.client.HttpClientResponse;
+import rx.Single;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Internal class to help support getting the full response as return value when Single is returned
+ * @param <T> the type of data to be returned
+ */
+class SingleWithResponse<T> extends Single<T> {
+
+    private final AtomicReference<HttpClientResponse> httpClientResponse;
+
+    SingleWithResponse(Single<T> inner, AtomicReference<HttpClientResponse> httpClientResponse) {
+        super((OnSubscribe<T>)inner::subscribe);
+        this.httpClientResponse = httpClientResponse;
+    }
+
+    HttpClientResponse getResponse() {
+        if (httpClientResponse.get() == null) {
+            throw new IllegalStateException("This method can only be called after the response has been received");
+        }
+        return httpClientResponse.get();
+    }
+}

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -536,11 +536,11 @@ public class HttpClientTest {
 
         TestResource resource = getHttpProxy(server.port());
 
-        HttpClient.Response<String> stringResponse = HttpClient.fullResponse(resource.getHello())
+        HttpClient.Response<String> stringResponse = HttpClient.getFullResponse(resource.getHello())
             .toBlocking().singleOrDefault(null);
 
         assertThat(stringResponse).isNotNull();
-        assertThat(stringResponse.getData()).isEqualTo("OK");
+        assertThat(stringResponse.getBody()).isEqualTo("OK");
         assertThat(stringResponse.getStatus()).isEqualTo(OK);
         assertThat(stringResponse.getHeaders().get("content-length")).isEqualTo("4");
     }
@@ -551,11 +551,11 @@ public class HttpClientTest {
 
         TestResource resource = getHttpProxy(server.port());
 
-        HttpClient.Response<String> stringResponse = HttpClient.fullResponse(resource.getSingle())
+        HttpClient.Response<String> stringResponse = HttpClient.getFullResponse(resource.getSingle())
             .toBlocking().value();
 
         assertThat(stringResponse).isNotNull();
-        assertThat(stringResponse.getData()).isEqualTo("OK");
+        assertThat(stringResponse.getBody()).isEqualTo("OK");
         assertThat(stringResponse.getStatus()).isEqualTo(OK);
         assertThat(stringResponse.getHeaders().get("content-length")).isEqualTo("4");
     }

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.inject.Injector;
-import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -76,14 +75,24 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
+import static io.netty.handler.codec.http.HttpResponseStatus.GATEWAY_TIMEOUT;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
-import static reactor.core.publisher.Flux.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static reactor.core.publisher.Flux.defer;
+import static reactor.core.publisher.Flux.empty;
+import static reactor.core.publisher.Flux.just;
 import static se.fortnox.reactivewizard.test.TestUtil.matches;
 
 public class HttpClientTest {
@@ -520,6 +529,37 @@ public class HttpClientTest {
 
         server.disposeNow();
     }
+
+    @Test
+    public void shouldReturnFullResponseFromObservable() {
+        DisposableServer server = startServer(HttpResponseStatus.OK, "\"OK\"");
+
+        TestResource resource = getHttpProxy(server.port());
+
+        HttpClient.Response<String> stringResponse = HttpClient.fullResponse(resource.getHello())
+            .toBlocking().singleOrDefault(null);
+
+        assertThat(stringResponse).isNotNull();
+        assertThat(stringResponse.getData()).isEqualTo("OK");
+        assertThat(stringResponse.getStatus()).isEqualTo(OK);
+        assertThat(stringResponse.getHeaders().get("content-length")).isEqualTo("4");
+    }
+
+    @Test
+    public void shouldReturnFullResponseFromSingle() {
+        DisposableServer server = startServer(HttpResponseStatus.OK, "\"OK\"");
+
+        TestResource resource = getHttpProxy(server.port());
+
+        HttpClient.Response<String> stringResponse = HttpClient.fullResponse(resource.getSingle())
+            .toBlocking().value();
+
+        assertThat(stringResponse).isNotNull();
+        assertThat(stringResponse.getData()).isEqualTo("OK");
+        assertThat(stringResponse.getStatus()).isEqualTo(OK);
+        assertThat(stringResponse.getHeaders().get("content-length")).isEqualTo("4");
+    }
+
 
     @Test
     public void shouldHandleLargeResponses() {

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -536,7 +536,7 @@ public class HttpClientTest {
 
         TestResource resource = getHttpProxy(server.port());
 
-        HttpClient.Response<String> stringResponse = HttpClient.getFullResponse(resource.getHello())
+        Response<String> stringResponse = HttpClient.getFullResponse(resource.getHello())
             .toBlocking().singleOrDefault(null);
 
         assertThat(stringResponse).isNotNull();
@@ -551,7 +551,7 @@ public class HttpClientTest {
 
         TestResource resource = getHttpProxy(server.port());
 
-        HttpClient.Response<String> stringResponse = HttpClient.getFullResponse(resource.getSingle())
+        Response<String> stringResponse = HttpClient.getFullResponse(resource.getSingle())
             .toBlocking().value();
 
         assertThat(stringResponse).isNotNull();

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTestUtil.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTestUtil.java
@@ -28,7 +28,7 @@ public class HttpClientTestUtil {
         when(httpClientResponse.responseHeaders()).thenReturn(httpHeaders);
         when(httpClientResponse.status()).thenReturn(httpResponseStatus);
 
-        return new HttpClient.ObservableWithResponse<>(source, new AtomicReference<>(httpClientResponse));
+        return new ObservableWithResponse<>(source, new AtomicReference<>(httpClientResponse));
     }
 
     public static <T> Single<T> mockResponseWithHeaders(Single<T> source, Map<String, String> headers, HttpResponseStatus httpResponseStatus) {
@@ -39,6 +39,6 @@ public class HttpClientTestUtil {
         when(httpClientResponse.responseHeaders()).thenReturn(httpHeaders);
         when(httpClientResponse.status()).thenReturn(httpResponseStatus);
 
-        return new HttpClient.SingleWithResponse<>(source, new AtomicReference<>(httpClientResponse));
+        return new SingleWithResponse<>(source, new AtomicReference<>(httpClientResponse));
     }
 }

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTestUtil.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTestUtil.java
@@ -1,0 +1,44 @@
+package se.fortnox.reactivewizard.client;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.mockito.Mockito;
+import reactor.netty.http.client.HttpClientResponse;
+import rx.Observable;
+import rx.Single;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Util class for mocking response from server with headers
+ */
+public class HttpClientTestUtil {
+
+    private HttpClientTestUtil() {}
+
+    public static <T> Observable<T> mockResponseWithHeaders(Observable<T> source, Map<String, String> headers, HttpResponseStatus httpResponseStatus) {
+        HttpClientResponse httpClientResponse = Mockito.mock(HttpClientResponse.class);
+
+        HttpHeaders httpHeaders = new DefaultHttpHeaders();
+        headers.forEach(httpHeaders::add);
+        when(httpClientResponse.responseHeaders()).thenReturn(httpHeaders);
+        when(httpClientResponse.status()).thenReturn(httpResponseStatus);
+
+        return new HttpClient.ObservableWithResponse<>(source, new AtomicReference<>(httpClientResponse));
+    }
+
+    public static <T> Single<T> mockResponseWithHeaders(Single<T> source, Map<String, String> headers, HttpResponseStatus httpResponseStatus) {
+        HttpClientResponse httpClientResponse = Mockito.mock(HttpClientResponse.class);
+
+        HttpHeaders httpHeaders = new DefaultHttpHeaders();
+        headers.forEach(httpHeaders::add);
+        when(httpClientResponse.responseHeaders()).thenReturn(httpHeaders);
+        when(httpClientResponse.status()).thenReturn(httpResponseStatus);
+
+        return new HttpClient.SingleWithResponse<>(source, new AtomicReference<>(httpClientResponse));
+    }
+}


### PR DESCRIPTION
Sending the api call through this new fullResponse method will return a wrapped object containing data, status and headers from the response.

Lets say you have a UserResource like this:

```java
interface UserResource {

    Observable<User> getUsers();
}
```

The normal way to use it is 

```java
userResource.getUsers().map(listofusers -> {
    //inspect data
    return listofusers
});

```
With this method you can
```java
HttpClient.fullResponse(userResource.getUsers()).map(responsewithdata -> {
    //inspect headers
    responsewithdata.getHeaders()
    //inspect status
    responsewithstatus.getStatus()
    //inspect data
    responsewithstatus.getData();

    return responsewithdata.getData();
});
```
