### PR TITLE
Added five second wait before server shutdown for improved Kubernetes interoperability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 
 jdk:
   - openjdk11
-  - openjdk8
 
 branches:
   only:

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <netty.version>4.1.51.Final</netty.version>
+        <netty.version>4.1.59.Final</netty.version>
         <rxjava.version>1.3.8</rxjava.version>
         <jackson.version>2.10.2</jackson.version>
         <jackson-databind.version>2.10.2</jackson-databind.version>
@@ -101,7 +101,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>Dysprosium-SR11</version>
+                <version>Dysprosium-SR17</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -43,6 +43,13 @@
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.3</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/server/src/main/java/se/fortnox/reactivewizard/server/RwServer.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/RwServer.java
@@ -33,38 +33,33 @@ import static reactor.netty.channel.BootstrapHandlers.updateConfiguration;
 @Singleton
 public class RwServer extends Thread {
 
-    private static final Logger      LOG                         = LoggerFactory.getLogger(RwServer.class);
-    private static final int         COMPRESSION_THRESHOLD_BYTES = 1000;
-    private static final Set<String> COMPRESSIBLE_MIME_TYPES      = new HashSet<>(asList(
+    private static final Logger LOG = LoggerFactory.getLogger(RwServer.class);
+    private static final int COMPRESSION_THRESHOLD_BYTES = 1000;
+    private static final Set<String> COMPRESSIBLE_MIME_TYPES = new HashSet<>(asList(
         "text/plain",
         "application/xml",
         "text/css",
         "application/x-javascript",
         "application/json"
     ));
+    private static final long SECONDS_WAIT_BEFORE_SHUTDOWN = 5;
 
-    private final  ServerConfig      config;
-    private final  ConnectionCounter connectionCounter;
-    private final  LoopResources     eventLoopGroup;
-    private final  DisposableServer  server;
-    private static Runnable          blockShutdownUntil;
+    private final ServerConfig config;
+    private final ConnectionCounter connectionCounter;
+    private final DisposableServer server;
+    private static Runnable blockShutdownUntil;
 
     @Inject
-    public RwServer(ServerConfig config, CompositeRequestHandler compositeRequestHandler, ConnectionCounter connectionCounter) {
-        this(config, compositeRequestHandler, connectionCounter, null);
-    }
-
-    RwServer(ServerConfig config, CompositeRequestHandler compositeRequestHandler, ConnectionCounter connectionCounter, LoopResources loopResources) {
-        this(config, connectionCounter, createHttpServer(config, loopResources), compositeRequestHandler, loopResources);
+    RwServer(ServerConfig config, CompositeRequestHandler compositeRequestHandler, ConnectionCounter connectionCounter) {
+        this(config, connectionCounter, createHttpServer(config), compositeRequestHandler);
     }
 
     RwServer(ServerConfig config, ConnectionCounter connectionCounter, HttpServer httpServer,
-        CompositeRequestHandler compositeRequestHandler, LoopResources loopResources
+             CompositeRequestHandler compositeRequestHandler
     ) {
         super("RwServerMain");
         this.config = config;
         this.connectionCounter = connectionCounter;
-        this.eventLoopGroup = loopResources;
 
         if (config.isEnabled()) {
             server = httpServer.handle(compositeRequestHandler).bindNow();
@@ -76,7 +71,7 @@ public class RwServer extends Thread {
         }
     }
 
-    private static HttpServer createHttpServer(ServerConfig config, LoopResources loopResources) {
+    private static HttpServer createHttpServer(ServerConfig config) {
         if (!config.isEnabled()) {
             return null;
         }
@@ -89,9 +84,6 @@ public class RwServer extends Thread {
             // Register a channel group, when invoking disposeNow() the implementation will wait for the active requests to finish
             .channelGroup(new DefaultChannelGroup(new DefaultEventExecutor()))
             .tcpConfiguration(tcpServer -> {
-                if (loopResources != null) {
-                    tcpServer = tcpServer.runOn(loopResources);
-                }
                 NoContentFixConfigurator noContentFixConfigurator = new NoContentFixConfigurator();
                 return tcpServer.doOnBind(serverBootstrap -> updateConfiguration(serverBootstrap, "rw-server-configuration",
                     (connectionObserver, channel) -> {
@@ -135,7 +127,7 @@ public class RwServer extends Thread {
     }
 
     void registerShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdownHook(config, server, eventLoopGroup, connectionCounter)));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdownHook(config, server, connectionCounter)));
     }
 
     public static void registerShutdownDependency(Runnable blockShutdownUntil) {
@@ -145,16 +137,22 @@ public class RwServer extends Thread {
         RwServer.blockShutdownUntil = blockShutdownUntil;
     }
 
-    static void shutdownHook(ServerConfig config, DisposableServer server, LoopResources loopResources, ConnectionCounter connectionCounter) {
-        LOG.info("Shutdown requested. Will wait up to {} seconds...", config.getShutdownTimeoutSeconds());
+    static void shutdownHook(ServerConfig config, DisposableServer server, ConnectionCounter connectionCounter) {
+        LOG.info("Shutdown requested. Waiting {} seconds before commencing.", SECONDS_WAIT_BEFORE_SHUTDOWN);
+        try {
+            Thread.sleep(SECONDS_WAIT_BEFORE_SHUTDOWN * 1000);
+        } catch (InterruptedException e) {
+            LOG.error("Interrupted while waiting for shutdown to commence.", e);
+        }
+        LOG.info("Shutdown commencing. Will wait up to {} seconds for ongoing requests to complete.", config.getShutdownTimeoutSeconds());
         int elapsedSeconds = measureElapsedSeconds(() ->
             awaitShutdownDependency(config.getShutdownTimeoutSeconds())
         );
         int secondsLeft = Math.max(config.getShutdownTimeoutSeconds() - elapsedSeconds, 0);
-        shutdownEventLoopGracefully(secondsLeft, loopResources);
         if (!connectionCounter.awaitZero(secondsLeft, TimeUnit.SECONDS)) {
             LOG.error("Shutdown proceeded while connection count was not zero: {}", connectionCounter.getCount());
         }
+
         server.disposeNow(Duration.ofSeconds(config.getShutdownTimeoutSeconds()));
         LOG.info("Shutdown complete");
     }
@@ -191,6 +189,6 @@ public class RwServer extends Thread {
         Instant start = Instant.now();
         function.call();
         Instant finish = Instant.now();
-        return (int)Duration.between(start, finish).getSeconds();
+        return (int) Duration.between(start, finish).getSeconds();
     }
 }

--- a/server/src/main/java/se/fortnox/reactivewizard/server/RwServer.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/RwServer.java
@@ -10,7 +10,6 @@ import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
 import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
-import reactor.netty.resources.LoopResources;
 import rx.functions.Action0;
 import se.fortnox.reactivewizard.RequestHandler;
 
@@ -171,18 +170,6 @@ public class RwServer extends Thread {
             LOG.error("Fail while waiting shutdown dependency", e);
         }
         LOG.info("Shutdown dependency completed, continue...");
-    }
-
-    static void shutdownEventLoopGracefully(int shutdownTimeoutSeconds, LoopResources loopResources) {
-        if (loopResources == null) {
-            return;
-        }
-        try {
-            int shutdownQuietPeriodSeconds = 0;
-            loopResources.disposeLater(Duration.ofSeconds(shutdownQuietPeriodSeconds), Duration.ofSeconds(shutdownTimeoutSeconds)).block();
-        } catch (Exception e) {
-            LOG.error("Graceful shutdown failed", e);
-        }
     }
 
     static int measureElapsedSeconds(Action0 function) {

--- a/server/src/main/java/se/fortnox/reactivewizard/server/RwServer.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/RwServer.java
@@ -48,7 +48,7 @@ public class RwServer extends Thread {
     private static Runnable blockShutdownUntil;
 
     @Inject
-    RwServer(ServerConfig config, CompositeRequestHandler compositeRequestHandler, ConnectionCounter connectionCounter) {
+    public RwServer(ServerConfig config, CompositeRequestHandler compositeRequestHandler, ConnectionCounter connectionCounter) {
         this(config, connectionCounter, createHttpServer(config), compositeRequestHandler);
     }
 

--- a/server/src/main/java/se/fortnox/reactivewizard/server/ServerConfig.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/ServerConfig.java
@@ -7,13 +7,14 @@ import se.fortnox.reactivewizard.config.Config;
  */
 @Config("server")
 public class ServerConfig {
-    private int     port                        = 8080;
-    private boolean enabled                     = true;
-    private int     maxHeaderSize               = 20 * 1024;
-    private int     maxInitialLineLengthDefault = 4096;
-    private int     maxRequestSize              = 10 * 1024 * 1024;
-    private int     shutdownTimeoutSeconds      = 20;
-    private boolean enableGzip                  = true;
+    private int port = 8080;
+    private boolean enabled = true;
+    private int maxHeaderSize = 20 * 1024;
+    private int maxInitialLineLengthDefault = 4096;
+    private int maxRequestSize = 10 * 1024 * 1024;
+    private int shutdownTimeoutSeconds = 20;
+    private boolean enableGzip = true;
+    private long shutdownDelaySeconds = 5;
 
     public int getPort() {
         return port;
@@ -69,5 +70,13 @@ public class ServerConfig {
 
     public void setEnableGzip(boolean enableGzip) {
         this.enableGzip = enableGzip;
+    }
+
+    public long getShutdownDelaySeconds() {
+        return shutdownDelaySeconds;
+    }
+
+    public void setShutdownDelaySeconds(int shutdownDelaySeconds) {
+        this.shutdownDelaySeconds = shutdownDelaySeconds;
     }
 }

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGracefulShutdownTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGracefulShutdownTest.java
@@ -4,89 +4,70 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
 import reactor.netty.http.client.HttpClient;
 import se.fortnox.reactivewizard.ExceptionHandler;
 import se.fortnox.reactivewizard.RequestHandler;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
 
 public class RwServerGracefulShutdownTest {
 
     private ServerConfig serverConfig;
+    private AtomicLong requests;
+    private AtomicLong responses;
 
     @Before
     public void before() {
         serverConfig = new ServerConfig();
         serverConfig.setPort(0);
+        requests = new AtomicLong(0);
+        responses = new AtomicLong(0);
     }
 
     @Test
-    public void shouldThrowExceptionIfGracefulShutDownIsNotPossible() throws InterruptedException {
-        CountDownLatch serverReceivedClientRequest = new CountDownLatch(1);
-        CountDownLatch clientReceivedResponse = new CountDownLatch(1);
+    public void shouldThrowExceptionIfGracefulShutDownIsNotPossible() {
         serverConfig.setShutdownTimeoutMs(1);
 
         // start server with a endpoint that takes 30 seconds to respond.
         Duration longResponseTime = Duration.ofSeconds(30);
-        RwServer rwServer = server(withEndpoint(serverReceivedClientRequest, longResponseTime));
+        RwServer rwServer = server(withEndpoint(longResponseTime));
 
         // client connects to endpoint and waits for server to respond.
-        clientSendsRequestToSlowEndpoint(rwServer,clientReceivedResponse);
+        clientSendsRequestToSlowEndpoint(rwServer);
 
-        assertThat(serverReceivedClientRequest.await(3, TimeUnit.SECONDS))
-            .describedAs("server should receive the client request")
-            .isTrue();
+        await()
+            .atMost(Duration.ofSeconds(3))
+            .until(() -> requests.get() == 1);
 
-        try {
-            // shutdown of server starts. A graceful shutdown is attempted.
-            RwServer.shutdownHook(serverConfig, rwServer.getServer(), null, new ConnectionCounter());
-            fail("Server should throw an exception that graceful shutdown could not be done. Expected IllegalStateException");
-        } catch (IllegalStateException illegalStateException) {
-                assertThat(illegalStateException.getMessage())
-                    .describedAs("server should throw an exception that graceful shutdown could not be done. The connection was cut.")
-                    .isEqualTo("Socket couldn't be stopped within 1000ms");
-        }
+        DisposableServer server = rwServer.getServer();
+        ConnectionCounter connectionCounter = new ConnectionCounter();
+
+        assertThatExceptionOfType(IllegalStateException.class)
+            .describedAs("server should throw an exception that graceful shutdown could not be done. The connection was cut.")
+            .isThrownBy(() -> RwServer.shutdownHook(serverConfig, server, connectionCounter))
+            .withMessage("Socket couldn't be stopped within 1000ms");
     }
 
     @Test
-    public void shouldGracefullyShutDown() throws InterruptedException {
-        CountDownLatch serverReceivedClientRequest = new CountDownLatch(1);
-        CountDownLatch clientReceivedResponse = new CountDownLatch(1);
-        serverConfig.setShutdownTimeoutMs(20);
-
-        // start server with a endpoint that takes 1 seconds to respond.
-        Duration responseTime = Duration.ofSeconds(1);
-        RwServer rwServer = server(withEndpoint(serverReceivedClientRequest, responseTime));
-
-        // client connects to endpoint and waits for server to respond.
-        clientSendsRequestToSlowEndpoint(rwServer,clientReceivedResponse);
-
-        assertThat(serverReceivedClientRequest.await(3, TimeUnit.SECONDS))
-            .describedAs("server should receive the client request")
-            .isTrue();
-
-        // shutdown of server starts. A graceful shutdown is attempted.
-        RwServer.shutdownHook(serverConfig, rwServer.getServer(), null, new ConnectionCounter());
-
-        // server waits for connection to complete before termination.
-        assertThat(clientReceivedResponse.await(5, TimeUnit.SECONDS))
-            .describedAs("client should get response")
-            .isTrue();
-
-        assertThat(rwServer.getServer().isDisposed())
-            .describedAs("server should shutdown")
-            .isTrue();
+    public void shouldWaitFiveSecondsBeforeDisposingServer() {
+        RwServer rwServer = server(withEndpoint(Duration.ofSeconds(1)));
+        Thread shutdown = new Thread(() -> RwServer.shutdownHook(serverConfig, rwServer.getServer(), new ConnectionCounter()));
+        shutdown.start();
+        await("Server should not be disposed until after five seconds")
+            .atLeast(5, SECONDS)
+            .until(() -> rwServer.getServer().isDisposed());
     }
 
-    private RequestHandler withEndpoint(CountDownLatch connectionReceived, Duration responseTime) {
+    private RequestHandler withEndpoint(Duration responseTime) {
         return (httpServerRequest, httpServerResponse) -> {
-            connectionReceived.countDown();
+            requests.incrementAndGet();
             return httpServerResponse
                 .chunkedTransfer(false)
                 .sendByteArray(Mono.just("Message that we want to receive before server terminates".getBytes())
@@ -94,7 +75,7 @@ public class RwServerGracefulShutdownTest {
         };
     }
 
-    private void clientSendsRequestToSlowEndpoint(RwServer rwServer, CountDownLatch responseReceived) {
+    private void clientSendsRequestToSlowEndpoint(RwServer rwServer) {
         HttpClient.ResponseReceiver<?> responseReceiver = HttpClient.create()
             .baseUrl("http://localhost:" + rwServer.getServer().port())
             .get();
@@ -103,14 +84,13 @@ public class RwServerGracefulShutdownTest {
             .aggregate()
             .asString()
             .doOnNext(e -> {
-                responseReceived.countDown();
+                responses.incrementAndGet();
             }).subscribe();
     }
 
-
     private RwServer server(RequestHandler handler) {
-        ConnectionCounter       connectionCounter = new ConnectionCounter();
-        CompositeRequestHandler handlers          = new CompositeRequestHandler(Collections.singleton(handler), new ExceptionHandler(new ObjectMapper()), connectionCounter);
+        ConnectionCounter connectionCounter = new ConnectionCounter();
+        CompositeRequestHandler handlers = new CompositeRequestHandler(Collections.singleton(handler), new ExceptionHandler(new ObjectMapper()), connectionCounter);
         return new RwServer(serverConfig, handlers, connectionCounter) {
             @Override
             void registerShutdownHook() {

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGracefulShutdownTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGracefulShutdownTest.java
@@ -56,12 +56,23 @@ public class RwServerGracefulShutdownTest {
     }
 
     @Test
-    public void shouldWaitFiveSecondsBeforeDisposingServer() {
+    public void shouldWaitFiveSecondsAsDefaultBeforeDisposingServer() {
         RwServer rwServer = server(withEndpoint(Duration.ofSeconds(1)));
         Thread shutdown = new Thread(() -> RwServer.shutdownHook(serverConfig, rwServer.getServer(), new ConnectionCounter()));
         shutdown.start();
         await("Server should not be disposed until after five seconds")
             .atLeast(5, SECONDS)
+            .until(() -> rwServer.getServer().isDisposed());
+    }
+
+    @Test
+    public void shouldWaitSpecifiedNumberOfSecondsBeforeDisposingServer() {
+        serverConfig.setShutdownDelaySeconds(1);
+        RwServer rwServer = server(withEndpoint(Duration.ofSeconds(1)));
+        Thread shutdown = new Thread(() -> RwServer.shutdownHook(serverConfig, rwServer.getServer(), new ConnectionCounter()));
+        shutdown.start();
+        await("Server should be disposed in two seconds")
+            .atMost(2, SECONDS)
             .until(() -> rwServer.getServer().isDisposed());
     }
 

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerTest.java
@@ -1,16 +1,17 @@
 package se.fortnox.reactivewizard.server;
 
-import io.netty.channel.EventLoopGroup;
 import org.apache.log4j.Appender;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
-import reactor.netty.resources.LoopResources;
 import reactor.netty.tcp.TcpServer;
 import se.fortnox.reactivewizard.test.LoggingMockUtil;
 
@@ -34,9 +35,20 @@ public class RwServerTest {
     @Mock
     CompositeRequestHandler compositeRequestHandler;
 
+    ArgumentCaptor<LoggingEvent> logCaptor;
+
+    Appender mockAppender;
+
     @Before
     public void before() {
         RwServer.registerShutdownDependency(null);
+        mockAppender = LoggingMockUtil.createMockedLogAppender(RwServer.class);
+        logCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+    }
+
+    @After
+    public void after() {
+        LoggingMockUtil.destroyMockedAppender(mockAppender, RwServer.class);
     }
 
     @Test
@@ -45,7 +57,7 @@ public class RwServerTest {
         serverConfig.setEnabled(false);
         serverConfig.setPort(0);
 
-        RwServer rwServer = new RwServer(serverConfig, compositeRequestHandler, connectionCounter, null);
+        RwServer rwServer = new RwServer(serverConfig, compositeRequestHandler, connectionCounter);
         rwServer.join();
 
         assertNull(rwServer.getServer());
@@ -53,22 +65,22 @@ public class RwServerTest {
 
     @Test
     public void shouldStartTheServerIfConfigSaysEnabled() throws InterruptedException {
-        ServerConfig  serverConfig              = new ServerConfig();
+        ServerConfig serverConfig = new ServerConfig();
         serverConfig.setPort(0);
-        AtomicInteger startInvocedNumberOfTimes = new AtomicInteger(0);
+        AtomicInteger startInvokedNumberOfTimes = new AtomicInteger(0);
 
         RwServer rwServer = null;
         try {
-            rwServer = new RwServer(serverConfig, compositeRequestHandler, connectionCounter, null) {
+            rwServer = new RwServer(serverConfig, compositeRequestHandler, connectionCounter) {
                 @Override
                 public void start() {
-                    startInvocedNumberOfTimes.incrementAndGet();
+                    startInvokedNumberOfTimes.incrementAndGet();
                 }
             };
             rwServer.join();
 
             assertThat(rwServer.getServer()).isNotNull().isInstanceOf(DisposableServer.class);
-            assertThat(startInvocedNumberOfTimes.get()).isEqualTo(1);
+            assertThat(startInvokedNumberOfTimes.get()).isEqualTo(1);
         } finally {
             if (rwServer != null) {
                 rwServer.getServer().disposeNow();
@@ -88,36 +100,30 @@ public class RwServerTest {
                 return just(disposableServer);
             }
         };
-        RwServer rwServer = new RwServer(serverConfig, connectionCounter, server, compositeRequestHandler, null) {};
+        RwServer rwServer = new RwServer(serverConfig, connectionCounter, server, compositeRequestHandler);
         rwServer.join();
 
-        verify(disposableServer, times(1)).onDispose();
+        verify(disposableServer).onDispose();
     }
 
     @Test
     public void shouldLogThatShutDownIsRegistered() {
         Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RwServer.class);
 
-        LoopResources loopResources = mock(LoopResources.class);
-        when(loopResources.disposeLater(any(), any())).thenReturn(Mono.empty());
-
         RwServer rwServer = null;
         try {
             final ServerConfig config = new ServerConfig();
             config.setPort(0);
-            rwServer = new RwServer(config, compositeRequestHandler, connectionCounter, null) {
-            };
-            RwServer.shutdownHook(config, rwServer.getServer(), loopResources, connectionCounter);
+            rwServer = new RwServer(config, compositeRequestHandler, connectionCounter);
+            RwServer.shutdownHook(config, rwServer.getServer(), connectionCounter);
 
-            verify(mockAppender).doAppend(matches(log ->
-                assertThat(log.getMessage().toString()).matches("Shutdown requested. Will wait up to 20 seconds...")
-            ));
+            verify(mockAppender, atLeastOnce()).doAppend(logCaptor.capture());
 
-            verify(mockAppender).doAppend(matches(log ->
-                assertThat(log.getMessage().toString()).matches("Shutdown complete")
-            ));
-
-            LoggingMockUtil.destroyMockedAppender(mockAppender, RwServer.class);
+            assertThat(logCaptor.getAllValues())
+                .extracting(LoggingEvent::getMessage)
+                .contains("Shutdown requested. Waiting 5 seconds before commencing.")
+                .contains("Shutdown commencing. Will wait up to 20 seconds for ongoing requests to complete.")
+                .contains("Shutdown complete");
         } finally {
             if (rwServer != null) {
                 rwServer.getServer().disposeNow();
@@ -127,9 +133,6 @@ public class RwServerTest {
 
     @Test
     public void shouldCallServerShutDownWhenShutdownHookIsInvoked() {
-        LoopResources loopResources = mock(LoopResources.class);
-        when(loopResources.disposeLater(any(), any())).thenReturn(Mono.empty());
-
         DisposableServer disposableServer = mock(DisposableServer.class);
         when(disposableServer.onDispose()).thenReturn(Mono.empty());
         HttpServer server = new HttpServer() {
@@ -139,39 +142,31 @@ public class RwServerTest {
             }
         };
 
-        RwServer rwServer = new RwServer(new ServerConfig(), connectionCounter, server, compositeRequestHandler, loopResources) {};
-        RwServer.shutdownHook(new ServerConfig(), rwServer.getServer(), loopResources, connectionCounter);
+        RwServer rwServer = new RwServer(new ServerConfig(), connectionCounter, server, compositeRequestHandler);
+        RwServer.shutdownHook(new ServerConfig(), rwServer.getServer(), connectionCounter);
 
-        verify(loopResources, times(1)).disposeLater(any(), any());
-        verify(disposableServer, times(1)).disposeNow(any());
+        verify(disposableServer).disposeNow(any());
     }
 
     @Test
     public void shouldLogErrorIfShutdownIsPerformedWhileConnectionCountIsNotZero() {
-        Appender mockAppender = LoggingMockUtil.createMockedLogAppender(RwServer.class);
-
-        LoopResources loopResources = mock(LoopResources.class);
-        when(loopResources.disposeLater(any(), any())).thenReturn(Mono.empty());
-
         when(connectionCounter.awaitZero(anyInt(), any(TimeUnit.class))).thenReturn(false);
         when(connectionCounter.getCount()).thenReturn(4L);
         RwServer rwServer = null;
         try {
             final ServerConfig config = new ServerConfig();
             config.setPort(0);
-            rwServer = new RwServer(config, compositeRequestHandler, connectionCounter, null) {
-            };
-            RwServer.shutdownHook(config, rwServer.getServer(), loopResources, connectionCounter);
+            rwServer = new RwServer(config, compositeRequestHandler, connectionCounter);
+            RwServer.shutdownHook(config, rwServer.getServer(), connectionCounter);
 
-            verify(mockAppender).doAppend(matches(log ->
-                assertThat(log.getMessage().toString()).matches("Shutdown requested. Will wait up to 20 seconds...")
-            ));
+            verify(mockAppender, atLeastOnce()).doAppend(logCaptor.capture());
 
-            verify(mockAppender).doAppend(matches(log ->
-                assertThat(log.getMessage().toString()).matches("Shutdown proceeded while connection count was not zero: 4")
-            ));
+            assertThat(logCaptor.getAllValues())
+                .extracting(LoggingEvent::getMessage)
+                .contains("Shutdown requested. Waiting 5 seconds before commencing.")
+                .contains("Shutdown commencing. Will wait up to 20 seconds for ongoing requests to complete.")
+                .contains("Shutdown proceeded while connection count was not zero: 4");
 
-            LoggingMockUtil.destroyMockedAppender(mockAppender, RwServer.class);
         } finally {
             rwServer.getServer().disposeNow();
         }
@@ -179,9 +174,11 @@ public class RwServerTest {
 
     @Test
     public void shouldNotOverrideShutdownDependency() {
-        RwServer.registerShutdownDependency(() -> {});
+        RwServer.registerShutdownDependency(() -> {
+        });
         try {
-            RwServer.registerShutdownDependency(() -> {});
+            RwServer.registerShutdownDependency(() -> {
+            });
             fail();
         } catch (IllegalStateException e) {
             assertThat(e.getMessage()).isEqualTo("Shutdown dependency is already registered");
@@ -208,7 +205,7 @@ public class RwServerTest {
         verify(mockAppender).doAppend(matches(log ->
             assertThat(log.getMessage().toString()).matches("Wait for completion of shutdown dependency")
         ));
-        verify(supplier, times(1)).get();
+        verify(supplier).get();
         verify(mockAppender).doAppend(matches(log ->
             assertThat(log.getMessage().toString()).matches("Shutdown dependency completed, continue...")
         ));

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerTest.java
@@ -114,6 +114,7 @@ public class RwServerTest {
         try {
             final ServerConfig config = new ServerConfig();
             config.setPort(0);
+            config.setShutdownDelaySeconds(3);
             rwServer = new RwServer(config, compositeRequestHandler, connectionCounter);
             RwServer.shutdownHook(config, rwServer.getServer(), connectionCounter);
 
@@ -121,7 +122,7 @@ public class RwServerTest {
 
             assertThat(logCaptor.getAllValues())
                 .extracting(LoggingEvent::getMessage)
-                .contains("Shutdown requested. Waiting 5 seconds before commencing.")
+                .contains("Shutdown requested. Waiting 3 seconds before commencing.")
                 .contains("Shutdown commencing. Will wait up to 20 seconds for ongoing requests to complete.")
                 .contains("Shutdown complete");
         } finally {


### PR DESCRIPTION
Removed tests for graceful shutdown since they did not test what was intended.
Removed LoopResources from RwServer since it was never used.
Upped reactor-bom to SR17.