### PR TITLE
Making the enum deserializer resolve asc to ASC enum.

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/EnumDeserializer.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/EnumDeserializer.java
@@ -3,8 +3,8 @@ package se.fortnox.reactivewizard.jaxrs.params.deserializing;
 /**
  * Deserializes enums.
  */
-public class EnumDeserializer<T extends Enum> implements Deserializer<T> {
-    private final Class<?> paramType;
+public class EnumDeserializer<T extends Enum<T>> implements Deserializer<T> {
+    private final Class<T> paramType;
 
     public EnumDeserializer(Class<T> paramType) {
         this.paramType = paramType;
@@ -16,9 +16,14 @@ public class EnumDeserializer<T extends Enum> implements Deserializer<T> {
             return null;
         }
         try {
-            return (T)Enum.valueOf((Class)paramType, value);
+            return Enum.valueOf(paramType, value);
         } catch (Exception parseException) {
-            throw new DeserializerException("invalid.enum");
+            try {
+                return Enum.valueOf(paramType, value.toUpperCase());
+            } catch (Exception e) {
+                throw new DeserializerException("invalid.enum");
+            }
+
         }
     }
 }

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/EnumDeserializerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/EnumDeserializerTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 public class EnumDeserializerTest {
-    private final static Deserializer<TestEnum> DESERIALIZER = new EnumDeserializer(TestEnum.class);
+    private final static Deserializer<TestEnum> DESERIALIZER = new EnumDeserializer<>(TestEnum.class);
 
     enum TestEnum {
         FIRST, SECOND
@@ -22,6 +22,12 @@ public class EnumDeserializerTest {
     public void shouldDeserializeNull() throws DeserializerException {
         TestEnum deserialized = DESERIALIZER.deserialize(null);
         assertThat(deserialized).isNull();
+    }
+
+    @Test
+    public void shouldBeCaseInsensitive() throws DeserializerException {
+        TestEnum deserialized = DESERIALIZER.deserialize("first");
+        assertThat(deserialized).isEqualTo(TestEnum.FIRST);
     }
 
     @Test


### PR DESCRIPTION
Allowing for a queryparam asc to be resolved to the enum ASC

Trying the exact casing first, and if that fails checking upper case.
Found enums that was not upper cased so I couldn't always make the check uppercase