### PR TITLE
Make it possible to set the response status dynamically

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsResource.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsResource.java
@@ -22,7 +22,6 @@ import javax.ws.rs.core.MediaType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -131,8 +130,8 @@ public class JaxRsResource<T> implements Comparable<JaxRsResource> {
         // This part should be refactored so that this class does not know about decorator, but right now the meta data
         // is lost if not handled here.
         if (result instanceof ResponseDecorator.ObservableWithHeaders) {
-            Map<String, String> headers = ((ResponseDecorator.ObservableWithHeaders<T>) result).getHeaders();
-            return new ResponseDecorator.FluxWithHeaders<>(fluxResult, headers);
+            ResponseDecorator.ResponseDecorations decorations = ((ResponseDecorator.ObservableWithHeaders<T>) result).getDecorations();
+            return new ResponseDecorator.FluxWithHeaders<>(fluxResult, decorations);
         }
 
         return fluxResult;

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/response/ResponseDecorator.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/response/ResponseDecorator.java
@@ -1,12 +1,17 @@
 package se.fortnox.reactivewizard.jaxrs.response;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import rx.Observable;
 import rx.Observer;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Allows you to return response headers together with your result.
@@ -16,73 +21,108 @@ public class ResponseDecorator {
     /**
      * Use this to wrap your Observable with some headers. This must be the last decoration before returning from your
      * resource. Any Observable operator applied after this will remove the headers.
-     * @param value is the response
+     *
+     * @param value   is the response
      * @param headers is your headers
-     * @param <T> is the type of value
+     * @param <T>     is the type of value
      * @return the value, decorated with headers.
      */
-    public static <T> Observable<T> withHeaders(Observable<T> value, Map<String, String> headers) {
-        return new ObservableWithHeaders<>(value, headers);
+    @Nonnull
+    public static <T> Observable<T> withHeaders(@Nonnull Observable<T> value, @Nonnull Map<String, String> headers) {
+        return ResponseDecorator.of(value).withHeaders(headers).build();
     }
 
-    @SuppressWarnings("unchecked")
-    protected static <T> Flux<T> apply(Flux<T> output, JaxRsResult<T> result) {
+    /**
+     * Creates a DecoratedResponseBuilder for the supplied Observable.
+     * <p>
+     * Use {@link DecoratedResponseBuilder#withHeaders} and {@link DecoratedResponseBuilder#withStatus} to decorate
+     * your response.
+     * Use {@link DecoratedResponseBuilder#build} to create the decorated Observable.
+     * <p>
+     * This must be the last decoration before returning from your resource.
+     * Any Observable operator applied after this will remove the headers.
+     * <p>
+     * Example:
+     * <pre>{@code
+     *     ResponseDecorator.of(just("body"))
+     *         .withHeaders(Map.of("Location", "/somewhere-else"))
+     *         .withStatus(HttpResponseStatus.MOVED_PERMANENTLY)
+     *         .build();
+     * }</pre>
+     *
+     * @param value is the response
+     * @param <T>   is the type of value
+     * @return DecoratedResponseBuilder&lt;T&gt;
+     */
+    @Nonnull
+    public static <T> DecoratedResponseBuilder<T> of(@Nonnull Observable<T> value) {
+        return new DecoratedResponseBuilder<>(value);
+    }
+
+    protected static <T> Flux<T> apply(@Nonnull Flux<T> output, @Nonnull JaxRsResult<T> result) {
         if (output instanceof FluxWithHeaders) {
-            Map<String,String> headers = ((FluxWithHeaders) output).getHeaders();
-            headers.forEach(result::addHeader);
-            SetHeadersOnEmit setHeaders = new SetHeadersOnEmit(headers, result);
+            ResponseDecorations decorations = ((FluxWithHeaders<T>) output).getDecorations();
+
+            decorations.applyOn(result);
+
+            ApplyDecorationsOnEmit<T> applyDecorations = new ApplyDecorationsOnEmit<>(decorations, result);
+
             return output
-                .doOnNext(setHeaders::onNext)
-                .doOnComplete(setHeaders::onCompleted);
+                .doOnNext(applyDecorations::onNext)
+                .doOnComplete(applyDecorations::onCompleted);
         }
         return output;
     }
 
-    private static class SetHeadersOnEmit<T>  implements Observer<T> {
+    private static class ApplyDecorationsOnEmit<T> implements Observer<T> {
 
-        private final AtomicBoolean headersSet = new AtomicBoolean();
-        private final Map<String, String> headers;
+        private final AtomicBoolean hasApplied = new AtomicBoolean();
+        private final ResponseDecorations decorations;
         private final JaxRsResult<T> result;
 
-        public SetHeadersOnEmit(Map<String, String> headers, JaxRsResult<T> result) {
-            this.headers = headers;
+        public ApplyDecorationsOnEmit(@Nonnull ResponseDecorations decorations, @Nonnull JaxRsResult<T> result) {
+            this.decorations = decorations;
             this.result = result;
         }
 
         @Override
         public void onCompleted() {
-            setHeaders();
+            applyDecorations();
         }
 
         @Override
-        public void onError(Throwable exception) {
-
+        public void onError(@Nonnull Throwable exception) {
         }
 
         @Override
-        public void onNext(T record) {
-            setHeaders();
+        public void onNext(@Nonnull T record) {
+            applyDecorations();
         }
 
-        private void setHeaders() {
-            if (headersSet.compareAndSet(false, true)) {
-                headers.forEach(result::addHeader);
+        private void applyDecorations() {
+            if (hasApplied.compareAndSet(false, true)) {
+                decorations.applyOn(result);
             }
-
         }
     }
 
     public static class ObservableWithHeaders<T> extends Observable<T> {
 
-        private final Map<String, String> headers;
+        private final ResponseDecorations decorations;
 
-        protected ObservableWithHeaders(Observable<T> inner, Map<String,String> headers) {
+        protected ObservableWithHeaders(@Nonnull Observable<T> inner, @Nonnull ResponseDecorations decorations) {
             super(inner::unsafeSubscribe);
-            this.headers = headers;
+            this.decorations = decorations;
         }
 
+        @Nonnull
+        public ResponseDecorations getDecorations() {
+            return decorations;
+        }
+
+        @Nonnull
         public Map<String, String> getHeaders() {
-            return headers;
+            return decorations.getHeaders();
         }
     }
 
@@ -90,20 +130,140 @@ public class ResponseDecorator {
     public static class FluxWithHeaders<T> extends Flux<T> {
 
         private final Flux<T> inner;
-        private final Map<String, String> headers;
+        private final ResponseDecorations decorations;
 
-        public FluxWithHeaders(Flux<T> inner, Map<String,String> headers) {
+        public FluxWithHeaders(@Nonnull Flux<T> inner, @Nonnull ResponseDecorations decorations) {
             this.inner = inner;
+            this.decorations = decorations;
+        }
+
+        @Nonnull
+        public ResponseDecorations getDecorations() {
+            return decorations;
+        }
+
+        @Nonnull
+        public Map<String, String> getHeaders() {
+            return decorations.getHeaders();
+        }
+
+        @Override
+        public void subscribe(@Nonnull CoreSubscriber<? super T> actual) {
+            inner.subscribe(actual);
+        }
+    }
+
+    public static class DecoratedResponseBuilder<T> {
+
+        private final Observable<T> response;
+        private final ResponseDecorations decorations = new ResponseDecorations();
+
+        public DecoratedResponseBuilder(@Nonnull final Observable<T> response) {
+            this.response = response;
+        }
+
+        /**
+         * Set the headers map that will be used. Replaces any currently set headers.
+         * The content of the map may be altered during the handling of a response.
+         *
+         * @param headers A map of header values.
+         * @return this
+         */
+        @Nonnull
+        public DecoratedResponseBuilder<T> withHeaders(@Nonnull Map<String, String> headers) {
+            this.decorations.setHeaders(headers);
+            return this;
+        }
+
+        /**
+         * Appends a header to the current header collection.
+         *
+         * @param name the name of the header
+         * @param value the value of the header
+         * @return this
+         */
+        @Nonnull
+        public DecoratedResponseBuilder<T> withHeader(@Nonnull String name, @Nonnull String value) {
+            this.decorations.addHeader(name, value);
+            return this;
+        }
+
+        /**
+         * Set the status that will be returned. Calling this method will replace any currently set status.
+         *
+         * @param status The status object
+         * @return this
+         */
+        @Nonnull
+        public DecoratedResponseBuilder<T> withStatus(@Nullable HttpResponseStatus status) {
+            this.decorations.setStatus(status);
+            return this;
+        }
+
+        /**
+         * Set the status that will be returned. Calling this method will replace any currently set status.
+         * The content of the AtomicReference may be altered during the handling of a response.
+         *
+         * @param status An AtomicReference to the status object
+         * @return this
+         */
+        @Nonnull
+        public DecoratedResponseBuilder<T> withStatus(@Nullable AtomicReference<HttpResponseStatus> status) {
+            this.decorations.setStatus(status);
+            return this;
+        }
+
+        /**
+         * Create the decorated response Observable
+         *
+         * @return ObservableWithHeaders&lt;T&gt;
+         */
+        @Nonnull
+        public ObservableWithHeaders<T> build() {
+            return new ObservableWithHeaders<>(response, decorations);
+        }
+    }
+
+    public static class ResponseDecorations {
+
+        private Map<String, String> headers = new HashMap<>();
+        private AtomicReference<HttpResponseStatus> status = new AtomicReference<>(null);
+
+        public ResponseDecorations() {
+        }
+
+        public void setHeaders(@Nonnull Map<String, String> headers) {
             this.headers = headers;
         }
 
+        public void addHeader(@Nonnull String name, @Nonnull String value) {
+            headers.put(name, value);
+        }
+
+        public void setStatus(@Nullable HttpResponseStatus status) {
+            this.status.set(status);
+        }
+
+        public void setStatus(@Nullable AtomicReference<HttpResponseStatus> status) {
+            this.status = status;
+        }
+
+        @Nonnull
         public Map<String, String> getHeaders() {
             return headers;
         }
 
-        @Override
-        public void subscribe(CoreSubscriber<? super T> actual) {
-            inner.subscribe(actual);
+        @Nullable
+        public HttpResponseStatus getStatus() {
+            return status.get();
+        }
+
+        public void applyOn(@Nonnull JaxRsResult<?> result) {
+            headers.forEach(result::addHeader);
+
+            if (status.get() != null) {
+                result.responseStatus = status.get();
+            }
         }
     }
 }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/response/ResponseDecorator.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/response/ResponseDecorator.java
@@ -208,7 +208,7 @@ public class ResponseDecorator {
          * @return this
          */
         @Nonnull
-        public DecoratedResponseBuilder<T> withStatus(@Nullable AtomicReference<HttpResponseStatus> status) {
+        public DecoratedResponseBuilder<T> withStatus(@Nonnull AtomicReference<HttpResponseStatus> status) {
             this.decorations.setStatus(status);
             return this;
         }
@@ -244,7 +244,7 @@ public class ResponseDecorator {
             this.status.set(status);
         }
 
-        public void setStatus(@Nullable AtomicReference<HttpResponseStatus> status) {
+        public void setStatus(@Nonnull AtomicReference<HttpResponseStatus> status) {
             this.status = status;
         }
 

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ResponseDecoratorTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ResponseDecoratorTest.java
@@ -1,5 +1,6 @@
 package se.fortnox.reactivewizard.jaxrs;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Test;
 import rx.Observable;
 import se.fortnox.reactivewizard.jaxrs.response.ResponseDecorator;
@@ -11,6 +12,7 @@ import javax.ws.rs.Path;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static rx.Observable.defer;
@@ -20,21 +22,51 @@ public class ResponseDecoratorTest {
 
     @Test
     public void shouldReturnHeaderFromResource() {
-        MockHttpServerResponse response = JaxRsTestUtil.get(new ResourceWithHeaders(), "/");
+        MockHttpServerResponse response = JaxRsTestUtil.get(new ResourceWithHeaders(), "/headers");
         assertThat(response.responseHeaders().get("custom_header")).isEqualTo("value");
         assertThat(response.getOutp()).isEqualTo("\"body\"");
     }
 
     @Test
-    public void shouldReturnDeferedHeaderFromResource() {
-        MockHttpServerResponse response = JaxRsTestUtil.get(new ResourceWithHeaders(), "/deferred");
+    public void shouldReturnDeferredHeaderFromResource() {
+        MockHttpServerResponse response = JaxRsTestUtil.get(new ResourceWithHeaders(), "/headers/deferred");
         assertThat(response.responseHeaders().get("custom_header")).isEqualTo("deferred");
+        assertThat(response.getOutp()).isEqualTo("\"body\"");
+    }
+
+    @Test
+    public void shouldReturnHeaderFromResourceWithBuilder() {
+        MockHttpServerResponse response = JaxRsTestUtil.get(new ResourceWithHeaders(), "/with-builder/headers");
+        assertThat(response.responseHeaders().get("custom_header")).isEqualTo("value");
+        assertThat(response.responseHeaders().get("custom_header2")).isEqualTo("value2");
+        assertThat(response.getOutp()).isEqualTo("\"body\"");
+    }
+
+    @Test
+    public void shouldReturnDeferredHeaderFromResourceWithBuilder() {
+        MockHttpServerResponse response = JaxRsTestUtil.get(new ResourceWithHeaders(), "/with-builder/headers/deferred");
+        assertThat(response.responseHeaders().get("custom_header")).isEqualTo("deferred");
+        assertThat(response.getOutp()).isEqualTo("\"body\"");
+    }
+
+    @Test
+    public void shouldReturnStatusFromResourceWithBuilder() {
+        MockHttpServerResponse response = JaxRsTestUtil.get(new ResourceWithHeaders(), "/with-builder/status");
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.MOVED_PERMANENTLY);
+        assertThat(response.getOutp()).isEqualTo("\"body\"");
+    }
+
+    @Test
+    public void shouldReturnDeferredStatusFromResourceWithBuilder() {
+        MockHttpServerResponse response = JaxRsTestUtil.get(new ResourceWithHeaders(), "/with-builder/status/deferred");
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.MOVED_PERMANENTLY);
         assertThat(response.getOutp()).isEqualTo("\"body\"");
     }
 
     @Path("/")
     public class ResourceWithHeaders {
         @GET
+        @Path("headers")
         public Observable<String> methodReturningHeaders() {
             Map<String, String> headers = new HashMap<>();
             headers.put("custom_header", "value");
@@ -42,13 +74,56 @@ public class ResponseDecoratorTest {
         }
 
         @GET
-        @Path("deferred")
+        @Path("headers/deferred")
         public Observable<String> methodReturningDeferredHeaders() {
             Map<String, String> headers = new HashMap<>();
-            return ResponseDecorator.withHeaders(defer(()->{
+            return ResponseDecorator.withHeaders(defer(() -> {
                 headers.put("custom_header", "deferred");
                 return just("body");
             }), headers);
+        }
+
+        @GET
+        @Path("with-builder/headers")
+        public Observable<String> methodReturningHeadersWithBuilder() {
+            Map<String, String> headers = new HashMap<>();
+            headers.put("custom_header", "value");
+            return ResponseDecorator.of(just("body"))
+                .withHeaders(headers)
+                .withHeader("custom_header2", "value2")
+                .build();
+        }
+
+        @GET
+        @Path("with-builder/headers/deferred")
+        public Observable<String> methodReturningDeferredHeadersWithBuilder() {
+            Map<String, String> headers = new HashMap<>();
+            return ResponseDecorator.of(defer(() -> {
+                headers.put("custom_header", "deferred");
+                return just("body");
+            }))
+                .withHeaders(headers)
+                .build();
+        }
+
+        @GET
+        @Path("with-builder/status")
+        public Observable<String> methodReturningStatusWithBuilder() {
+            return ResponseDecorator.of(just("body"))
+                .withStatus(HttpResponseStatus.MOVED_PERMANENTLY)
+                .build();
+        }
+
+        @GET
+        @Path("with-builder/status/deferred")
+        public Observable<String> methodReturningDeferredStatusWithBuilder() {
+            AtomicReference<HttpResponseStatus> status = new AtomicReference<>(HttpResponseStatus.OK);
+            return ResponseDecorator.of(defer(() -> {
+                status.set(HttpResponseStatus.MOVED_PERMANENTLY);
+                return just("body");
+            }))
+                .withStatus(status)
+                .build();
         }
     }
 }


### PR DESCRIPTION
Generalizes `ResponseDecorator` to use a `ResponseDecorations` object rather than just response headers. Uses a builder to construct the decorated `Observable`.

## Example usage (static values):
```java
return ResponseDecorator.of(just("body"))
    .withHeaders(Map.of("Location", "/somewhere-else"))
    .withStatus(HttpResponseStatus.MOVED_PERMANENTLY)
    .build();
```

## Example usage (dynamic values):

```java
Map<String, String> headers = new HashMap<>();
AtomicReference<HttpResponseStatus> status = new AtomicReference<>(null);

return ResponseDecorator.of(defer(() -> {
    headers.put("Location", "/somewhere-else");
    status.set(HttpResponseStatus.MOVED_PERMANENTLY);
    return just("body");
}))
    .withHeaders(headers)
    .withStatus(status)    
    .build();
```
