### PR TITLE
when client aborts, the exceptionhandler should debug-log it but not …

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.netty.channel.AbortedException;
 import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
 import rx.exceptions.CompositeException;
@@ -67,7 +68,7 @@ public class ExceptionHandler {
             webException = new WebException(HttpResponseStatus.BAD_REQUEST, "invalidjson", throwable.getMessage());
         } else if (throwable instanceof WebException) {
             webException = (WebException)throwable;
-        } else if (throwable instanceof ClosedChannelException) {
+        } else if (throwable instanceof ClosedChannelException || throwable instanceof AbortedException) {
             LOG.debug("ClosedChannelException: {} {}", request.method(), request.uri(), throwable);
             return Flux.empty();
         } else {

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
@@ -69,7 +69,9 @@ public class ExceptionHandler {
         } else if (throwable instanceof WebException) {
             webException = (WebException)throwable;
         } else if (throwable instanceof ClosedChannelException || throwable instanceof AbortedException) {
-            LOG.debug("Inbound connection has been closed: {} {}", request.method(), request.uri(), throwable);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Inbound connection has been closed: {} {}", request.method(), request.uri(), throwable);
+            }
             return Flux.empty();
         } else {
             webException = new WebException(HttpResponseStatus.INTERNAL_SERVER_ERROR, throwable);

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
@@ -69,7 +69,7 @@ public class ExceptionHandler {
         } else if (throwable instanceof WebException) {
             webException = (WebException)throwable;
         } else if (throwable instanceof ClosedChannelException || throwable instanceof AbortedException) {
-            LOG.debug("ClosedChannelException: {} {}", request.method(), request.uri(), throwable);
+            LOG.debug("Inbound connection has been closed: {} {}", request.method(), request.uri(), throwable);
             return Flux.empty();
         } else {
             webException = new WebException(HttpResponseStatus.INTERNAL_SERVER_ERROR, throwable);

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ExceptionHandlerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ExceptionHandlerTest.java
@@ -1,6 +1,5 @@
 package se.fortnox.reactivewizard.jaxrs;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.log4j.Appender;
@@ -74,7 +73,7 @@ public class ExceptionHandlerTest {
         assertLog(new MockHttpServerRequest("/path"),
             new ClosedChannelException(),
             Level.DEBUG,
-            "ClosedChannelException: GET /path");
+            "Inbound connection has been closed: GET /path");
     }
 
     @Test

--- a/server/src/test/java/se/fortnox/reactivewizard/server/AbortedRequestHandlingTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/AbortedRequestHandlingTest.java
@@ -1,0 +1,91 @@
+package se.fortnox.reactivewizard.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.log4j.Appender;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.netty.http.client.HttpClient;
+import rx.Observable;
+import se.fortnox.reactivewizard.ExceptionHandler;
+import se.fortnox.reactivewizard.RequestHandler;
+import se.fortnox.reactivewizard.jaxrs.JaxRsRequestHandler;
+import se.fortnox.reactivewizard.jaxrs.JaxRsResourceFactory;
+import se.fortnox.reactivewizard.test.LoggingMockUtil;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static rx.Observable.just;
+import static se.fortnox.reactivewizard.test.TestUtil.matches;
+
+/**
+ * When client aborts the connection the server should still finish gracefully with only a debug-log as the result
+ */
+public class AbortedRequestHandlingTest {
+
+    @Test
+    public void shouldHandleAbortedRequestGracefully() throws NoSuchFieldException, IllegalAccessException {
+
+        final Appender mockedLogAppender = LoggingMockUtil.createMockedLogAppender(ExceptionHandler.class);
+        LogManager.getLogger(ExceptionHandler.class).setLevel(Level.DEBUG);
+
+        RwServer      rwServer                   = null;
+        AtomicBoolean serverFinishedWithoutError = new AtomicBoolean(false);
+
+        try {
+            JaxRsRequestHandler jaxRsRequestHandler = new JaxRsRequestHandler(new Object[]{new TestResourceImpl()}, new JaxRsResourceFactory(), new ExceptionHandler(), false);
+
+            rwServer = server((httpServerRequest, httpServerResponse) -> {
+                httpServerRequest.withConnection(connection -> {
+                    connection.channel().close();
+                });
+                return Flux.from(jaxRsRequestHandler.apply(httpServerRequest, httpServerResponse)).doOnComplete(() -> {
+                    serverFinishedWithoutError.set(true);
+                });
+            });
+
+            HttpClient.create()
+                .get()
+                .uri("http://localhost:" + rwServer.getServer().port())
+                .response()
+                .block();
+            fail("Should throw exception since client connection is closed");
+
+        } catch (Exception e) {
+            verify(mockedLogAppender, timeout(3000)).doAppend(matches(event -> {
+                assertThat(event.getMessage().toString()).contains("ClosedChannelException: GET /");
+            }));
+            assertThat(serverFinishedWithoutError.get()).isTrue();
+        }
+        finally {
+            if (rwServer != null) {
+                rwServer.getServer().disposeNow();
+            }
+            LoggingMockUtil.destroyMockedAppender(mockedLogAppender, ExceptionHandler.class);
+        }
+    }
+
+    private RwServer server(RequestHandler handler) {
+        ServerConfig config = new ServerConfig();
+        config.setPort(0);
+        ConnectionCounter connectionCounter = new ConnectionCounter();
+        CompositeRequestHandler handlers = new CompositeRequestHandler(Collections.singleton(handler), new ExceptionHandler(new ObjectMapper()), connectionCounter);
+        return new RwServer(config, handlers, connectionCounter);
+    }
+
+    @Path("/")
+    public class TestResourceImpl {
+        @GET
+        public Observable<String> get() {
+            return just("");
+        }
+    }
+}

--- a/server/src/test/java/se/fortnox/reactivewizard/server/AbortedRequestHandlingTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/AbortedRequestHandlingTest.java
@@ -61,7 +61,7 @@ public class AbortedRequestHandlingTest {
 
         } catch (Exception e) {
             verify(mockedLogAppender, timeout(3000)).doAppend(matches(event -> {
-                assertThat(event.getMessage().toString()).contains("ClosedChannelException: GET /");
+                assertThat(event.getMessage().toString()).contains("Inbound connection has been closed: GET /");
             }));
             assertThat(serverFinishedWithoutError.get()).isTrue();
         }


### PR DESCRIPTION
…throw exception since it is so commonly occuring.
