### PR TITLE
adding support for responses that are empty in combination with getFullResponse

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -54,7 +54,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static reactor.core.Exceptions.isRetryExhausted;
-import static rx.Observable.just;
+import static rx.Observable.fromCallable;
 import static se.fortnox.reactivewizard.jaxrs.RequestLogger.getHeaderValuesOrRedact;
 
 public class HttpClient implements InvocationHandler {
@@ -175,9 +175,7 @@ public class HttpClient implements InvocationHandler {
         }
 
         return source.map(data -> new Response<>(((ObservableWithResponse<T>)source).getResponse(), data))
-            .switchIfEmpty(Observable.defer(() ->
-                just(new Response<>(((ObservableWithResponse<T>)source).getResponse(), null)))
-            );
+            .switchIfEmpty(fromCallable(() -> new Response<>(((ObservableWithResponse<T>)source).getResponse(), null)));
     }
 
     /**

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTestUtil.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTestUtil.java
@@ -3,12 +3,17 @@ package se.fortnox.reactivewizard.client;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
 import org.mockito.Mockito;
 import reactor.netty.http.client.HttpClientResponse;
 import rx.Observable;
 import rx.Single;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.Mockito.when;
@@ -31,6 +36,23 @@ public class HttpClientTestUtil {
         return new ObservableWithResponse<>(source, new AtomicReference<>(httpClientResponse));
     }
 
+    public static <T> Observable<T> mockResponseWithHeadersAndCookies(Observable<T> source, Map<String, String> headers, Map<String, String> cookies, HttpResponseStatus httpResponseStatus) {
+        HttpClientResponse httpClientResponse = Mockito.mock(HttpClientResponse.class);
+
+        Map<CharSequence, Set<Cookie>> cookieMap = new HashMap<>();
+        cookies.forEach((key, value) -> {
+            cookieMap.put(key, Collections.singleton(new DefaultCookie(key, value)));
+        });
+        HttpHeaders httpHeaders = new DefaultHttpHeaders();
+        headers.forEach(httpHeaders::add);
+        when(httpClientResponse.responseHeaders()).thenReturn(httpHeaders);
+        when(httpClientResponse.cookies()).thenReturn(cookieMap);
+        when(httpClientResponse.status()).thenReturn(httpResponseStatus);
+
+
+        return new ObservableWithResponse<>(source, new AtomicReference<>(httpClientResponse));
+    }
+
     public static <T> Single<T> mockResponseWithHeaders(Single<T> source, Map<String, String> headers, HttpResponseStatus httpResponseStatus) {
         HttpClientResponse httpClientResponse = Mockito.mock(HttpClientResponse.class);
 
@@ -38,6 +60,23 @@ public class HttpClientTestUtil {
         headers.forEach(httpHeaders::add);
         when(httpClientResponse.responseHeaders()).thenReturn(httpHeaders);
         when(httpClientResponse.status()).thenReturn(httpResponseStatus);
+
+        return new SingleWithResponse<>(source, new AtomicReference<>(httpClientResponse));
+    }
+
+    public static <T> Single<T> mockResponseWithHeadersAndCookies(Single<T> source, Map<String, String> headers, Map<String, String> cookies, HttpResponseStatus httpResponseStatus) {
+        HttpClientResponse httpClientResponse = Mockito.mock(HttpClientResponse.class);
+
+        Map<CharSequence, Set<Cookie>> cookieMap = new HashMap<>();
+        cookies.forEach((key, value) -> {
+            cookieMap.put(key, Collections.singleton(new DefaultCookie(key, value)));
+        });
+        HttpHeaders httpHeaders = new DefaultHttpHeaders();
+        headers.forEach(httpHeaders::add);
+        when(httpClientResponse.responseHeaders()).thenReturn(httpHeaders);
+        when(httpClientResponse.cookies()).thenReturn(cookieMap);
+        when(httpClientResponse.status()).thenReturn(httpResponseStatus);
+
 
         return new SingleWithResponse<>(source, new AtomicReference<>(httpClientResponse));
     }


### PR DESCRIPTION
When receiving an empty response we didn't get the meta data either.
This should solve that