### PR TITLE
Allow streaming of response values by using the @Stream annotation on resource interfaces

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/JsonTokenBufferer.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/JsonTokenBufferer.java
@@ -1,0 +1,65 @@
+package se.fortnox.reactivewizard.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.async.ByteArrayFeeder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+import reactor.core.publisher.Flux;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class JsonTokenBufferer {
+
+    @Nonnull
+    public static Flux<TokenBuffer> buffer(
+        @Nonnull Flux<byte[]> byteFlux,
+        @Nonnull ObjectMapper objectMapper
+    ) {
+        final JsonParser parser;
+        try {
+            //noinspection BlockingMethodInNonBlockingContext
+            parser = objectMapper.getFactory().createNonBlockingByteArrayParser();
+        } catch (IOException e) {
+            return Flux.error(e);
+        }
+
+        final ByteArrayFeeder feeder = (ByteArrayFeeder)parser.getNonBlockingInputFeeder();
+
+        final AtomicInteger structDepth = new AtomicInteger(0);
+
+        final AtomicReference<TokenBuffer> currentBuffer = new AtomicReference<>(new TokenBuffer(parser));
+
+        return byteFlux.flatMap(chunk -> Flux.fromStream(() -> {
+            try {
+                final List<TokenBuffer> completedBuffers = new ArrayList<>();
+
+                feeder.feedInput(chunk, 0, chunk.length);
+
+                while (parser.nextToken() != JsonToken.NOT_AVAILABLE) {
+                    currentBuffer.get().copyCurrentEvent(parser);
+
+                    if (parser.currentToken().isStructStart()) {
+                        structDepth.incrementAndGet();
+                    } else if (parser.currentToken().isStructEnd()) {
+                        structDepth.decrementAndGet();
+                    }
+
+                    if (structDepth.get() == 0) {
+                        completedBuffers.add(currentBuffer.get());
+                        currentBuffer.set(new TokenBuffer(parser));
+                    }
+                }
+
+                return completedBuffers.stream();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }));
+    }
+}

--- a/client/src/test/java/se/fortnox/reactivewizard/client/JsonTokenBuffererTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/JsonTokenBuffererTest.java
@@ -1,0 +1,92 @@
+package se.fortnox.reactivewizard.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonTokenBuffererTest {
+    @Test
+    public void shallBeAbleToBufferWholeObjectsFromAChunkedStream() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectReader reader       = objectMapper.reader();
+
+        Flux<byte[]> stream = createChunkedJson();
+
+        List<AnObject> result = JsonTokenBufferer.buffer(stream, objectMapper)
+            .map(tokenBuffer -> {
+                try {
+                    return reader.readValue(tokenBuffer.asParser(), AnObject.class);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }).collectList().block();
+
+        assertThat(result.size()).isEqualTo(1000);
+        assertThat(result.get(0).getAn().getObject().get(2)).isEqualTo(3);
+        assertThat(result.get(999).getAn().getObject().get(2)).isEqualTo(3);
+    }
+
+    private Flux<byte[]> createChunkedJson() {
+        String json = "{\"an\":{\"object\":[1,2,3]}}";
+
+        byte[] longJson = IntStream.range(0, 1000)
+            .mapToObj(i -> json).collect(Collectors.joining())
+            .getBytes(StandardCharsets.UTF_8);
+
+        byte[][] partitioned = partition(longJson, 29);
+
+        return Flux.fromArray(partitioned);
+    }
+
+    private static byte[][] partition(byte[] input, int partitionSize) {
+        int partitionCount = (int)Math.ceil((double)input.length / (double)partitionSize);
+
+        byte[][] result = new byte[partitionCount][];
+
+        for (int i = 0; i < partitionCount; i++) {
+            boolean isLast    = (i == partitionCount - 1);
+            int     start     = i * partitionSize;
+            int     len       = !isLast ? partitionSize : input.length - start;
+            byte[]  partition = new byte[len];
+
+            System.arraycopy(input, start, partition, 0, len);
+
+            result[i] = partition;
+        }
+
+        return result;
+    }
+
+    private static class AnObject {
+        private Inner an;
+
+        public Inner getAn() {
+            return an;
+        }
+
+        public void setAn(Inner an) {
+            this.an = an;
+        }
+
+        private static class Inner {
+            private List<Integer> object;
+
+            public List<Integer> getObject() {
+                return object;
+            }
+
+            public void setObject(List<Integer> object) {
+                this.object = object;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Example declarations (from `HttpClientTest.java`)
```java
interface TestResource {
        @GET
        @Path("string-stream")
        @Produces("text/plain")
        @Stream
        Observable<String> streamingStrings();

        @GET
        @Path("pojo-stream")
        @Stream
        Observable<Pojo> streamingPojos();
}
```

Breaking changes:
* `HttpClient.parseResponse` now returns `Flux<?>` rather than `Mono<Object>`
* `HttpClient.deserialize` now returns `Flux<Object>` rather than `Mono<Object>`

Notes:
* This change also allows the client to parse streamed JSON objects even without the annotation, but the objects will only be outputted after the entire response has been read. Previously only the first object in the stream was made available.
* ~~JSON stream parsing assumes that the object boundaries precisely match the HTTP chunks. (This appears to be the case when streamed from an RW server.)~~
  * This was fixed in a38479fccb944a0ebdf4995b08b885886d3e41e8 with the `JsonTokenBufferer`
* It is not possible to stream "primitive" json values such as numbers since there are no delimiters in the streamed response.