### PR TITLE
Added a way to wrap an Observable-/SingleWithResponse

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/ObservableWithResponse.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/ObservableWithResponse.java
@@ -24,4 +24,8 @@ class ObservableWithResponse<T> extends Observable<T> {
         }
         return httpClientResponse.get();
     }
+
+    static <T> ObservableWithResponse<T> from(ObservableWithResponse observableWithResponse, Observable<T> inner) {
+        return new ObservableWithResponse<T>(inner, observableWithResponse.httpClientResponse);
+    }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/ObservableWithResponse.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/ObservableWithResponse.java
@@ -25,7 +25,7 @@ class ObservableWithResponse<T> extends Observable<T> {
         return httpClientResponse.get();
     }
 
-    static <T> ObservableWithResponse<T> from(ObservableWithResponse observableWithResponse, Observable<T> inner) {
+    static <T> ObservableWithResponse<T> from(ObservableWithResponse<T> observableWithResponse, Observable<T> inner) {
         return new ObservableWithResponse<T>(inner, observableWithResponse.httpClientResponse);
     }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/SingleWithResponse.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/SingleWithResponse.java
@@ -24,4 +24,8 @@ class SingleWithResponse<T> extends Single<T> {
         }
         return httpClientResponse.get();
     }
+
+    static <T> SingleWithResponse<T> from(SingleWithResponse<T> singleWithResponse, Single<T> inner) {
+        return new SingleWithResponse<T>(inner, singleWithResponse.httpClientResponse);
+    }
 }

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -569,6 +569,29 @@ public class HttpClientTest {
     }
 
     @Test
+    public void shouldWrapAndReturnNewFullResponseObservable() {
+        DisposableServer server = startServer(HttpResponseStatus.OK, "\"OK\"");
+
+        TestResource resource = getHttpProxy(server.port());
+
+        Observable<String> hello = resource.getHello();
+
+        ObservableWithResponse<String> wrappedStringResponse = ObservableWithResponse.from((ObservableWithResponse)hello,
+            hello.doOnError(Throwable::printStackTrace));
+
+        Response<String> stringResponse = HttpClient.getFullResponse(wrappedStringResponse).toBlocking().singleOrDefault(null);
+        assertThat(stringResponse).isNotNull();
+        assertThat(stringResponse.getBody()).isEqualTo("OK");
+        assertThat(stringResponse.getStatus()).isEqualTo(OK);
+
+        //Case sensitive when getting the entire map structure
+        assertThat(stringResponse.getHeaders().get("content-length")).isEqualTo("4");
+
+        //Case insensitive when fetching
+        assertThat(stringResponse.getHeader(CONTENT_LENGTH)).isEqualTo("4");
+    }
+
+    @Test
     public void shouldReturnFullResponseFromSingle() {
         DisposableServer server = startServer(HttpResponseStatus.OK, "\"OK\"");
 
@@ -581,6 +604,30 @@ public class HttpClientTest {
         assertThat(stringResponse.getBody()).isEqualTo("OK");
         assertThat(stringResponse.getStatus()).isEqualTo(OK);
         assertThat(stringResponse.getHeaders().get("content-length")).isEqualTo("4");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldWrapAndReturnNewFullResponseSingle() {
+        DisposableServer server = startServer(HttpResponseStatus.OK, "\"OK\"");
+
+        TestResource resource = getHttpProxy(server.port());
+
+        Single<String> hello = resource.getSingle();
+
+        SingleWithResponse<String> wrappedStringResponse = SingleWithResponse.from((SingleWithResponse)hello,
+            hello.doOnError(Throwable::printStackTrace));
+
+        Response<String> stringResponse = HttpClient.getFullResponse(wrappedStringResponse).toBlocking().value();
+        assertThat(stringResponse).isNotNull();
+        assertThat(stringResponse.getBody()).isEqualTo("OK");
+        assertThat(stringResponse.getStatus()).isEqualTo(OK);
+
+        //Case sensitive when getting the entire map structure
+        assertThat(stringResponse.getHeaders().get("content-length")).isEqualTo("4");
+
+        //Case insensitive when fetching
+        assertThat(stringResponse.getHeader(CONTENT_LENGTH)).isEqualTo("4");
     }
 
 


### PR DESCRIPTION
Our subsystem uses it's own subclass extending HttpClient and makes the original solution not working at all times. We need a way to create new ObservableWithResponses when our internal httpclient applies some some operators on the ObservableWithResponse.

This was a way to make it possible but not too easy so that everyone would use it. 