### PR TITLE
Redact value of Authorization header from logs

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -75,6 +75,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static reactor.core.Exceptions.isRetryExhausted;
+import static se.fortnox.reactivewizard.jaxrs.RequestLogger.getHeaderValuesOrRedact;
 
 public class HttpClient implements InvocationHandler {
     private static final Logger LOG = LoggerFactory.getLogger(HttpClient.class);
@@ -211,7 +212,7 @@ public class HttpClient implements InvocationHandler {
     }
 
     private <T> Flux<T> convertError(RequestBuilder fullReq, Throwable throwable) {
-        String request = format("%s, headers: %s", fullReq.getFullUrl(), fullReq.getHeaders().entrySet());
+        String request = format("%s, headers: %s", fullReq.getFullUrl(), getHeaderValuesOrRedact(fullReq.getHeaders()));
         LOG.warn("Failed request. Url: {}", request, throwable);
 
         if (isRetryExhausted(throwable)) {
@@ -303,7 +304,7 @@ public class HttpClient implements InvocationHandler {
                 // Log the error on every retry.
                 LOG.info(format("Will retry because an error occurred. %s, headers: %s",
                     fullReq.getFullUrl(),
-                    fullReq.getHeaders().entrySet()), throwable);
+                    getHeaderValuesOrRedact(fullReq.getHeaders())), throwable);
 
                 // Retry if it's 500+ error
                 return true;

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -67,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -612,7 +613,9 @@ public class HttpClientTest {
     public void shouldRedactAuthorizationHeaderInLogs() throws Exception {
         DisposableServer                   server       = startServer(BAD_REQUEST, "someError");
         HttpClientConfig                   config       = new HttpClientConfig("localhost:" + server.port());
-        config.setDevHeaders(Map.of("Authorization", "secretvalue"));
+        Map<String, String>                headers      = new HashMap<>();
+        headers.put("Authorization", "secretvalue");
+        config.setDevHeaders(headers);
         TestResource                       resource     = getHttpProxy(config);
 
         assertThatExceptionOfType(WebException.class)

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -13,7 +13,9 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.apache.log4j.Appender;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
@@ -67,6 +69,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -83,6 +86,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -93,11 +97,23 @@ import static org.mockito.Mockito.when;
 import static reactor.core.publisher.Flux.defer;
 import static reactor.core.publisher.Flux.empty;
 import static reactor.core.publisher.Flux.just;
+import static se.fortnox.reactivewizard.test.LoggingMockUtil.destroyMockedAppender;
 import static se.fortnox.reactivewizard.test.TestUtil.matches;
 
 public class HttpClientTest {
 
     private HealthRecorder healthRecorder = new HealthRecorder();
+    private Appender       mockAppender;
+
+    @Before
+    public void before() throws Exception {
+        mockAppender = LoggingMockUtil.createMockedLogAppender(HttpClient.class);
+    }
+
+    @After
+    public void after() throws Exception{
+        destroyMockedAppender(mockAppender, HttpClient.class);
+    }
 
     @Test
     public void shouldNotRetryFailedPostCalls() {
@@ -571,8 +587,7 @@ public class HttpClientTest {
     }
 
     @Test
-    public void shouldLogErrorOnTooLargeResponse() throws NoSuchFieldException, IllegalAccessException {
-        Appender                           mockAppender = LoggingMockUtil.createMockedLogAppender(HttpClient.class);
+    public void shouldLogErrorOnTooLargeResponse() {
         DisposableServer                   server       = startServer(HttpResponseStatus.OK, generateLargeString(11));
         TestResource                       resource     = getHttpProxy(server.port());
         WebException                       e            = null;
@@ -588,6 +603,25 @@ public class HttpClientTest {
 
         verify(mockAppender).doAppend(matches(log -> {
             assertThat(log.getMessage()).isEqualTo("Failed request. Url: localhost:" + server.port() + "/hello, headers: [Host=localhost]");
+        }));
+
+        server.disposeNow();
+    }
+
+    @Test
+    public void shouldRedactAuthorizationHeaderInLogs() throws Exception {
+        DisposableServer                   server       = startServer(BAD_REQUEST, "someError");
+        HttpClientConfig                   config       = new HttpClientConfig("localhost:" + server.port());
+        config.setDevHeaders(Map.of("Authorization", "secretvalue"));
+        TestResource                       resource     = getHttpProxy(config);
+
+        assertThatExceptionOfType(WebException.class)
+            .isThrownBy(() -> resource.getHello()
+                .toBlocking()
+                .single());
+        verify(mockAppender).doAppend(matches(log -> {
+            assertThat(log.getMessage())
+                .isEqualTo("Failed request. Url: localhost:" + server.port() + "/hello, headers: [Authorization=REDACTED, Host=localhost]");
         }));
 
         server.disposeNow();
@@ -889,6 +923,8 @@ public class HttpClientTest {
     @Test
     public void shouldShouldNotGivePoolExhaustedIfServerDoesNotCloseConnection() throws URISyntaxException {
 
+        Level originalLogLevel = LogManager.getLogger(HttpClient.class)
+            .getLevel();
         LogManager.getLogger(HttpClient.class).setLevel(Level.toLevel(Level.OFF_INT));
 
         DisposableServer server = HttpServer.create().port(0)
@@ -920,6 +956,8 @@ public class HttpClientTest {
         }
 
         server.disposeNow();
+        LogManager.getLogger(HttpClient.class)
+            .setLevel(originalLogLevel);
     }
 
     @Test

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
@@ -22,6 +22,8 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.file.FileSystemException;
 import java.util.List;
 
+import static se.fortnox.reactivewizard.jaxrs.RequestLogger.getHeaderValueOrRedact;
+
 /**
  * Handles exceptions and writes errors to the response and the log.
  */
@@ -109,7 +111,7 @@ public class ExceptionHandler {
             msg
                 .append(header.getKey())
                 .append('=')
-                .append(header.getValue())
+                .append(getHeaderValueOrRedact(header))
                 .append(' ')
         );
         return msg.toString();

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
@@ -56,7 +56,9 @@ public class RequestLogger {
      * @return value of the header or "REDACTED" if the header contains sensitive information
      */
     public static String getHeaderValueOrRedact(Map.Entry<String, String> header) {
-        if ("Authorization".equalsIgnoreCase(header.getKey())) {
+        if(header == null) {
+            return null;
+        } else if ("Authorization".equalsIgnoreCase(header.getKey())) {
             return "REDACTED";
         }
         return header.getValue();
@@ -69,6 +71,9 @@ public class RequestLogger {
      * @return headers with sensitive information redacted
      */
     public static Set<Map.Entry<String, String>> getHeaderValuesOrRedact(Map<String, String> headers) {
+        if(headers == null) {
+            return null;
+        }
         return headers
             .entrySet()
             .stream()

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
@@ -57,7 +57,7 @@ public class RequestLogger {
      * @return value of the header or "REDACTED" if the header contains sensitive information
      */
     public static String getHeaderValueOrRedact(Map.Entry<String, String> header) {
-        if(header == null) {
+        if (header == null) {
             return null;
         } else if ("Authorization".equalsIgnoreCase(header.getKey())) {
             return "REDACTED";
@@ -72,7 +72,7 @@ public class RequestLogger {
      * @return headers with sensitive information redacted
      */
     public static Set<Map.Entry<String, String>> getHeaderValuesOrRedact(Map<String, String> headers) {
-        if(headers == null) {
+        if (headers == null) {
             return Collections.emptySet();
         }
         return headers

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
@@ -5,6 +5,10 @@ import org.slf4j.Logger;
 import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Logs incoming requests to a Logger.
  */
@@ -22,8 +26,11 @@ public class RequestLogger {
      * @param logLine StringBuilder to append the header content to.
      */
     public static void headersToString(HttpServerRequest request, StringBuilder logLine) {
-        request.requestHeaders().forEach(e ->
-            logLine.append(e.getKey()).append('=').append(e.getValue()).append(' ')
+        request.requestHeaders().forEach(header ->
+            logLine.append(header.getKey())
+                .append('=')
+                .append(getHeaderValueOrRedact(header))
+                .append(' ')
         );
     }
 
@@ -35,8 +42,41 @@ public class RequestLogger {
      */
     public static void headersToString(HttpServerResponse response, StringBuilder logLine) {
         response.responseHeaders().forEach(header ->
-            logLine.append(header.getKey()).append('=').append(header.getValue()).append(' ')
+            logLine.append(header.getKey())
+                .append('=')
+                .append(getHeaderValueOrRedact(header))
+                .append(' ')
         );
+    }
+
+    /**
+     * Returns the value of a header. If the header contains sensitive information the value will be replaced with "REDACTED".
+     *
+     * @param header The header to get the value from
+     * @return value of the header or "REDACTED" if the header contains sensitive information
+     */
+    public static String getHeaderValueOrRedact(Map.Entry<String, String> header) {
+        if ("Authorization".equalsIgnoreCase(header.getKey())) {
+            return "REDACTED";
+        }
+        return header.getValue();
+    }
+
+    /**
+     * Redact sensitive information from header values. Any header that contains sensitive information will have the value replaced with "REDACTED"
+     *
+     * @param headers The headers to map
+     * @return headers with sensitive information redacted
+     */
+    public static Set<Map.Entry<String, String>> getHeaderValuesOrRedact(Map<String, String> headers) {
+        return headers
+            .entrySet()
+            .stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                RequestLogger::getHeaderValueOrRedact
+            ))
+            .entrySet();
     }
 
     /**

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -72,7 +73,7 @@ public class RequestLogger {
      */
     public static Set<Map.Entry<String, String>> getHeaderValuesOrRedact(Map<String, String> headers) {
         if(headers == null) {
-            return null;
+            return Collections.emptySet();
         }
         return headers
             .entrySet()

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ExceptionHandlerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ExceptionHandlerTest.java
@@ -46,6 +46,18 @@ public class ExceptionHandlerTest {
     }
 
     @Test
+    public void shouldRedactSensitiveHeaders(){
+        MockHttpServerRequest request = new MockHttpServerRequest("/path");
+        request.requestHeaders()
+            .add("Authorization", "secret")
+            .add("OtherHeader", "notasecret");
+        assertLog(request,
+            new WebException(HttpResponseStatus.BAD_REQUEST),
+            Level.WARN,
+            "400 Bad Request\n\tCause: -\n\tResponse: {\"id\":\"*\",\"error\":\"badrequest\"}\n\tRequest: GET /path headers: Authorization=REDACTED OtherHeader=notasecret ");
+    }
+
+    @Test
     public void shouldLog404AsDebug() {
         MockHttpServerRequest request = new MockHttpServerRequest("/path");
         String expectedLog = "404 Not Found\n" +

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.junit.Test;
 
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,15 +30,15 @@ public class RequestLoggerTest {
 
     @Test
     public void shouldRedactAuthorizationValues() {
-        Map<String,String> headers = Map.of(
-            "Authorization", "secret",
-            "OtherHeader", "notasecret"
-        );
+        Map<String,String> headers = new HashMap<>();
+        headers.put("Authorization", "secret");
+        headers.put("OtherHeader", "notasecret");
+
         Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers);
-        Set<Map.Entry<String, String>> expectedValue = Map.of(
-            "Authorization", "REDACTED",
-            "OtherHeader", "notasecret"
-        ).entrySet();
-        assertTrue(CollectionUtils.isEqualCollection(result, expectedValue));
+
+        Map<String, String> expectedValue = new HashMap<>();
+        expectedValue.put("Authorization", "REDACTED");
+        expectedValue.put("OtherHeader", "notasecret");
+        assertTrue(CollectionUtils.isEqualCollection(result, expectedValue.entrySet()));
     }
 }

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
@@ -1,0 +1,43 @@
+package se.fortnox.reactivewizard.jaxrs;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Test;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RequestLoggerTest {
+
+    @Test
+    public void shouldRedactAuthorizationValue() {
+        Map.Entry<String,String> header = new AbstractMap.SimpleEntry<>("Authorization", "secret");
+
+        String result = RequestLogger.getHeaderValueOrRedact(header);
+        assertEquals(result, "REDACTED");
+    }
+
+    @Test
+    public void shouldNotRedactAuthorizationValue() {
+        Map.Entry<String,String> header = new AbstractMap.SimpleEntry<>("OtherHeader", "notasecret");
+        String result = RequestLogger.getHeaderValueOrRedact(header);
+        assertEquals(result, "notasecret");
+    }
+
+    @Test
+    public void shouldRedactAuthorizationValues() {
+        Map<String,String> headers = Map.of(
+            "Authorization", "secret",
+            "OtherHeader", "notasecret"
+        );
+        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers);
+        Set<Map.Entry<String, String>> expectedValue = Map.of(
+            "Authorization", "REDACTED",
+            "OtherHeader", "notasecret"
+        ).entrySet();
+        assertTrue(CollectionUtils.isEqualCollection(result, expectedValue));
+    }
+}

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class RequestLoggerTest {
@@ -40,5 +41,15 @@ public class RequestLoggerTest {
         expectedValue.put("Authorization", "REDACTED");
         expectedValue.put("OtherHeader", "notasecret");
         assertTrue(CollectionUtils.isEqualCollection(result, expectedValue.entrySet()));
+    }
+
+    @Test
+    public void shouldReturnNull_getHeaderValuesOrRedact() {
+        assertNull(RequestLogger.getHeaderValuesOrRedact(null));
+    }
+
+    @Test
+    public void shouldReturnNull_getHeaderValueOrRedact() {
+        assertNull(RequestLogger.getHeaderValueOrRedact(null));
     }
 }

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.junit.Test;
 
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -45,7 +46,8 @@ public class RequestLoggerTest {
 
     @Test
     public void shouldReturnNull_getHeaderValuesOrRedact() {
-        assertNull(RequestLogger.getHeaderValuesOrRedact(null));
+        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(null);
+        assertTrue(CollectionUtils.isEqualCollection(result, Collections.emptySet()));
     }
 
     @Test


### PR DESCRIPTION
The purpose of this change is to allow us to hide the value of specific headers that contains sensitive information.
Right now, only the Authorization header is redacted.