### PR TITLE
Removed the verbose checked exceptions thrown by LoggingMockUtil

### DIFF
--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -112,12 +112,12 @@ public class HttpClientTest {
     private Appender       mockAppender;
 
     @Before
-    public void before() throws Exception {
+    public void before() {
         mockAppender = LoggingMockUtil.createMockedLogAppender(HttpClient.class);
     }
 
     @After
-    public void after() throws Exception{
+    public void after() {
         destroyMockedAppender(mockAppender, HttpClient.class);
     }
 

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/deserializing/DeserializerUtilTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/deserializing/DeserializerUtilTest.java
@@ -17,7 +17,7 @@ import static se.fortnox.reactivewizard.test.TestUtil.matches;
 
 public class DeserializerUtilTest {
     @Test
-    public void shouldLogWarnIfNoPropertyDeserializerWasFound() throws SQLException, NoSuchFieldException, IllegalAccessException {
+    public void shouldLogWarnIfNoPropertyDeserializerWasFound() throws SQLException {
         SimpleResultSet resultSet = new SimpleResultSet();
         resultSet.addColumn("test_a", Types.VARCHAR, 255, 0);
 
@@ -33,7 +33,7 @@ public class DeserializerUtilTest {
     }
 
     @Test
-    public void shouldNotWarnForFoundProperties() throws SQLException, NoSuchFieldException, IllegalAccessException {
+    public void shouldNotWarnForFoundProperties() throws SQLException {
         SimpleResultSet resultSet = new SimpleResultSet();
         resultSet.addColumn("test_b", Types.VARCHAR, 255, 0);
 

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerTest.java
@@ -95,7 +95,7 @@ public class RwServerTest {
     }
 
     @Test
-    public void shouldLogThatShutDownIsRegistered() throws NoSuchFieldException, IllegalAccessException {
+    public void shouldLogThatShutDownIsRegistered() {
         Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RwServer.class);
 
         LoopResources loopResources = mock(LoopResources.class);
@@ -147,7 +147,7 @@ public class RwServerTest {
     }
 
     @Test
-    public void shouldLogErrorIfShutdownIsPerformedWhileConnectionCountIsNotZero() throws NoSuchFieldException, IllegalAccessException {
+    public void shouldLogErrorIfShutdownIsPerformedWhileConnectionCountIsNotZero() {
         Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RwServer.class);
 
         LoopResources loopResources = mock(LoopResources.class);
@@ -189,14 +189,14 @@ public class RwServerTest {
     }
 
     @Test
-    public void shouldSkipAwaitingShutdownDependencyIfNotSet() throws NoSuchFieldException, IllegalAccessException {
+    public void shouldSkipAwaitingShutdownDependencyIfNotSet() {
         Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RwServer.class);
         RwServer.awaitShutdownDependency(new ServerConfig().getShutdownTimeoutSeconds());
         verify(mockAppender, never()).doAppend(any());
     }
 
     @Test
-    public void shouldAwaitShutdownDependency() throws NoSuchFieldException, IllegalAccessException {
+    public void shouldAwaitShutdownDependency() {
         Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RwServer.class);
         Supplier supplier = mock(Supplier.class);
 

--- a/test/src/main/java/se/fortnox/reactivewizard/test/LoggingMockUtil.java
+++ b/test/src/main/java/se/fortnox/reactivewizard/test/LoggingMockUtil.java
@@ -14,15 +14,16 @@ public class LoggingMockUtil {
 
     }
 
-    public static Appender createMockedLogAppender(Class cls) throws NoSuchFieldException, IllegalAccessException {
+    public static Appender createMockedLogAppender(Class cls) {
         Logger   logger       = LoggingMockUtil.getLogger(cls);
         Appender mockAppender = mock(Appender.class);
-        when(mockAppender.getName()).thenReturn("mockAppender");
+        when(mockAppender.getName())
+            .thenReturn("mockAppender");
         logger.addAppender(mockAppender);
         return mockAppender;
     }
 
-    public static void destroyMockedAppender(Appender appender, Class cls) throws NoSuchFieldException, IllegalAccessException {
+    public static void destroyMockedAppender(Appender appender, Class cls) {
         Logger logger = LoggingMockUtil.getLogger(cls);
         appender.close();
         logger.removeAppender(appender);
@@ -34,12 +35,17 @@ public class LoggingMockUtil {
      *
      * @return the logger instance used in the class
      */
-    static Logger getLogger(Class cls) throws NoSuchFieldException, IllegalAccessException {
-        Field logField = cls.getDeclaredField("LOG");
-        logField.setAccessible(true);
-        Log4jLoggerAdapter loggerAdapter = (Log4jLoggerAdapter)logField.get(null);
-        Field              innerLogField = loggerAdapter.getClass().getDeclaredField("logger");
-        innerLogField.setAccessible(true);
-        return (Logger)innerLogField.get(loggerAdapter);
+    static Logger getLogger(Class cls) {
+        try {
+            Field logField = cls.getDeclaredField("LOG");
+            logField.setAccessible(true);
+            Log4jLoggerAdapter loggerAdapter = (Log4jLoggerAdapter)logField.get(null);
+            Field innerLogField = loggerAdapter.getClass()
+                .getDeclaredField("logger");
+            innerLogField.setAccessible(true);
+            return (Logger)innerLogField.get(loggerAdapter);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/test/src/test/java/se/fortnox/reactivewizard/test/LoggingMockUtilTest.java
+++ b/test/src/test/java/se/fortnox/reactivewizard/test/LoggingMockUtilTest.java
@@ -6,37 +6,55 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static se.fortnox.reactivewizard.test.TestUtil.matches;
 
 public class LoggingMockUtilTest {
     @Test
-    public void shouldLogToMockAppender() throws NoSuchFieldException, IllegalAccessException {
+    public void shouldLogToMockAppender() {
         ClassWithLogger classWithLogger = new ClassWithLogger();
-        Appender appender = LoggingMockUtil.createMockedLogAppender(ClassWithLogger.class);
+        Appender        appender        = LoggingMockUtil.createMockedLogAppender(ClassWithLogger.class);
 
         classWithLogger.doSomethingLogged();
 
-        verify(appender).doAppend(matches(log -> {
-            assertThat(log.getLevel().toString()).isEqualTo("INFO");
-            assertThat(log.getMessage().toString()).contains("Information was logged");
-        }));
+        verify(appender)
+            .doAppend(matches(log -> {
+                assertThat(log.getLevel()
+                    .toString())
+                    .isEqualTo("INFO");
+                assertThat(log.getMessage()
+                    .toString())
+                    .contains("Information was logged");
+            }));
         LoggingMockUtil.destroyMockedAppender(appender, ClassWithLogger.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfFieldLOGCannotBeFoundWhileCreatingMockAppender() {
+        try {
+            LoggingMockUtil.createMockedLogAppender(String.class);
+            fail("expected exception");
+        } catch (RuntimeException exception) {
+            assertThat(exception.getCause())
+                .isInstanceOf(ReflectiveOperationException.class);
+        }
     }
 
     /**
      * Closes and removes the appender. Should be called after you have verified the logging, with help of this class.
-     *
      */
     @Test
-    public void shouldBePossibleToDestroyMockAppender() throws NoSuchFieldException, IllegalAccessException {
+    public void shouldBePossibleToDestroyMockAppender() {
         Appender appender = LoggingMockUtil.createMockedLogAppender(ClassWithLogger.class);
 
         LoggingMockUtil.destroyMockedAppender(appender, ClassWithLogger.class);
 
-        Appender destroyedAppender = LoggingMockUtil.getLogger(ClassWithLogger.class).getAppender("mockAppender");
-        assertThat(destroyedAppender).isNull();
+        Appender destroyedAppender = LoggingMockUtil.getLogger(ClassWithLogger.class)
+            .getAppender("mockAppender");
+        assertThat(destroyedAppender)
+            .isNull();
     }
 }
 

--- a/test/src/test/java/se/fortnox/reactivewizard/test/LoggingMockUtilTest.java
+++ b/test/src/test/java/se/fortnox/reactivewizard/test/LoggingMockUtilTest.java
@@ -1,13 +1,13 @@
 package se.fortnox.reactivewizard.test;
 
 import org.apache.log4j.Appender;
+import org.apache.log4j.Level;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static se.fortnox.reactivewizard.test.TestUtil.matches;
 
@@ -21,9 +21,8 @@ public class LoggingMockUtilTest {
 
         verify(appender)
             .doAppend(matches(log -> {
-                assertThat(log.getLevel()
-                    .toString())
-                    .isEqualTo("INFO");
+                assertThat(log.getLevel())
+                    .isEqualTo(Level.INFO);
                 assertThat(log.getMessage()
                     .toString())
                     .contains("Information was logged");


### PR DESCRIPTION
When we verify our log messages in our testing, we always need to take care of the exceptions thrown by LoggingMockUtil. This change will just wrap the exceptions in a runtime exception, so that we don't need to care about adding error handling.🎃