### PR TITLE
Added possibility to enable gzip for certain mime-types.

### DIFF
--- a/server/src/main/java/se/fortnox/reactivewizard/server/RwServer.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/RwServer.java
@@ -31,7 +31,7 @@ import static reactor.netty.channel.BootstrapHandlers.updateConfiguration;
 public class RwServer extends Thread {
 
     private static final Logger            LOG                         = LoggerFactory.getLogger(RwServer.class);
-    private static final Set<String>       COMPRESS_CONTENT_TYPES      = new HashSet<>(asList("text/plain", "application/xml", "text/css application/x-javascript", "application/json"));
+    private static final Set<String>       COMPRESS_CONTENT_TYPES      = new HashSet<>(asList("text/plain", "application/xml", "text/css", "application/x-javascript", "application/json"));
     private static final int               COMPRESSION_THRESHOLD_BYTES = 1000;
     private final        ServerConfig      config;
     private final        ConnectionCounter connectionCounter;

--- a/server/src/main/java/se/fortnox/reactivewizard/server/ServerConfig.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/ServerConfig.java
@@ -13,6 +13,7 @@ public class ServerConfig {
     private int     maxInitialLineLengthDefault = 4096;
     private int     maxRequestSize              = 10 * 1024 * 1024;
     private int     shutdownTimeoutSeconds      = 20;
+    private boolean enableGzip                  = false;
 
     public int getPort() {
         return port;
@@ -60,5 +61,13 @@ public class ServerConfig {
 
     public void setShutdownTimeoutMs(int shutdownTimeoutSeconds) {
         this.shutdownTimeoutSeconds = shutdownTimeoutSeconds;
+    }
+
+    public boolean isEnableGzip() {
+        return enableGzip;
+    }
+
+    public void setEnableGzip(boolean enableGzip) {
+        this.enableGzip = enableGzip;
     }
 }

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
@@ -29,6 +29,12 @@ public class RwServerGzipTest {
     }
 
     @Test
+    public void shouldCompressWhenMultipleDirectivesAreCombined() {
+        Arrays.asList("text/plain; boundary=something", "text/plain; charset=UTF-8")
+            .forEach(allowedContentType -> assertCompressionForContentType(true, allowedContentType, true));
+    }
+
+    @Test
     public void shouldNotCompressAllowedContentTypeWhenGzipIsDisabled() {
         Arrays.asList("text/plain", "application/xml", "text/css", "application/x-javascript", "application/json")
             .forEach(allowedContentType -> assertCompressionForContentType(false, allowedContentType, false));
@@ -50,8 +56,8 @@ public class RwServerGzipTest {
     }
 
     @Test
-    public void shouldCompressIfMissingContentLength() {
-        assertCompressionForContentType(true, "text/plain", 5, true, true);
+    public void shouldNotCompressIfMissingContentLength() {
+        assertCompressionForContentType(true, "text/plain", 5, true, false);
     }
 
     private RwServer server(RequestHandler handler, boolean compress) {

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
@@ -24,13 +24,13 @@ public class RwServerGzipTest {
 
     @Test
     public void shouldCompressAllowedContentTypes() {
-        Arrays.asList("text/plain", "application/xml", "text/css application/x-javascript", "application/json")
+        Arrays.asList("text/plain", "application/xml", "text/css", "application/x-javascript", "application/json")
             .forEach(allowedContentType -> assertCompressionForContentType(true, allowedContentType, true));
     }
 
     @Test
     public void shouldNotCompressAllowedContentTypeWhenGzipIsDisabled() {
-        Arrays.asList("text/plain", "application/xml", "text/css application/x-javascript", "application/json")
+        Arrays.asList("text/plain", "application/xml", "text/css", "application/x-javascript", "application/json")
             .forEach(allowedContentType -> assertCompressionForContentType(false, allowedContentType, false));
     }
 

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
@@ -1,0 +1,126 @@
+package se.fortnox.reactivewizard.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import se.fortnox.reactivewizard.ExceptionHandler;
+import se.fortnox.reactivewizard.RequestHandler;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RwServerGzipTest {
+    private RwServer rwServer;
+
+    @Test
+    public void shouldCompressAllowedContentTypes() {
+        Arrays.asList("text/plain", "application/xml", "text/css application/x-javascript", "application/json")
+            .forEach(allowedContentType -> assertCompressionForContentType(true, allowedContentType, true));
+    }
+
+    @Test
+    public void shouldNotCompressAllowedContentTypeWhenGzipIsDisabled() {
+        Arrays.asList("text/plain", "application/xml", "text/css application/x-javascript", "application/json")
+            .forEach(allowedContentType -> assertCompressionForContentType(false, allowedContentType, false));
+    }
+
+    @Test
+    public void shouldNotCompressNonAllowedContentTypes() {
+        assertCompressionForContentType(true, "application/pdf", false);
+    }
+
+    @Test
+    public void shouldNotCompressWhenMissingContentType() {
+        assertCompressionForContentType(true, null, false);
+    }
+
+    @Test
+    public void shouldNotCompressSmallPayload() {
+        assertCompressionForContentType(true, "text/plain", 5, false);
+    }
+
+    @Test
+    public void shouldCompressIfMissingContentLength() {
+        assertCompressionForContentType(true, "text/plain", 5, true, true);
+    }
+
+    private RwServer server(RequestHandler handler, boolean compress) {
+        ServerConfig config = new ServerConfig();
+        config.setPort(0);
+        config.setEnableGzip(compress);
+        ConnectionCounter       connectionCounter = new ConnectionCounter();
+        CompositeRequestHandler handlers          = new CompositeRequestHandler(Collections.singleton(handler), new ExceptionHandler(new ObjectMapper()), connectionCounter);
+        return new RwServer(config, handlers, connectionCounter);
+    }
+
+    private void assertCompressionForContentType(boolean serverUsesCompression, String contentType, boolean compressionExpected) {
+        assertCompressionForContentType(serverUsesCompression, contentType, 1024, false, compressionExpected);
+    }
+
+    private void assertCompressionForContentType(boolean serverUsesCompression, String contentType, Integer contentLength, boolean compressionExpected) {
+        assertCompressionForContentType(serverUsesCompression, contentType, contentLength, false, compressionExpected);
+    }
+
+    private void assertCompressionForContentType(boolean serverUsesCompression,
+        String contentType,
+        Integer contentLength,
+        boolean chunked,
+        boolean compressionExpected
+    ) {
+        try {
+            final String randomContent = randomAlphabetic(contentLength);
+            rwServer = server((httpServerRequest, httpServerResponse) -> {
+                if (contentType != null) {
+                    httpServerResponse = httpServerResponse
+                        .addHeader(CONTENT_TYPE, contentType);
+                }
+                if (!chunked) {
+                    httpServerResponse = httpServerResponse
+                        .addHeader(CONTENT_LENGTH, String.valueOf(contentLength));
+                }
+                return httpServerResponse
+                    .chunkedTransfer(chunked)
+                    .sendByteArray(Mono.just(randomContent.getBytes(UTF_8)));
+            }, serverUsesCompression);
+
+            HttpClient.ResponseReceiver<?> responseReceiver = HttpClient.create()
+                .baseUrl("http://localhost:" + rwServer.getServer().port())
+                .headers(headers -> headers.add("Accept-encoding", "gzip"))
+                .get();
+
+            String responseContent = responseReceiver.responseContent()
+                .aggregate()
+                .asString()
+                .block();
+            String actualContentType = responseReceiver.response()
+                .block()
+                .responseHeaders()
+                .get(CONTENT_TYPE);
+
+            assertThat(actualContentType)
+                .isEqualTo(contentType);
+            if (compressionExpected) {
+                assertThat(responseContent)
+                    .describedAs("Expected compressed content not to be equal to raw content for content type %s", contentType)
+                    .isNotEqualTo(randomContent);
+            } else {
+                assertThat(responseContent)
+                    .describedAs("Expected content to be equal to raw content for content type %s", contentType)
+                    .isEqualTo(randomContent);
+            }
+        } finally {
+            rwServer.getServer()
+                .disposeNow();
+        }
+    }
+}

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
@@ -30,7 +30,7 @@ public class RwServerGzipTest {
 
     @Test
     public void shouldCompressWhenMultipleDirectivesAreCombined() {
-        Arrays.asList("text/plain; boundary=something", "text/plain; charset=UTF-8")
+        Arrays.asList("text/plain; boundary=something", "text/plain; charset=UTF-8","text/plain; charset=UTF-8; boundary=something")
             .forEach(allowedContentType -> assertCompressionForContentType(true, allowedContentType, true));
     }
 


### PR DESCRIPTION
Gzip will be enabled if we set enableGzip = true in ServerConfig.
Compression will only be enabled for the following mime-types.

- text/plain
- application/xml
- text/css 
- application/x-javascript
- application/json

We will compress response payloads exceeding 1000 bytes. Chunked responses are not compressed.

Resources with stream annotation will not be compressed ( and should not be ).