### PR TITLE
Fix failing test-case in RequestLoggerTest

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -127,7 +127,12 @@ public class HttpClient implements InvocationHandler {
     }
 
     public static void setTimeout(Object proxy, int timeout, ChronoUnit timeoutUnit) {
-       ifHttpClientDo(proxy, httpClient -> httpClient.setTimeout(timeout, timeoutUnit));
+        ifHttpClientDo(proxy, httpClient -> httpClient.setTimeout(timeout, timeoutUnit));
+    }
+
+    public void setTimeout(int timeout, ChronoUnit timeoutUnit) {
+        this.timeout     = timeout;
+        this.timeoutUnit = timeoutUnit;
     }
 
     public static void markHeaderAsSensitive(Object proxy, String header) {
@@ -145,12 +150,6 @@ public class HttpClient implements InvocationHandler {
                 consumer.accept((HttpClient) handler);
             }
         }
-    }
-
-
-    public void setTimeout(int timeout, ChronoUnit timeoutUnit) {
-        this.timeout     = timeout;
-        this.timeoutUnit = timeoutUnit;
     }
 
     public void setSensitiveHeaders(Set<String> headers) {

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -100,7 +100,7 @@ public class HttpClient implements InvocationHandler {
     private final   Map<Method, JaxRsMeta>                            jaxRsMetaMap     = new ConcurrentHashMap<>();
     private         int                                               timeout          = 10;
     private         TemporalUnit                                      timeoutUnit      = ChronoUnit.SECONDS;
-    private         Set<String>                                       sensitiveHeaders = new TreeSet<>(Comparator.comparing(String::toLowerCase));
+    private final   Set<String>                                       sensitiveHeaders = new TreeSet<>(Comparator.comparing(String::toLowerCase));
     private final   Duration                                          retryDuration;
 
     @Inject
@@ -140,7 +140,7 @@ public class HttpClient implements InvocationHandler {
     }
 
     public static void markHeadersAsSensitive(Object proxy, Set<String> headers) {
-        ifHttpClientDo(proxy, httpClient -> httpClient.setSensitiveHeaders(headers));
+        ifHttpClientDo(proxy, httpClient -> httpClient.addSensitiveHeaders(headers));
     }
 
     private static void ifHttpClientDo(Object proxy, Consumer<HttpClient> consumer) {
@@ -152,8 +152,8 @@ public class HttpClient implements InvocationHandler {
         }
     }
 
-    public void setSensitiveHeaders(Set<String> headers) {
-        this.sensitiveHeaders = headers;
+    public void addSensitiveHeaders(Set<String> headers) {
+        this.sensitiveHeaders.addAll(headers);
     }
 
     @SuppressWarnings("unchecked")

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/RequestLoggerTest.java
@@ -5,9 +5,11 @@ import org.junit.Test;
 
 import java.util.AbstractMap;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
@@ -51,7 +53,10 @@ public class RequestLoggerTest {
         headers.put("OtherHeader", "notasecret");
         headers.put("Cookie", "oreo");
 
-        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers, singleton("cookie"));
+        Set<String> sensitiveHeaders = new TreeSet<>(Comparator.comparing(String::toLowerCase));
+        sensitiveHeaders.add("cookie");
+
+        Set<Map.Entry<String, String>> result = RequestLogger.getHeaderValuesOrRedact(headers, sensitiveHeaders);
 
         Map<String, String> expectedValue = new HashMap<>();
         expectedValue.put("Cookie", "REDACTED");


### PR DESCRIPTION
Should supply a TreeSet with a Comparator to `getHeaderValuesOrRedact`, in order to properly validate if Set contains header or not - regardless of casing.

Missed this in previous PR: #219 