### PR TITLE
Improve support for records

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/RestClientFactory.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/RestClientFactory.java
@@ -58,7 +58,9 @@ public class RestClientFactory implements AutoBindModule {
                 if (configClass.isAnnotationPresent(UseInResource.class)) {
                     for (Class resource : configClass.getAnnotation(UseInResource.class).value()) {
                         if (!resource.isInterface()) {
-                            throw new IllegalArgumentException(format("%s pointed out in UseInResource annotation must be an interface", resource));
+                            throw new IllegalArgumentException(format(
+                                "class %s pointed out in UseInResource annotation must be an interface",
+                                resource.getCanonicalName()));
                         }
                         httpClientConfigByResource.put(resource, configClass);
                     }

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -539,6 +539,15 @@ public class HttpClientTest {
     }
 
     @Test
+    public void shouldSupportBeanParamRecord() throws Exception {
+        HttpClient client = new HttpClient(new HttpClientConfig("localhost"));
+        Method     method = TestResource.class.getMethod("withBeanParamRecord", TestResource.SomeRecord.class);
+        TestResource.SomeRecord record = new TestResource.SomeRecord("value1", "value2");
+        String     path   = client.getPath(method, new Object[]{record}, new JaxRsMeta(method, null));
+        assertThat(path).isEqualTo("/hello/beanParamRecord?param2=value2&param1=value1");
+    }
+
+    @Test
     public void shouldSupportSingleSource() {
         DisposableServer server = startServer(HttpResponseStatus.OK, "\"OK\"");
 
@@ -1612,6 +1621,12 @@ public class HttpClientTest {
             }
         }
 
+        record SomeRecord(
+            @QueryParam("param1") String param1,
+            @QueryParam("param2") String param2
+        ) {
+        }
+
         @GET
         Single<String> getSingle();
 
@@ -1632,6 +1647,9 @@ public class HttpClientTest {
 
         @Path("beanParam")
         Observable<String> withBeanParam(@BeanParam Filters filters);
+
+        @Path("beanParamRecord")
+        Observable<String> withBeanParamRecord(@BeanParam SomeRecord record);
 
         @GET
         @Path("/multicookie")

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -1696,7 +1696,7 @@ public class HttpClientTest {
         Observable<Void> sendXml(Pojo pojo);
     }
 
-    class Wrapper {
+    static class Wrapper {
         private Pojo result;
 
         public Pojo getResult() {
@@ -1708,7 +1708,7 @@ public class HttpClientTest {
         }
     }
 
-    class Pojo {
+    static class Pojo {
         private String name;
 
         public String getName() {

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/config/src/main/java/se/fortnox/reactivewizard/config/ConfigReader.java
+++ b/config/src/main/java/se/fortnox/reactivewizard/config/ConfigReader.java
@@ -96,6 +96,7 @@ public class ConfigReader {
                 .map(Defaults::defaultValue)
                 .toArray();
 
+            //noinspection unchecked
             return (T)ctor.newInstance(args);
         }
     }

--- a/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
@@ -1,27 +1,11 @@
 package se.fortnox.reactivewizard.config;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
-import com.fasterxml.jackson.databind.node.JsonNodeCreator;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.MissingNode;
-import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.name.Names;
 import org.junit.Test;
 import org.yaml.snakeyaml.error.MarkedYAMLException;
 import se.fortnox.reactivewizard.binding.AutoBindModules;
-import se.fortnox.reactivewizard.test.TestUtil;
-
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
@@ -129,6 +113,17 @@ public class ConfigReaderTest {
     }
 
     @Test
+    public void shouldReplaceEnvPlaceholderWithEmptyStringIfEnvNotSetForRecord() {
+        TestConfigRecord testConfig = ConfigReader.fromFile("src/test/resources/testconfig-missing-value.yml", TestConfigRecord.class);
+        assertThat(testConfig.configWithEnvPlaceholder()).isNull();
+        assertThat(testConfig.configWithEnvPlaceholderInMiddle()).isEqualTo("beforeafter");
+
+        testConfig = ConfigReader.fromTree(ConfigReader.readTree("src/test/resources/testconfig-missing-value.yml"), TestConfigRecord.class);
+        assertThat(testConfig.configWithEnvPlaceholder()).isNull();
+        assertThat(testConfig.configWithEnvPlaceholderInMiddle()).isEqualTo("beforeafter");
+    }
+
+    @Test
     public void shouldReplaceMultipleEnvPlaceholders() {
         Map<String, String> env = new HashMap<>(System.getenv());
         env.put("HOST", "localhost");
@@ -162,6 +157,26 @@ public class ConfigReaderTest {
     public void shouldSupportEmptyConfigRecord() {
         EmptyConfigRecord testConfig = ConfigReader.fromFile("src/test/resources/testconfig.yml", EmptyConfigRecord.class);
         assertThat(testConfig).isNotNull();
+    }
+
+    @Test
+    public void shouldSupportConfigWithAllMissingValues() {
+        TestConfig testConfig = ConfigReader.fromFile("src/test/resources/testconfig-empty.yml", TestConfig.class);
+        assertThat(testConfig.getMyKey()).isNull();
+        assertThat(testConfig.getConfigWithEnvPlaceholder()).isNull();
+        assertThat(testConfig.getConfigWithEnvPlaceholderInMiddle()).isNull();
+        assertThat(testConfig.getConfigWithEnvPlaceholder2()).isNull();
+        assertThat(testConfig.getUrl()).isNull();
+    }
+
+    @Test
+    public void shouldSupportConfigRecordWithAllMissingValues() {
+        TestConfigRecord testConfig = ConfigReader.fromFile("src/test/resources/testconfig-empty.yml", TestConfigRecord.class);
+        assertThat(testConfig.myKey()).isNull();
+        assertThat(testConfig.configWithEnvPlaceholder()).isNull();
+        assertThat(testConfig.configWithEnvPlaceholderInMiddle()).isNull();
+        assertThat(testConfig.configWithEnvPlaceholder2()).isNull();
+        assertThat(testConfig.url()).isNull();
     }
 
     @Test

--- a/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/ConfigReaderTest.java
@@ -80,6 +80,15 @@ public class ConfigReaderTest {
     }
 
     @Test
+    public void shouldReadConfigRecordFromFile() {
+        TestConfigRecord testConfig = ConfigReader.fromFile("src/test/resources/testconfig.yml", TestConfigRecord.class);
+        assertThat(testConfig.myKey()).isEqualTo("myValue");
+
+        testConfig = ConfigReader.fromTree(ConfigReader.readTree("src/test/resources/testconfig.yml"), TestConfigRecord.class);
+        assertThat(testConfig.myKey()).isEqualTo("myValue");
+    }
+
+    @Test
     public void shouldReplaceEnvPlaceholderWithValue() {
         Map<String, String> env = new HashMap<>(System.getenv());
         env.put("CUSTOM_ENV_VAR", "hello");
@@ -149,6 +158,11 @@ public class ConfigReaderTest {
         assertThat(testConfig).isNotNull();
     }
 
+    @Test
+    public void shouldSupportEmptyConfigRecord() {
+        EmptyConfigRecord testConfig = ConfigReader.fromFile("src/test/resources/testconfig.yml", EmptyConfigRecord.class);
+        assertThat(testConfig).isNotNull();
+    }
 
     @Test
     public void shouldThrowExceptionForInvalidYaml() {

--- a/config/src/test/java/se/fortnox/reactivewizard/config/EmptyConfigRecord.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/EmptyConfigRecord.java
@@ -1,0 +1,5 @@
+package se.fortnox.reactivewizard.config;
+
+@Config("myEmptyConfig")
+public class EmptyConfigRecord {
+}

--- a/config/src/test/java/se/fortnox/reactivewizard/config/EmptyConfigRecord.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/EmptyConfigRecord.java
@@ -1,5 +1,5 @@
 package se.fortnox.reactivewizard.config;
 
 @Config("myEmptyConfig")
-public class EmptyConfigRecord {
+public record EmptyConfigRecord() {
 }

--- a/config/src/test/java/se/fortnox/reactivewizard/config/TestConfigRecord.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/TestConfigRecord.java
@@ -1,0 +1,11 @@
+package se.fortnox.reactivewizard.config;
+
+@Config("myTestConfig")
+public record TestConfigRecord(
+    String myKey,
+    String configWithEnvPlaceholder,
+    String configWithEnvPlaceholder2,
+    String configWithEnvPlaceholderInMiddle,
+    String url
+) {
+}

--- a/config/src/test/resources/testconfig-empty.yml
+++ b/config/src/test/resources/testconfig-empty.yml
@@ -1,0 +1,1 @@
+myTestConfig:

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DbResultSetDeserializerTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DbResultSetDeserializerTest.java
@@ -21,10 +21,10 @@ import static org.mockito.Mockito.when;
 
 public class DbResultSetDeserializerTest {
 
-    private ResultSet         rs        = mock(ResultSet.class);
-    private ResultSetMetaData meta      = mock(ResultSetMetaData.class);
-    private Array             jdbcArray = mock(Array.class);
-    private TimeZone          previousTimeZone;
+    private final ResultSet         rs        = mock(ResultSet.class);
+    private final ResultSetMetaData meta      = mock(ResultSetMetaData.class);
+    private final Array             jdbcArray = mock(Array.class);
+    private       TimeZone          previousTimeZone;
 
     @Before
     public void setup() {
@@ -215,6 +215,23 @@ public class DbResultSetDeserializerTest {
     }
 
     @Test
+    public void shouldDeserializeObjectRecord() throws SQLException {
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        when(meta.getColumnCount()).thenReturn(3);
+        when(meta.getColumnLabel(1)).thenReturn("sql_val");
+        when(meta.getColumnLabel(2)).thenReturn("my_bool");
+        when(meta.getColumnLabel(3)).thenReturn("enum_val");
+        when(rs.getString(1)).thenReturn("MyValue");
+        when(rs.getBoolean(2)).thenReturn(true);
+        when(rs.getString(3)).thenReturn("T3");
+        when(rs.getMetaData()).thenReturn(meta);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.sqlVal()).isEqualTo("MyValue");
+        assertThat(myTestObj.myBool()).isEqualTo(Boolean.TRUE);
+        Assertions.assertThat(myTestObj.enumVal()).isEqualTo(TestEnum.T3);
+    }
+
+    @Test
     public void shouldDeserializeChildObject() throws SQLException {
         DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObj.class);
         when(meta.getColumnCount()).thenReturn(1);
@@ -226,6 +243,17 @@ public class DbResultSetDeserializerTest {
     }
 
     @Test
+    public void shouldDeserializeChildObjectRecord() throws SQLException {
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        when(meta.getColumnCount()).thenReturn(1);
+        when(meta.getColumnLabel(1)).thenReturn("child.sql_val");
+        when(rs.getString(1)).thenReturn("MyChildValue");
+        when(rs.getMetaData()).thenReturn(meta);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.child().sqlVal()).isEqualTo("MyChildValue");
+    }
+
+    @Test
     public void shouldDeserializeGrandChildObject() throws SQLException {
         DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObj.class);
         when(meta.getColumnCount()).thenReturn(1);
@@ -234,6 +262,17 @@ public class DbResultSetDeserializerTest {
         when(rs.getMetaData()).thenReturn(meta);
         DbTestObj myTestObj = (DbTestObj)des.deserialize(rs);
         assertThat(myTestObj.getChild().getChild().getSqlVal()).isEqualTo("MyChildValue");
+    }
+
+    @Test
+    public void shouldDeserializeGrandChildObjectRecord() throws SQLException {
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        when(meta.getColumnCount()).thenReturn(1);
+        when(meta.getColumnLabel(1)).thenReturn("child.child.sql_val");
+        when(rs.getString(1)).thenReturn("MyChildValue");
+        when(rs.getMetaData()).thenReturn(meta);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.child().child().sqlVal()).isEqualTo("MyChildValue");
     }
 
     @Test
@@ -256,6 +295,19 @@ public class DbResultSetDeserializerTest {
         when(rs.getMetaData()).thenReturn(meta);
         DbTestObj myTestObj = (DbTestObj)des.deserialize(rs);
         assertThat(myTestObj.getValueWithoutGetter()).isEqualTo("MyNonGettableChildValue");
+    }
+
+    @Test
+    public void shouldIgnoreUnknownColumnsForRecords() throws SQLException {
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        when(meta.getColumnCount()).thenReturn(2);
+        when(meta.getColumnLabel(1)).thenReturn("sql_val");
+        when(meta.getColumnLabel(2)).thenReturn("non_existing_prop");
+        when(rs.getString(1)).thenReturn("MyValue");
+        when(rs.getString(2)).thenReturn("ValueForNonExistingProp");
+        when(rs.getMetaData()).thenReturn(meta);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.sqlVal()).isEqualTo("MyValue");
     }
 
     @Test
@@ -283,6 +335,17 @@ public class DbResultSetDeserializerTest {
     }
 
     @Test
+    public void shouldDeserializeObjectRecordWithDoubleProperty() throws SQLException {
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        when(meta.getColumnCount()).thenReturn(1);
+        when(meta.getColumnLabel(1)).thenReturn("double_val");
+        when(rs.getDouble(1)).thenReturn(63.53d);
+        when(rs.getMetaData()).thenReturn(meta);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.doubleVal()).isEqualTo(63.53d);
+    }
+
+    @Test
     public void shouldDeserializeObjectWithNullValues() throws SQLException {
         DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObj.class);
         when(meta.getColumnCount()).thenReturn(3);
@@ -301,6 +364,24 @@ public class DbResultSetDeserializerTest {
     }
 
     @Test
+    public void shouldDeserializeObjectRecordWithNullValues() throws SQLException {
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        when(meta.getColumnCount()).thenReturn(3);
+        when(meta.getColumnLabel(1)).thenReturn("sql_val");
+        when(meta.getColumnLabel(2)).thenReturn("my_bool");
+        when(meta.getColumnLabel(3)).thenReturn("enum_val");
+        when(rs.getString(1)).thenReturn(null);
+        when(rs.getBoolean(2)).thenReturn(false);
+        when(rs.getString(3)).thenReturn(null);
+        when(rs.getMetaData()).thenReturn(meta);
+        when(rs.wasNull()).thenReturn(true);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.sqlVal()).isNull();
+        assertThat(myTestObj.myBool()).isNull();
+        Assertions.assertThat(myTestObj.enumVal()).isNull();
+    }
+
+    @Test
     public void shouldDeserializeCollectionAsJson() throws SQLException {
         DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObj.class);
         when(meta.getColumnCount()).thenReturn(1);
@@ -312,6 +393,20 @@ public class DbResultSetDeserializerTest {
         assertThat(myTestObj.getListOfStrings()).isNotNull().hasSize(2);
         assertThat(myTestObj.getListOfStrings().get(0)).isEqualTo("one");
         assertThat(myTestObj.getListOfStrings().get(1)).isEqualTo("two");
+    }
+
+    @Test
+    public void shouldDeserializeRecordCollectionAsJson() throws SQLException {
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        when(meta.getColumnCount()).thenReturn(1);
+        when(meta.getColumnLabel(1)).thenReturn("list_of_strings");
+        when(rs.getString(1)).thenReturn("[\"one\",\"two\"]");
+        when(rs.getMetaData()).thenReturn(meta);
+        when(rs.wasNull()).thenReturn(false);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.listOfStrings()).isNotNull().hasSize(2);
+        assertThat(myTestObj.listOfStrings().get(0)).isEqualTo("one");
+        assertThat(myTestObj.listOfStrings().get(1)).isEqualTo("two");
     }
 
     @Test
@@ -331,6 +426,22 @@ public class DbResultSetDeserializerTest {
     }
 
     @Test
+    public void shouldDeserializeRecordCollectionAsArray() throws SQLException {
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        when(meta.getColumnCount()).thenReturn(1);
+        when(meta.getColumnType(1)).thenReturn(Types.ARRAY);
+        when(meta.getColumnLabel(1)).thenReturn("list_of_strings");
+        when(jdbcArray.getArray()).thenReturn(new Object[]{"one", "two"});
+        when(rs.getArray(1)).thenReturn(jdbcArray);
+        when(rs.getMetaData()).thenReturn(meta);
+        when(rs.wasNull()).thenReturn(false);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.listOfStrings()).isNotNull().hasSize(2);
+        assertThat(myTestObj.listOfStrings().get(0)).isEqualTo("one");
+        assertThat(myTestObj.listOfStrings().get(1)).isEqualTo("two");
+    }
+
+    @Test
     public void shouldDeserializeListOfEnums() throws SQLException {
         when(meta.getColumnCount()).thenReturn(1);
         when(meta.getColumnLabel(1)).thenReturn("list_of_enums");
@@ -342,6 +453,20 @@ public class DbResultSetDeserializerTest {
         DbTestObj myTestObj = (DbTestObj)des.deserialize(rs);
         assertThat(myTestObj.getListOfEnums()).hasSize(2);
         assertThat(myTestObj.getListOfEnums().get(0)).isInstanceOf(TestEnum.class);
+    }
+
+    @Test
+    public void shouldDeserializeRecordListOfEnums() throws SQLException {
+        when(meta.getColumnCount()).thenReturn(1);
+        when(meta.getColumnLabel(1)).thenReturn("list_of_enums");
+        when(rs.getMetaData()).thenReturn(meta);
+        when(rs.getString(1)).thenReturn("[\"T1\", \"T2\"]");
+        when(rs.wasNull()).thenReturn(false);
+
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.listOfEnums()).hasSize(2);
+        assertThat(myTestObj.listOfEnums().get(0)).isInstanceOf(TestEnum.class);
     }
 
     @Test
@@ -360,6 +485,21 @@ public class DbResultSetDeserializerTest {
     }
 
     @Test
+    public void shouldDeserializeRecordListOfObjects() throws SQLException {
+        when(meta.getColumnCount()).thenReturn(1);
+        when(meta.getColumnLabel(1)).thenReturn("list_of_objects");
+        when(rs.getMetaData()).thenReturn(meta);
+        when(rs.getString(1)).thenReturn("[{}, {}]");
+        when(rs.wasNull()).thenReturn(false);
+
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.listOfObjects()).hasSize(2);
+        assertThat(myTestObj.listOfObjects().get(0)).isInstanceOf(DbTestObjRecord.class);
+        assertThat(myTestObj.listOfObjects().get(1)).isInstanceOf(DbTestObjRecord.class);
+    }
+
+    @Test
     public void shouldDeserializeJsonObject() throws SQLException {
         when(meta.getColumnCount()).thenReturn(1);
         when(meta.getColumnLabel(1)).thenReturn("child");
@@ -375,6 +515,21 @@ public class DbResultSetDeserializerTest {
     }
 
     @Test
+    public void shouldDeserializeJsonObjectRecord() throws SQLException {
+        when(meta.getColumnCount()).thenReturn(1);
+        when(meta.getColumnLabel(1)).thenReturn("child");
+        when(meta.getColumnType(1)).thenReturn(Types.OTHER);
+        when(rs.getMetaData()).thenReturn(meta);
+
+        when(rs.getString(1)).thenReturn("{}");
+        when(rs.wasNull()).thenReturn(false);
+
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.child()).isNotNull();
+    }
+
+    @Test
     public void shouldDeserializeNullCollectionAsNull() throws SQLException {
         DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObj.class);
         when(meta.getColumnCount()).thenReturn(1);
@@ -384,6 +539,18 @@ public class DbResultSetDeserializerTest {
         when(rs.wasNull()).thenReturn(true);
         DbTestObj myTestObj = (DbTestObj)des.deserialize(rs);
         assertThat(myTestObj.getListOfStrings()).isNull();
+    }
+
+    @Test
+    public void shouldDeserializeRecordNullCollectionAsNull() throws SQLException {
+        DbResultSetDeserializer des = new DbResultSetDeserializer(DbTestObjRecord.class);
+        when(meta.getColumnCount()).thenReturn(1);
+        when(meta.getColumnLabel(1)).thenReturn("list_of_strings");
+        when(rs.getString(1)).thenReturn(null);
+        when(rs.getMetaData()).thenReturn(meta);
+        when(rs.wasNull()).thenReturn(true);
+        DbTestObjRecord myTestObj = (DbTestObjRecord)des.deserialize(rs);
+        assertThat(myTestObj.listOfStrings()).isNull();
     }
 
     @Test
@@ -412,7 +579,7 @@ public class DbResultSetDeserializerTest {
         assertThat(myTestObj.getBytes()).isEqualTo("hello".getBytes());
     }
 
-    private ObjectAssert thenDeserialized(Class<?> cls) throws SQLException {
+    private ObjectAssert<?> thenDeserialized(Class<?> cls) throws SQLException {
         DbResultSetDeserializer des = new DbResultSetDeserializer(cls);
         when(meta.getColumnCount()).thenReturn(1);
         when(meta.getColumnLabel(1)).thenReturn("colname");

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DbTestObjRecord.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DbTestObjRecord.java
@@ -1,0 +1,18 @@
+package se.fortnox.reactivewizard.db;
+
+import se.fortnox.reactivewizard.db.DbResultSetDeserializerTest.TestEnum;
+
+import java.util.List;
+
+public record DbTestObjRecord(
+    String sqlVal,
+    Boolean myBool,
+    TestEnum enumVal,
+    List<String> listOfStrings,
+    List<TestEnum> listOfEnums,
+    List<DbTestObjRecord> listOfObjects,
+    Double doubleVal,
+    DbTestObjRecord child,
+    byte[] bytes
+) {
+}

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/ParameterizedQueryTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/ParameterizedQueryTest.java
@@ -40,6 +40,15 @@ public class ParameterizedQueryTest {
     }
 
     @Test
+    public void shouldResolveNestedRecordParametersFromQuery() throws SQLException {
+        dao.nestedRecordParameters("myid", new MyTestParamRecord("testName")).toBlocking().singleOrDefault(null);
+
+        verify(db.getConnection()).prepareStatement("SELECT * FROM foo WHERE id=? AND name=?");
+        verify(db.getPreparedStatement()).setObject(1, "myid");
+        verify(db.getPreparedStatement()).setObject(2, "testName");
+    }
+
+    @Test
     public void shouldResolveParametersWithoutAnnotationFromQuery() throws SQLException {
         dao.missingParamNames("myid", "myname").toBlocking().singleOrDefault(null);
 
@@ -256,6 +265,9 @@ public class ParameterizedQueryTest {
         @Query("SELECT * FROM foo WHERE id=:id AND name=:test.name")
         Observable<String> nestedParameters(String id, MyTestParam test);
 
+        @Query("SELECT * FROM foo WHERE id=:id AND name=:test.name")
+        Observable<String> nestedRecordParameters(String id, MyTestParamRecord test);
+
         @Query("SELECT * FROM foo WHERE id=? AND name=?")
         Observable<String> unnamedParameters(String id, String name);
 
@@ -365,9 +377,12 @@ public class ParameterizedQueryTest {
         }
     }
 
-    public class MyTestParam {
+    public static class MyTestParam {
         public String getName() {
             return "testName";
         }
+    }
+
+    public record MyTestParamRecord(String name) {
     }
 }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/annotated/BeanParamResolver.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/annotated/BeanParamResolver.java
@@ -3,7 +3,6 @@ package se.fortnox.reactivewizard.jaxrs.params.annotated;
 import com.fasterxml.jackson.core.type.TypeReference;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import rx.Observable;
 import se.fortnox.reactivewizard.jaxrs.JaxRsRequest;
 import se.fortnox.reactivewizard.jaxrs.params.ParamResolver;
 import se.fortnox.reactivewizard.jaxrs.params.ParamResolverFactories;
@@ -11,27 +10,24 @@ import se.fortnox.reactivewizard.json.Types;
 import se.fortnox.reactivewizard.util.ReflectionUtil;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.lang.reflect.Parameter;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static java.util.Arrays.asList;
-import static rx.Observable.merge;
-import static se.fortnox.reactivewizard.util.rx.FirstThen.first;
 
 public class BeanParamResolver<T> extends AnnotatedParamResolver<T> {
 
-    private final Supplier<T> instantiator;
-    private final List<BiFunction<T, JaxRsRequest, Mono<T>>> fieldSetter;
+    private final Function<JaxRsRequest, Mono<T>> resolver;
 
-    public BeanParamResolver(Supplier<T> instantiator, List<BiFunction<T, JaxRsRequest, Mono<T>>> setters) {
+    public BeanParamResolver(Function<JaxRsRequest, Mono<T>> resolver) {
         super(null, null, null);
-        this.instantiator = instantiator;
-        this.fieldSetter = setters;
+        this.resolver = resolver;
     }
 
     @Override
@@ -41,12 +37,7 @@ public class BeanParamResolver<T> extends AnnotatedParamResolver<T> {
 
     @Override
     public Mono<T> resolve(JaxRsRequest request) {
-        T instance = instantiator.get();
-        List<Mono<T>> runSetters = new ArrayList<>(fieldSetter.size());
-        for (int i = 0; i < fieldSetter.size(); i++) {
-            runSetters.add(fieldSetter.get(i).apply(instance, request));
-        }
-        return Flux.merge(runSetters).count().map(count -> instance);
+        return resolver.apply(request);
     }
 
     public static class Factory implements AnnotatedParamResolverFactory {
@@ -59,7 +50,17 @@ public class BeanParamResolver<T> extends AnnotatedParamResolver<T> {
 
         @Override
         public <T> ParamResolver<T> create(TypeReference<T> paramType, Annotation annotation, String defaultValue) {
-            Class<T> beanParamCls = (Class<T>) paramType.getType();
+            //noinspection unchecked
+            Class<T> beanParamCls = (Class<T>)paramType.getType();
+
+            if (beanParamCls.isRecord()) {
+                return createForRecord(beanParamCls);
+            } else {
+                return createForClass(beanParamCls);
+            }
+        }
+
+        private <T> BeanParamResolver<T> createForClass(Class<T> beanParamCls) {
             Supplier<T> instantiator = ReflectionUtil.instantiator(beanParamCls);
 
             List<BiFunction<T, JaxRsRequest, Mono<T>>> fieldSetters = new ArrayList<>();
@@ -74,10 +75,10 @@ public class BeanParamResolver<T> extends AnnotatedParamResolver<T> {
                         ParamResolver<?> fieldResolver = paramResolverFactory.create(fieldType, fieldAnnotation, defaultFieldValue);
 
                         Optional<BiConsumer<T, Object>> setterOptional = ReflectionUtil.setter(beanParamCls, field.getName());
-                        if (!setterOptional.isPresent()) {
+                        if (setterOptional.isEmpty()) {
                             continue;
                         }
-                        BiConsumer setter = setterOptional.get();
+                        BiConsumer<T, Object> setter = setterOptional.get();
                         fieldSetters.add((instance, request) -> {
                             Mono<?> fieldValue = fieldResolver.resolve(request);
                             return fieldValue.map(value -> {
@@ -88,7 +89,66 @@ public class BeanParamResolver<T> extends AnnotatedParamResolver<T> {
                     }
                 }
             }
-            return new BeanParamResolver<T>(instantiator, fieldSetters);
+
+            Function<JaxRsRequest, Mono<T>> resolver = (JaxRsRequest request) -> {
+                T instance = instantiator.get();
+                List<Mono<T>> runSetters = new ArrayList<>(fieldSetters.size());
+                for (var setter : fieldSetters) {
+                    runSetters.add(setter.apply(instance, request));
+                }
+                return Flux.merge(runSetters).count().map(count -> instance);
+            };
+
+            return new BeanParamResolver<>(resolver);
+        }
+
+        private <T> BeanParamResolver<T> createForRecord(Class<T> beanParamCls) {
+            var constructor = beanParamCls.getDeclaredConstructors()[0];
+
+            var constructorParams = constructor.getParameters();
+            var constructorArgumentResolvers = new ArrayList<ParamResolver<?>>(constructorParams.length);
+
+            for (Parameter constructorParam : constructorParams) {
+                Annotation annotation = null;
+                AnnotatedParamResolverFactory paramResolverFactory = null;
+
+                for (var ann : constructorParam.getAnnotations()) {
+                    paramResolverFactory = annotatedParamResolverFactories.get(ann.annotationType());
+                    if (paramResolverFactory != null) {
+                        annotation = ann;
+                        break;
+                    }
+                }
+
+                if (paramResolverFactory == null) {
+                    throw new IllegalArgumentException("Missing Param annotation for @BeanParam record parameter");
+                }
+
+                var paramType = Types.toReference(constructorParam.getParameterizedType());
+                var defaultValue = ParamResolverFactories.findDefaultValue(List.of(annotation));
+                var paramResolver = paramResolverFactory.create(paramType, annotation, defaultValue);
+
+                constructorArgumentResolvers.add(paramResolver);
+            }
+
+            Function<JaxRsRequest, Mono<T>> resolver = (JaxRsRequest request) -> {
+                var argMonos = constructorArgumentResolvers.stream()
+                    .map(it -> it.resolve(request))
+                    .toArray(Mono<?>[]::new);
+
+                return Flux.concat(argMonos)
+                    .reduce(new ArrayList<>(), (acc, next) -> { acc.add(next); return acc; })
+                    .map(args -> {
+                        try {
+                            //noinspection unchecked
+                            return (T)(constructor.newInstance(args.toArray()));
+                        } catch (Throwable e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+            };
+
+            return new BeanParamResolver<>(resolver);
         }
 
         private static List<Field> getAllDeclaredFields(Class<?> type) {

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/annotated/BeanParamResolver.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/annotated/BeanParamResolver.java
@@ -10,10 +10,10 @@ import se.fortnox.reactivewizard.json.Types;
 import se.fortnox.reactivewizard.util.ReflectionUtil;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.Parameter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -144,7 +144,8 @@ public class BeanParamResolver<T> extends AnnotatedParamResolver<T> {
 
                 return Flux.concat(argsFlux)
                     .reduce(new ArrayList<>(), (acc, next) -> {
-                        acc.add(next); return acc;
+                        acc.add(next);
+                        return acc;
                     })
                     .map(args -> {
                         try {

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -728,12 +728,17 @@ public class JaxRsResourceTest {
 
     @Test
     public void shouldAcceptBeanParamRecord() {
-        assertThat(get(service, "/test/acceptsBeanParamRecord?name=foo&age=3&items=1,2").getOutp()).isEqualTo("\"foo - 3 2\"");
+        assertThat(get(service, "/test/acceptsBeanParamRecord?name=foo&age=3&items=1,2").getOutp()).isEqualTo("\"ParamEntityRecord[name=foo, age=3, items=[1, 2]]\"");
     }
 
     @Test
     public void shouldAcceptBeanParamRecordWithDefaults() {
-        assertThat(get(service, "/test/acceptsBeanParamRecord?name=foo&items=1,2").getOutp()).isEqualTo("\"foo - 123 2\"");
+        assertThat(get(service, "/test/acceptsBeanParamRecord?name=foo&items=1,2").getOutp()).isEqualTo("\"ParamEntityRecord[name=foo, age=123, items=[1, 2]]\"");
+    }
+
+    @Test
+    public void shouldAcceptBeanParamRecordWithDefaultsAndMissingFields() {
+        assertThat(get(service, "/test/acceptsBeanParamRecord").getOutp()).isEqualTo("\"ParamEntityRecord[name=null, age=123, items=null]\"");
     }
 
     @Test
@@ -1394,7 +1399,7 @@ public class JaxRsResourceTest {
 
         @Override
         public Observable<String> acceptsBeanParamRecord(ParamEntityRecord beanParam) {
-            return just(String.format("%s - %d %d", beanParam.name(), beanParam.age(), beanParam.items().size()));
+            return just(beanParam.toString());
         }
 
         @Override

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -721,6 +721,11 @@ public class JaxRsResourceTest {
     }
 
     @Test
+    public void shouldAcceptBeanParamRecord() {
+        assertThat(get(service, "/test/acceptsBeanParamRecord?name=foo&age=3&items=1,2").getOutp()).isEqualTo("\"foo - 3 2\"");
+    }
+
+    @Test
     public void shouldAcceptBeanParamInherited() {
         assertThat(get(service, "/test/acceptsBeanParamInherited?name=foo&age=3&items=1,2&inherited=YES").getOutp()).isEqualTo("\"foo - 3 2 - YES\"");
     }
@@ -1057,6 +1062,10 @@ public class JaxRsResourceTest {
         @GET
         Observable<String> acceptsBeanParam(@BeanParam ParamEntity beanParam);
 
+        @Path("acceptsBeanParamRecord")
+        @GET
+        Observable<String> acceptsBeanParamRecord(@BeanParam ParamEntityRecord beanParam);
+
         @Path("acceptsBeanParamInherited")
         @GET
         Observable<String> acceptsBeanParamInherited(@BeanParam InheritedParamEntity beanParam);
@@ -1370,6 +1379,11 @@ public class JaxRsResourceTest {
         @Override
         public Observable<String> acceptsBeanParam(ParamEntity beanParam) {
             return just(String.format("%s - %d %d", beanParam.getName(), beanParam.getAge(), beanParam.getItems().size()));
+        }
+
+        @Override
+        public Observable<String> acceptsBeanParamRecord(ParamEntityRecord beanParam) {
+            return just(String.format("%s - %d %d", beanParam.name(), beanParam.age(), beanParam.items().size()));
         }
 
         @Override

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -650,6 +650,7 @@ public class JaxRsResourceTest {
     public void shouldAcceptBodyForPut() {
         assertThat(body(put(service, "/test/acceptBodyPut", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
     }
+
     @Test
     public void shouldAcceptBodyForPutRecord() {
         assertThat(body(put(service, "/test/acceptBodyPutRecord", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
@@ -721,8 +722,18 @@ public class JaxRsResourceTest {
     }
 
     @Test
+    public void shouldAcceptBeanParamWithDefaults() {
+        assertThat(get(service, "/test/acceptsBeanParam?name=foo&items=1,2").getOutp()).isEqualTo("\"foo - 123 2\"");
+    }
+
+    @Test
     public void shouldAcceptBeanParamRecord() {
         assertThat(get(service, "/test/acceptsBeanParamRecord?name=foo&age=3&items=1,2").getOutp()).isEqualTo("\"foo - 3 2\"");
+    }
+
+    @Test
+    public void shouldAcceptBeanParamRecordWithDefaults() {
+        assertThat(get(service, "/test/acceptsBeanParamRecord?name=foo&items=1,2").getOutp()).isEqualTo("\"foo - 123 2\"");
     }
 
     @Test

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -456,7 +456,7 @@ public class JaxRsResourceTest {
         assertBadRequest(post(service, "/test/jsonParam", "{hej}"), expectedBodyRegex1);
 
         String expectedBodyRegex2 = "{\"id\":\".*\",\"error\":\"invalidjson\"," +
-            "\"message\":\"Cannot deserialize value of type `int` from String \\\\\"nan\\\\\": not a valid Integer value\"}";
+            "\"message\":\"Cannot deserialize value of type `int` from String \\\\\"nan\\\\\": not a valid `int` value\"}";
         assertBadRequest(post(service, "/test/jsonParam", "{\"age\": \"nan\"}"), expectedBodyRegex2);
 
         String expectedBodyRegex3 = "{\"id\":\".*\",\"error\":\"invalidjson\"," +

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -647,23 +647,42 @@ public class JaxRsResourceTest {
     }
 
     @Test
-    public void shouldAcceptBodyForPut() throws Exception {
+    public void shouldAcceptBodyForPut() {
         assertThat(body(put(service, "/test/acceptBodyPut", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
+    }
+    @Test
+    public void shouldAcceptBodyForPutRecord() {
+        assertThat(body(put(service, "/test/acceptBodyPutRecord", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
     }
 
     @Test
-    public void shouldAcceptBodyForPost() throws Exception {
+    public void shouldAcceptBodyForPost() {
         assertThat(body(post(service, "/test/acceptBodyPost", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
     }
 
     @Test
-    public void shouldAcceptBodyForPatch() throws Exception {
+    public void shouldAcceptBodyForPostRecord() {
+        assertThat(body(post(service, "/test/acceptBodyPostRecord", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
+    }
+
+    @Test
+    public void shouldAcceptBodyForPatch() {
         assertThat(body(patch(service, "/test/acceptBodyPatch", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
     }
 
     @Test
-    public void shouldAcceptBodyForDelete() throws Exception {
+    public void shouldAcceptBodyForPatchRecord() {
+        assertThat(body(patch(service, "/test/acceptBodyPatchRecord", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
+    }
+
+    @Test
+    public void shouldAcceptBodyForDelete() {
         assertThat(body(delete(service, "/test/acceptBodyDelete", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
+    }
+
+    @Test
+    public void shouldAcceptBodyForDeleteRecord() {
+        assertThat(body(delete(service, "/test/acceptBodyDeleteRecord", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
     }
 
     @Test
@@ -981,17 +1000,33 @@ public class JaxRsResourceTest {
         @PUT
         Observable<ParamEntity> acceptBodyPut(ParamEntity paramEntity);
 
+        @Path("acceptBodyPutRecord")
+        @PUT
+        Observable<ParamEntityRecord> acceptBodyPutRecord(ParamEntityRecord paramEntity);
+
         @Path("acceptBodyPost")
         @POST
         Observable<ParamEntity> acceptBodyPost(ParamEntity paramEntity);
+
+        @Path("acceptBodyPostRecord")
+        @POST
+        Observable<ParamEntityRecord> acceptBodyPostRecord(ParamEntityRecord paramEntity);
 
         @Path("acceptBodyPatch")
         @PATCH
         Observable<ParamEntity> acceptBodyPatch(ParamEntity paramEntity);
 
+        @Path("acceptBodyPatchRecord")
+        @PATCH
+        Observable<ParamEntityRecord> acceptBodyPatchRecord(ParamEntityRecord paramEntity);
+
         @Path("acceptBodyDelete")
         @DELETE
         Observable<ParamEntity> acceptBodyDelete(ParamEntity paramEntity);
+
+        @Path("acceptBodyDeleteRecord")
+        @DELETE
+        Observable<ParamEntityRecord> acceptBodyDeleteRecord(ParamEntityRecord paramEntity);
 
         @Path("acceptsQueryList")
         @GET
@@ -1260,7 +1295,17 @@ public class JaxRsResourceTest {
         }
 
         @Override
+        public Observable<ParamEntityRecord> acceptBodyPutRecord(ParamEntityRecord paramEntity) {
+            return just(paramEntity);
+        }
+
+        @Override
         public Observable<ParamEntity> acceptBodyPost(ParamEntity paramEntity) {
+            return just(paramEntity);
+        }
+
+        @Override
+        public Observable<ParamEntityRecord> acceptBodyPostRecord(ParamEntityRecord paramEntity) {
             return just(paramEntity);
         }
 
@@ -1270,7 +1315,17 @@ public class JaxRsResourceTest {
         }
 
         @Override
+        public Observable<ParamEntityRecord> acceptBodyPatchRecord(ParamEntityRecord paramEntity) {
+            return just(paramEntity);
+        }
+
+        @Override
         public Observable<ParamEntity> acceptBodyDelete(ParamEntity paramEntity) {
+            return just(paramEntity);
+        }
+
+        @Override
+        public Observable<ParamEntityRecord> acceptBodyDeleteRecord(ParamEntityRecord paramEntity) {
             return just(paramEntity);
         }
 

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ParamEntity.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ParamEntity.java
@@ -1,5 +1,6 @@
 package se.fortnox.reactivewizard.jaxrs;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
 import java.util.List;
 
@@ -9,6 +10,7 @@ public class ParamEntity {
     private String name;
 
     @QueryParam("age")
+    @DefaultValue("123")
     private int age;
 
     @QueryParam("items")

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ParamEntityRecord.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ParamEntityRecord.java
@@ -1,11 +1,12 @@
 package se.fortnox.reactivewizard.jaxrs;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
 import java.util.List;
 
 public record ParamEntityRecord(
     @QueryParam("name") String name,
-    @QueryParam("age") int age,
+    @QueryParam("age") @DefaultValue("123") int age,
     @QueryParam("items") List<String> items
 ) {
 }

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ParamEntityRecord.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ParamEntityRecord.java
@@ -1,10 +1,11 @@
 package se.fortnox.reactivewizard.jaxrs;
 
+import javax.ws.rs.QueryParam;
 import java.util.List;
 
 public record ParamEntityRecord(
-    String name,
-    int age,
-    List<String> items
+    @QueryParam("name") String name,
+    @QueryParam("age") int age,
+    @QueryParam("items") List<String> items
 ) {
 }

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ParamEntityRecord.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/ParamEntityRecord.java
@@ -1,0 +1,10 @@
+package se.fortnox.reactivewizard.jaxrs;
+
+import java.util.List;
+
+public record ParamEntityRecord(
+    String name,
+    int age,
+    List<String> items
+) {
+}

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/json/src/main/java/se/fortnox/reactivewizard/json/JsonDeserializerFactory.java
+++ b/json/src/main/java/se/fortnox/reactivewizard/json/JsonDeserializerFactory.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 
 import javax.inject.Inject;
 import java.lang.reflect.Type;
@@ -22,9 +24,11 @@ public class JsonDeserializerFactory {
     }
 
     public JsonDeserializerFactory() {
-        this(new ObjectMapper()
-            .findAndRegisterModules()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false));
+        this(JsonMapper.builder()
+            .findAndAddModules()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .defaultDateFormat(new StdDateFormat().withColonInTimeZone(false)) // Preserve behavior prior to Jackson 2.11
+            .build());
     }
 
     public <T> Function<String, T> createDeserializer(TypeReference<T> typeReference) {

--- a/json/src/main/java/se/fortnox/reactivewizard/json/JsonSerializerFactory.java
+++ b/json/src/main/java/se/fortnox/reactivewizard/json/JsonSerializerFactory.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import com.fasterxml.jackson.databind.ser.SerializerFactory;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 
 import javax.inject.Inject;
 import java.lang.reflect.Type;
@@ -21,14 +21,16 @@ public class JsonSerializerFactory {
     @Inject
     public JsonSerializerFactory(ObjectMapper mapper) {
         this.mapper = mapper.setSerializerFactory(mapper.getSerializerFactory()
-                .withSerializerModifier(new LambdaSerializerModifier()));
+            .withSerializerModifier(new LambdaSerializerModifier()));
     }
 
     public JsonSerializerFactory() {
-        this(new ObjectMapper()
-            .findAndRegisterModules()
+        this(JsonMapper.builder()
+            .findAndAddModules()
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false));
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .defaultDateFormat(new StdDateFormat().withColonInTimeZone(false)) // Preserve behavior prior to Jackson 2.11
+            .build());
     }
 
     public <T> Function<T, String> createStringSerializer(TypeReference<T> paramType) {

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
@@ -62,6 +62,10 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
+            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,8 @@
 
         <netty.version>4.1.65.Final</netty.version>
         <rxjava.version>1.3.8</rxjava.version>
-        <jackson.version>2.10.2</jackson.version>
-        <jackson-databind.version>2.10.2</jackson-databind.version>
-        <snakeyaml.version>1.24</snakeyaml.version>
+        <jackson.version>2.12.5</jackson.version>
+        <snakeyaml.version>1.27</snakeyaml.version> <!-- Matches version in jackson-dataformat-yaml:2.12.5 -->
         <slf4j.version>1.7.28</slf4j.version>
         <guice.version>5.0.1</guice.version>
         <guava.version>30.1.1-jre</guava.version>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson-databind.version}</version>
+			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>

--- a/validation/src/test/java/se/fortnox/reactivewizard/validation/ConfigValidationTest.java
+++ b/validation/src/test/java/se/fortnox/reactivewizard/validation/ConfigValidationTest.java
@@ -26,9 +26,31 @@ public class ConfigValidationTest {
     }
 
     @Test
+    public void shouldReturnErrorForInvalidConfigRecord() {
+        Injector injector = TestInjector.create("src/test/resources/invalidconfig.yml");
+        try {
+            injector.getInstance(ValidatedConfigRecord.class);
+            fail("expected exception");
+        } catch (ProvisionException e) {
+            assertThat(e.getCause()).isInstanceOf(ValidationFailedException.class);
+            assertThat(((ValidationFailedException)e.getCause()).getFields()[0].getField()).isEqualTo("mykey");
+        }
+    }
+
+    @Test
     public void shouldReturnConfigForCorrectConfig() {
         Injector injector = TestInjector.create("src/test/resources/correctconfig.yml");
         injector.getInstance(ValidatedConfig.class);
+    }
+
+    @Test
+    public void shouldReturnConfigForCorrectConfigRecord() {
+        Injector injector = TestInjector.create("src/test/resources/correctconfig.yml");
+        var config = injector.getInstance(ValidatedConfigRecord.class);
+
+        assertThat(config.mykey()).isEqualTo("myvalue");
+        assertThat(config.anInt()).isEqualTo(0);
+        assertThat(config.aNestedConfig()).isNull();
     }
 
     @Config("myconfig")
@@ -43,5 +65,13 @@ public class ConfigValidationTest {
         public void setMykey(String mykey) {
             this.mykey = mykey;
         }
+    }
+
+    @Config("myconfig")
+    public record ValidatedConfigRecord(
+        @NotEmpty String mykey,
+        int anInt,
+        ValidatedConfig aNestedConfig
+    ) {
     }
 }

--- a/validation/src/test/java/se/fortnox/reactivewizard/validation/ValidationExamples.java
+++ b/validation/src/test/java/se/fortnox/reactivewizard/validation/ValidationExamples.java
@@ -361,6 +361,20 @@ public class ValidationExamples {
         }});
     }
 
+    record PeriodRecord(
+        @NotNull Date startDate,
+        Date endDate) {
+    }
+
+    /**
+     * Records are also validated
+     */
+    @Test
+    public void shouldFailIfStartDateIsNullInRecord() {
+        assertValidationException(callService(new PeriodRecord(null, null)),
+            "{'id':'.*','error':'validation','fields':[{'field':'startDate','error':'validation.notnull'}]}");
+    }
+
     private static <T> Runnable callService(T inputClass) {
         AcceptingService<T> service = mock(AcceptingService.class);
         AcceptingService<T> validatedService = ValidatingProxy.create(AcceptingService.class, service, new ValidatorUtil());


### PR DESCRIPTION
# Updates Jackson to 2.12.5.

* Had a breaking change in datetime offset serialization that needed to be configured for previous behavior
* Additional configuration needed in internal framework

# Adds/verifies support for records in ...

* [x] `ConfigReader`
* [x] JSON request/response
* [x] DAO params/deserialization
* [x] `ValidatingProxy` 
* [x] `@BeanParam`