### PR TITLE
Mark headers as sensitive on resources for outgoing calls

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -140,7 +140,7 @@ public class HttpClient implements InvocationHandler {
         if (Proxy.isProxyClass(proxy.getClass())) {
             Object handler = Proxy.getInvocationHandler(proxy);
             if (handler instanceof HttpClient) {
-                ((HttpClient) handler).setSensitiveHeaders(headers);
+                ((HttpClient)handler).setSensitiveHeaders(headers);
             }
         }
     }
@@ -157,7 +157,7 @@ public class HttpClient implements InvocationHandler {
 
     @SuppressWarnings("unchecked")
     public <T> T create(Class<T> jaxRsInterface) {
-        return (T) Proxy.newProxyInstance(jaxRsInterface.getClassLoader(), new Class[]{jaxRsInterface}, this);
+        return (T)Proxy.newProxyInstance(jaxRsInterface.getClassLoader(), new Class[]{jaxRsInterface}, this);
     }
 
     @Override
@@ -175,7 +175,7 @@ public class HttpClient implements InvocationHandler {
 
         Mono<RwHttpClientResponse> response = request.submit(rxClient, request);
 
-        Publisher<?>                        publisher   = null;
+        Publisher<?> publisher = null;
         AtomicReference<HttpClientResponse> rawResponse = new AtomicReference<>();
         if (expectsByteArrayResponse(method)) {
             publisher = response.flatMap(rwHttpClientResponse -> {
@@ -196,7 +196,7 @@ public class HttpClient implements InvocationHandler {
 
         //End of publisher
         Flux<?> flux = Flux.from(publisher);
-        flux      = flux.timeout(Duration.of(timeout, timeoutUnit));
+        flux = flux.timeout(Duration.of(timeout, timeoutUnit));
         publisher = withRetry(request, flux).onErrorResume(e -> convertError(request, e));
 
         if (Single.class.isAssignableFrom(method.getReturnType())) {
@@ -219,7 +219,7 @@ public class HttpClient implements InvocationHandler {
         }
 
         return source.map(data -> new Response<>(((ObservableWithResponse<T>) source).getResponse(), data))
-            .switchIfEmpty(fromCallable(() -> new Response<>(((ObservableWithResponse<T>) source).getResponse(), null)));
+            .switchIfEmpty(fromCallable(() -> new Response<>(((ObservableWithResponse<T>)source).getResponse(), null)));
     }
 
     /**
@@ -235,7 +235,7 @@ public class HttpClient implements InvocationHandler {
         }
 
         return source
-            .map(data -> new Response<>(((SingleWithResponse<T>) source).getResponse(), data));
+            .map(data -> new Response<>(((SingleWithResponse<T>)source).getResponse(), data));
     }
 
     private <T> Flux<T> convertError(RequestBuilder fullReq, Throwable throwable) {
@@ -366,10 +366,10 @@ public class HttpClient implements InvocationHandler {
                         requestBuilder.setContent(objectMapper.writeValueAsBytes(value));
                     } else {
                         if (value instanceof String) {
-                            requestBuilder.setContent((String) value);
+                            requestBuilder.setContent((String)value);
                             return;
                         } else if (value instanceof byte[]) {
-                            requestBuilder.setContent((byte[]) value);
+                            requestBuilder.setContent((byte[])value);
                             return;
                         }
                         throw new IllegalArgumentException("When content type is not " + MediaType.APPLICATION_JSON
@@ -396,7 +396,7 @@ public class HttpClient implements InvocationHandler {
     private FormParam getFormParam(Annotation[] annotations) {
         for (Annotation annotation : annotations) {
             if (annotation instanceof FormParam) {
-                return (FormParam) annotation;
+                return (FormParam)annotation;
             }
         }
         return null;
@@ -499,10 +499,10 @@ public class HttpClient implements InvocationHandler {
             }
             for (Annotation annotation : annotations[i]) {
                 if (annotation instanceof HeaderParam) {
-                    request.addHeader(((HeaderParam) annotation).value(), serialize(value));
+                    request.addHeader(((HeaderParam)annotation).value(), serialize(value));
                 } else if (annotation instanceof CookieParam) {
                     final String currentCookieValue = request.getHeaders().get(COOKIE);
-                    final String cookiePart         = ((CookieParam) annotation).value() + "=" + serialize(value);
+                    final String cookiePart         = ((CookieParam)annotation).value() + "=" + serialize(value);
                     if (currentCookieValue != null) {
                         request.addHeader(COOKIE, format("%s; %s", currentCookieValue, cookiePart));
                     } else {
@@ -631,14 +631,14 @@ public class HttpClient implements InvocationHandler {
 
     protected String serialize(Object value) {
         if (value instanceof Date) {
-            return String.valueOf(((Date) value).getTime());
+            return String.valueOf(((Date)value).getTime());
         }
         if (value.getClass().isArray()) {
-            value = asList((Object[]) value);
+            value = asList((Object[])value);
         }
         if (value instanceof List) {
             StringBuilder stringBuilder = new StringBuilder();
-            List          list          = (List) value;
+            List          list          = (List)value;
             for (int i = 0; i < list.size(); i++) {
                 Object entryValue = list.get(i);
                 stringBuilder.append(entryValue);

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -572,14 +572,14 @@ public class HttpClient implements InvocationHandler {
                     } else {
                         query.append('&');
                     }
-                    query.append(((QueryParam) annotation).value());
+                    query.append(((QueryParam)annotation).value());
                     query.append('=');
                     query.append(urlEncode(serialize(value)));
                 } else if (annotation instanceof PathParam) {
-                    if (path.contains("{" + ((PathParam) annotation).value() + ":.*}")) {
-                        path = path.replaceAll("\\{" + ((PathParam) annotation).value() + ":.*\\}", this.encode(this.serialize(value)));
+                    if (path.contains("{" + ((PathParam)annotation).value() + ":.*}")) {
+                        path = path.replaceAll("\\{" + ((PathParam)annotation).value() + ":.*\\}", this.encode(this.serialize(value)));
                     } else {
-                        path = path.replaceAll("\\{" + ((PathParam) annotation).value() + "\\}", this.urlEncode(this.serialize(value)));
+                        path = path.replaceAll("\\{" + ((PathParam)annotation).value() + "\\}", this.urlEncode(this.serialize(value)));
                     }
                 } else if (annotation instanceof BeanParam) {
                     if (value == null) {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -127,7 +127,7 @@ public class HttpClient implements InvocationHandler {
     }
 
     public static void setTimeout(Object proxy, int timeout, ChronoUnit timeoutUnit) {
-       ifHttpClientDo(proxy, handler -> handler.setTimeout(timeout, timeoutUnit));
+       ifHttpClientDo(proxy, httpClient -> httpClient.setTimeout(timeout, timeoutUnit));
     }
 
     public static void markHeaderAsSensitive(Object proxy, String header) {
@@ -135,7 +135,7 @@ public class HttpClient implements InvocationHandler {
     }
 
     public static void markHeadersAsSensitive(Object proxy, Set<String> headers) {
-        ifHttpClientDo(proxy, handler -> handler.setSensitiveHeaders(headers));
+        ifHttpClientDo(proxy, httpClient -> httpClient.setSensitiveHeaders(headers));
     }
 
     private static void ifHttpClientDo(Object proxy, Consumer<HttpClient> consumer) {

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -39,6 +39,7 @@ import se.fortnox.reactivewizard.metrics.HealthRecorder;
 import se.fortnox.reactivewizard.server.ServerConfig;
 import se.fortnox.reactivewizard.test.LoggingMockUtil;
 import se.fortnox.reactivewizard.test.TestUtil;
+import se.fortnox.reactivewizard.test.observable.ObservableAssertions;
 import se.fortnox.reactivewizard.util.rx.RetryWithDelay;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -722,16 +723,15 @@ public class HttpClientTest {
         DisposableServer                   server       = startServer(BAD_REQUEST, "someError");
         HttpClientConfig                   config       = new HttpClientConfig("localhost:" + server.port());
         Map<String, String>                headers      = new HashMap<>();
+
         headers.put("Cookie", "pepperidge farm");
         config.setDevHeaders(headers);
         TestResource                       resource     = getHttpProxy(config);
 
         HttpClient.markHeaderAsSensitive(resource, "cookie");
 
-        assertThatExceptionOfType(WebException.class)
-            .isThrownBy(() -> resource.getHello()
-                .toBlocking()
-                .single());
+        ObservableAssertions.assertThatExceptionOfType(WebException.class)
+            .isEmittedBy(resource.getHello().single());
 
         verify(mockAppender).doAppend(matches(log -> {
             assertThat(log.getThrowableInformation().getThrowableStrRep())

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
@@ -28,9 +28,9 @@ import static se.fortnox.reactivewizard.jaxrs.RequestLogger.getHeaderValueOrReda
  * Handles exceptions and writes errors to the response and the log.
  */
 public class ExceptionHandler {
-    private static Logger LOG = LoggerFactory.getLogger(ExceptionHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ExceptionHandler.class);
 
-    private ObjectMapper mapper;
+    private final ObjectMapper mapper;
 
     @Inject
     public ExceptionHandler(ObjectMapper mapper) {
@@ -68,7 +68,7 @@ public class ExceptionHandler {
         } else if (throwable instanceof WebException) {
             webException = (WebException)throwable;
         } else if (throwable instanceof ClosedChannelException) {
-            LOG.debug("ClosedChannelException: " + request.method() + " " + request.uri(), throwable);
+            LOG.debug("ClosedChannelException: {} {}", request.method(), request.uri(), throwable);
             return Flux.empty();
         } else {
             webException = new WebException(HttpResponseStatus.INTERNAL_SERVER_ERROR, throwable);
@@ -90,7 +90,7 @@ public class ExceptionHandler {
         try {
             return mapper.writeValueAsString(webException);
         } catch (JsonProcessingException e) {
-            LOG.error("Error writing json for exception " + webException, e);
+            LOG.error("Error writing json for exception {}", webException, e);
             return null;
         }
     }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
+
 /**
  * Logs incoming requests to a Logger.
  */
@@ -61,18 +63,14 @@ public class RequestLogger {
      * @return value of the header or "REDACTED" if the header contains sensitive information
      */
     public static String getHeaderValueOrRedact(Map.Entry<String, String> header) {
-        if (header == null) {
-            return null;
-        } else if (AUTHORIZATION_HEADER.equalsIgnoreCase(header.getKey())) {
-            return REDACTED;
-        }
-        return header.getValue();
+        return getHeaderValueOrRedact(header, emptyList());
     }
 
     /**
      * Returns the value of a header. If the header contains sensitive information the value will be replaced with "REDACTED".
      *
-     * @param header The header to get the value from
+     * @param header           The header to get the value from
+     * @param sensitiveHeaders Sensitive headers to redact
      * @return value of the header or "REDACTED" if the header contains sensitive information
      */
     public static String getHeaderValueOrRedact(Map.Entry<String, String> header, List<String> sensitiveHeaders) {
@@ -90,6 +88,17 @@ public class RequestLogger {
      * Redact sensitive information from header values. Any header that contains sensitive information will have the value replaced with "REDACTED"
      *
      * @param headers The headers to map
+     * @return headers with sensitive information redacted
+     */
+    public static Set<Map.Entry<String, String>> getHeaderValuesOrRedact(Map<String, String> headers) {
+        return getHeaderValuesOrRedact(headers, emptyList());
+    }
+
+    /**
+     * Redact sensitive information from header values. Any header that contains sensitive information will have the value replaced with "REDACTED"
+     *
+     * @param headers          The headers to map
+     * @param sensitiveHeaders Sensitive headers that should be redacted from logging
      * @return headers with sensitive information redacted
      */
     public static Set<Map.Entry<String, String>> getHeaderValuesOrRedact(Map<String, String> headers, List<String> sensitiveHeaders) {

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/RequestLogger.java
@@ -6,12 +6,11 @@ import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 
 /**
  * Logs incoming requests to a Logger.
@@ -63,7 +62,7 @@ public class RequestLogger {
      * @return value of the header or "REDACTED" if the header contains sensitive information
      */
     public static String getHeaderValueOrRedact(Map.Entry<String, String> header) {
-        return getHeaderValueOrRedact(header, emptyList());
+        return getHeaderValueOrRedact(header, emptySet());
     }
 
     /**
@@ -73,12 +72,12 @@ public class RequestLogger {
      * @param sensitiveHeaders Sensitive headers to redact
      * @return value of the header or "REDACTED" if the header contains sensitive information
      */
-    public static String getHeaderValueOrRedact(Map.Entry<String, String> header, List<String> sensitiveHeaders) {
+    public static String getHeaderValueOrRedact(Map.Entry<String, String> header, Set<String> sensitiveHeaders) {
         if (header == null) {
             return null;
         } else if (AUTHORIZATION_HEADER.equalsIgnoreCase(header.getKey())) {
             return REDACTED;
-        } else if (sensitiveHeaders.stream().anyMatch(header.getKey()::equalsIgnoreCase)) {
+        } else if (sensitiveHeaders.contains(header.getKey())) {
             return REDACTED;
         }
         return header.getValue();
@@ -91,7 +90,7 @@ public class RequestLogger {
      * @return headers with sensitive information redacted
      */
     public static Set<Map.Entry<String, String>> getHeaderValuesOrRedact(Map<String, String> headers) {
-        return getHeaderValuesOrRedact(headers, emptyList());
+        return getHeaderValuesOrRedact(headers, emptySet());
     }
 
     /**
@@ -101,7 +100,7 @@ public class RequestLogger {
      * @param sensitiveHeaders Sensitive headers that should be redacted from logging
      * @return headers with sensitive information redacted
      */
-    public static Set<Map.Entry<String, String>> getHeaderValuesOrRedact(Map<String, String> headers, List<String> sensitiveHeaders) {
+    public static Set<Map.Entry<String, String>> getHeaderValuesOrRedact(Map<String, String> headers, Set<String> sensitiveHeaders) {
         if (headers == null) {
             return Collections.emptySet();
         }

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
@@ -38,7 +38,7 @@ public class RequestLoggerTest {
         headers.put("Authorization", "secret");
         headers.put("OtherHeader", "notasecret");
 
-        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers, emptyList());
+        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers);
 
         Map<String, String> expectedValue = new HashMap<>();
         expectedValue.put("Authorization", "REDACTED");
@@ -62,7 +62,7 @@ public class RequestLoggerTest {
 
     @Test
     public void shouldReturnNull_getHeaderValuesOrRedact() {
-        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(null, emptyList());
+        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(null);
         assertTrue(CollectionUtils.isEqualCollection(result, Collections.emptySet()));
     }
 

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
@@ -9,6 +9,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -20,14 +22,14 @@ public class RequestLoggerTest {
         Map.Entry<String,String> header = new AbstractMap.SimpleEntry<>("Authorization", "secret");
 
         String result = RequestLogger.getHeaderValueOrRedact(header);
-        assertEquals(result, "REDACTED");
+        assertEquals("REDACTED", result);
     }
 
     @Test
     public void shouldNotRedactAuthorizationValue() {
         Map.Entry<String,String> header = new AbstractMap.SimpleEntry<>("OtherHeader", "notasecret");
         String result = RequestLogger.getHeaderValueOrRedact(header);
-        assertEquals(result, "notasecret");
+        assertEquals("notasecret", result);
     }
 
     @Test
@@ -36,7 +38,7 @@ public class RequestLoggerTest {
         headers.put("Authorization", "secret");
         headers.put("OtherHeader", "notasecret");
 
-        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers);
+        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers, emptyList());
 
         Map<String, String> expectedValue = new HashMap<>();
         expectedValue.put("Authorization", "REDACTED");
@@ -45,8 +47,22 @@ public class RequestLoggerTest {
     }
 
     @Test
+    public void shouldRedactSuppliedSensitiveHeader() {
+        Map<String,String> headers = new HashMap<>();
+        headers.put("OtherHeader", "notasecret");
+        headers.put("Cookie", "oreo");
+
+        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers, singletonList("cookie"));
+
+        Map<String, String> expectedValue = new HashMap<>();
+        expectedValue.put("Cookie", "REDACTED");
+        expectedValue.put("OtherHeader", "notasecret");
+        assertTrue(CollectionUtils.isEqualCollection(result, expectedValue.entrySet()));
+    }
+
+    @Test
     public void shouldReturnNull_getHeaderValuesOrRedact() {
-        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(null);
+        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(null, emptyList());
         assertTrue(CollectionUtils.isEqualCollection(result, Collections.emptySet()));
     }
 

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
@@ -9,8 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -52,7 +51,7 @@ public class RequestLoggerTest {
         headers.put("OtherHeader", "notasecret");
         headers.put("Cookie", "oreo");
 
-        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers, singletonList("cookie"));
+        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers, singleton("cookie"));
 
         Map<String, String> expectedValue = new HashMap<>();
         expectedValue.put("Cookie", "REDACTED");


### PR DESCRIPTION
This change allows you to mark specified headers as sensitive on resources for outgoing calls, redacting the header values from logging.

Example: `HttpClient.markHeaderAsSensitive(someResource, "cookie")`