### PR TITLE
Rassmate patch 2

### DIFF
--- a/.github/workflows/on_release_publish_to_maven.yml
+++ b/.github/workflows/on_release_publish_to_maven.yml
@@ -15,16 +15,15 @@ jobs:
         with:
           java-version: 1.8
           server-id: ossrh
-          server-username: OSSRH_USER_NAME
-          server-password: OSSRH_SERVER_PASSWORD
-          gpg-private-key: GPG_KEY
+          server-username: USER_NAME
+          server-password: PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASS
       - name: set version
         run: mvn versions:set -DnewVersion=${GITHUB_REF##*/}
       - name: Publish to the Maven Central Repository
         run: mvn clean deploy -Prelease
-        env:
-          OSSRH_USER_NAME:  ${{ secrets.OSSRH_USER_NAME }}
-          OSSRH_PASSWORD:  ${{ secrets.OSSRH_TOKEN }}
-          GPG_KEY:  ${{ secrets.GPG_PRIVATE_KEY }}
+        env: 
+          USER_NAME: ${{ secrets.OSSRH_USERNAME }}
+          PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           GPG_PASS:  ${{ secrets.PASSPHRASE }}

--- a/.github/workflows/on_release_publish_to_maven.yml
+++ b/.github/workflows/on_release_publish_to_maven.yml
@@ -15,11 +15,16 @@ jobs:
         with:
           java-version: 1.8
           server-id: ossrh
-          server-username: 0idY5C00
-          server-password: ${{ secrets.OSSRH_TOKEN }}
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.PASSPHRASE }}
+          server-username: OSSRH_USER_NAME
+          server-password: OSSRH_SERVER_PASSWORD
+          gpg-private-key: GPG_KEY
+          gpg-passphrase: GPG_PASS
       - name: set version
         run: mvn versions:set -DnewVersion=${GITHUB_REF##*/}
       - name: Publish to the Maven Central Repository
         run: mvn clean deploy -Prelease
+        env:
+          OSSRH_USER_NAME:  ${{ secrets.OSSRH_USER_NAME }}
+          OSSRH_PASSWORD:  ${{ secrets.OSSRH_TOKEN }}
+          GPG_KEY:  ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASS:  ${{ secrets.PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,13 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>1.6</version>
+                        <configuration>
+							<!-- Prevent gpg from using pinentry programs -->
+							<gpgArguments>
+								<arg>--pinentry-mode</arg>
+								<arg>loopback</arg>
+							</gpgArguments>
+						</configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
The gpg-private-key must be passed in directly.
The other params must be env:s 

And we have to prevent the gpg plugin from using pinentry programs

Tried this solution on another repo of mine and it fails (as expected) at the very last step of the deploying to nexus since my artifact is bogus. But runs without previous errors until then