### PR TITLE
Getting all fields from ancestors as well when serializing beanparam annotate…

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -578,7 +578,7 @@ public class HttpClient implements InvocationHandler {
 
     private List<BeanParamProperty> getBeanParamGetters(Class beanParamType) {
         List<BeanParamProperty> result = new ArrayList<>();
-        for (Field field : beanParamType.getDeclaredFields()) {
+        for (Field field : getDeclaredFieldsFromClassAndAncestors(beanParamType, new ArrayList<>())) {
             Optional<Function<Object, Object>> getter = ReflectionUtil.getter(beanParamType, field.getName());
             if (getter.isPresent()) {
                 result.add(new BeanParamProperty(
@@ -588,6 +588,24 @@ public class HttpClient implements InvocationHandler {
             }
         }
         return result;
+    }
+
+    /**
+     * Recursive function getting all declared fields from the passed in class and its ancestors
+     *
+     * @param clazz the clazz
+     * @param fields the fields found so far.
+     *
+     * @return list of fields
+     */
+    private List<Field> getDeclaredFieldsFromClassAndAncestors(Class clazz, List<Field> fields) {
+        fields.addAll(asList(clazz.getDeclaredFields()));
+
+        if (clazz.getSuperclass() != null && !Object.class.equals(clazz.getSuperclass())) {
+            return getDeclaredFieldsFromClassAndAncestors(clazz.getSuperclass(), fields);
+        }
+
+        return fields;
     }
 
     protected String serialize(Object value) {

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -540,7 +540,7 @@ public class HttpClientTest {
         filters.setLimit(10);
         filters.setOffset(15);
         String     path   = client.getPath(method, new Object[]{filters}, new JaxRsMeta(method, null));
-        assertThat(path).isEqualTo("/hello/beanParam?filter1=a&filter2=b&limit=10&offset=15");
+        assertThat(path).isEqualTo("/hello/beanParam?limit=10&offset=15&filter2=b&filter1=a");
     }
 
     @Test


### PR DESCRIPTION
When calling other services with @Bean param annotaded parameters the http client would not serialize fields from superclasses. 
This pr will traverse the class hieararchy and and add all declared fields that should be used to the path