### PR TITLE
make the httpclient more resilient to failures when connecting.

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientConfig.java
@@ -52,6 +52,9 @@ public class HttpClientConfig {
     @JsonProperty("validateCertificates")
     private boolean isValidateCertificates = true;
 
+    private long connectionMaxIdleTimeInMs         = TimeUnit.MILLISECONDS.convert(10, MINUTES);
+    private int  numberOfConnectionFailuresAllowed = 10;
+
     private BasicAuthConfig basicAuth;
 
     public HttpClientConfig() {
@@ -197,5 +200,21 @@ public class HttpClientConfig {
 
     public void setPoolAcquireTimeoutMs(int poolAcquireTimeoutMs) {
         this.poolAcquireTimeoutMs = poolAcquireTimeoutMs;
+    }
+
+    public long getConnectionMaxIdleTimeInMs() {
+        return connectionMaxIdleTimeInMs;
+    }
+
+    public void setConnectionMaxIdleTimeInMs(long connectionMaxIdleTimeInMs) {
+        this.connectionMaxIdleTimeInMs = connectionMaxIdleTimeInMs;
+    }
+
+    public int getNumberOfConnectionFailuresAllowed() {
+        return numberOfConnectionFailuresAllowed;
+    }
+
+    public void setNumberOfConnectionFailuresAllowed(int numberOfConnectionFailuresAllowed) {
+        this.numberOfConnectionFailuresAllowed = numberOfConnectionFailuresAllowed;
     }
 }

--- a/client/src/main/java/se/fortnox/reactivewizard/client/ReactorRxClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/ReactorRxClientProvider.java
@@ -67,7 +67,7 @@ public class ReactorRxClientProvider {
                 healthRecorder.logStatus(connectionProvider, true);
             })
             .doOnError((httpClientRequest, throwable) -> {
-                healthRecorder.logStatus(connectionProvider, errorCount.incrementAndGet() < config.getNumberOfConnectionFailuresAllowed());
+                healthRecorder.logStatus(connectionProvider, errorCount.incrementAndGet() <= config.getNumberOfConnectionFailuresAllowed());
             }, (httpClientResponse, throwable) -> { })
             .followRedirect(false);
 

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -395,12 +395,12 @@ public class HttpClientTest {
 
         TestResource testResource = reactorHttpClient.create(TestResource.class);
 
-        //First nine should not cause the client to be unhealthy
-        range(1, 10)
+        //First ten should not cause the client to be unhealthy
+        range(1, 11)
             .forEach(value -> testResource.postHello().test().awaitTerminalEvent());
         assertThat(healthRecorder.isHealthy()).isTrue();
 
-        //next one should
+        //but the eleventh should
         testResource.postHello().test().awaitTerminalEvent();
         assertThat(healthRecorder.isHealthy()).isFalse();
 
@@ -426,8 +426,8 @@ public class HttpClientTest {
             e.printStackTrace();
         }
 
-        //And should accept another 9 errors
-        range(1, 10)
+        //And should accept another 10 errors
+        range(1, 11)
             .forEach(value -> testResource.postHello().test().awaitTerminalEvent());
         assertThat(healthRecorder.isHealthy()).isTrue();
     }


### PR DESCRIPTION
A single failure should not cause the health recorder to report unhealthy. Adding a config for this, and also adding a config for how long a connection can remain idle before thrown away.