### PR TITLE
Rewrite creation of transactions

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
@@ -138,4 +138,8 @@ public class DbProxy implements InvocationHandler {
     public DatabaseConfig getDatabaseConfig() {
         return databaseConfig;
     }
+
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ObservableStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ObservableStatementFactory.java
@@ -11,15 +11,13 @@ import se.fortnox.reactivewizard.db.paging.PagingOutput;
 import se.fortnox.reactivewizard.db.statement.DbStatementFactory;
 import se.fortnox.reactivewizard.db.statement.Statement;
 import se.fortnox.reactivewizard.db.transactions.DaoObservable;
-import se.fortnox.reactivewizard.db.transactions.Transaction;
-import se.fortnox.reactivewizard.db.transactions.TransactionStatement;
 import se.fortnox.reactivewizard.metrics.Metrics;
 import se.fortnox.reactivewizard.util.DebugUtil;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static java.lang.String.format;
 import static rx.Observable.error;
@@ -58,23 +56,13 @@ public class ObservableStatementFactory {
     }
 
     public Observable<Object> create(Object[] args, ConnectionProvider connectionProvider) {
-        AtomicReference<TransactionStatement> transactionHolder = new AtomicReference<>();
-        Statement dbStatement = statementFactory.create(args);
-
+        Supplier<Statement> statementSupplier = () -> statementFactory.create(args);
         Observable<Object> result = Observable.unsafeCreate(subscription -> {
             try {
+                Statement dbStatement = statementSupplier.get();
                 dbStatement.setSubscriber(subscription);
 
-                TransactionStatement transactionStatement = transactionHolder.get();
-                if (transactionStatement != null) {
-                    Transaction transaction = transactionStatement.getTransaction();
-                    transactionStatement.markStatementSubscribed(dbStatement);
-                    if (transaction.isAllSubscribed()) {
-                        scheduleWorker(subscription, transaction::execute);
-                    }
-                } else {
-                    scheduleWorker(subscription, () -> executeStatement(dbStatement, connectionProvider));
-                }
+                scheduleWorker(subscription, () -> executeStatement(dbStatement, connectionProvider));
             } catch (Exception e) {
                 if (!subscription.isUnsubscribed()) {
                     subscription.onError(e);
@@ -91,10 +79,10 @@ public class ObservableStatementFactory {
         }
 
         result = pagingOutput.apply(result, args);
-        result = metrics.measure(result, time -> logSlowQuery(transactionHolder.get(), time, args));
+        result = metrics.measure(result, this::logSlowQuery);
         result = result.onBackpressureBuffer(RECORD_BUFFER_SIZE);
 
-        return new DaoObservable<>(result, transactionHolder, dbStatement);
+        return new DaoObservable<>(result, statementSupplier);
     }
 
     private void scheduleWorker(Subscriber<?> subscription, Action0 action) {
@@ -112,8 +100,8 @@ public class ObservableStatementFactory {
         });
     }
 
-    private void logSlowQuery(TransactionStatement transactionStatement, long time, Object[] args) {
-        if (transactionStatement == null && time > config.getSlowQueryLogThreshold()) {
+    private void logSlowQuery(long time) {
+        if (time > config.getSlowQueryLogThreshold()) {
             LOG.warn(format("Slow query: %s\ntime: %d", statementFactory, time));
         }
     }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/AbstractDbStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/AbstractDbStatementFactory.java
@@ -30,19 +30,18 @@ public abstract class AbstractDbStatementFactory implements DbStatementFactory {
     }
 
     @Override
-    public Statement create(Object[] args, Subscriber subscriber) {
-        return new StatementImpl(args, subscriber, parameterizedQuery);
+    public Statement create(Object[] args) {
+        return new StatementImpl(args, parameterizedQuery);
     }
 
     private class StatementImpl implements Statement {
 
         private final Object[]           args;
-        private final Subscriber         subscriber;
         private final ParameterizedQuery parameterizedQuery;
+        private       Subscriber         subscriber;
 
-        private StatementImpl(Object[] args, Subscriber subscriber, ParameterizedQuery parameterizedQuery) {
+        private StatementImpl(Object[] args, ParameterizedQuery parameterizedQuery) {
             this.args = args;
-            this.subscriber = subscriber;
             this.parameterizedQuery = parameterizedQuery;
         }
 
@@ -71,12 +70,21 @@ public abstract class AbstractDbStatementFactory implements DbStatementFactory {
 
         @Override
         public void onCompleted() {
-            subscriber.onCompleted();
+            if (subscriber != null) {
+                subscriber.onCompleted();
+            }
         }
 
         @Override
         public void onError(Throwable throwable) {
-            subscriber.onError(throwable);
+            if (subscriber != null) {
+                subscriber.onError(throwable);
+            }
+        }
+
+        @Override
+        public void setSubscriber(Subscriber<?> subscriber) {
+            this.subscriber = subscriber;
         }
     }
 

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/DbStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/DbStatementFactory.java
@@ -1,8 +1,6 @@
 package se.fortnox.reactivewizard.db.statement;
 
-import rx.Subscriber;
-
 public interface DbStatementFactory {
 
-    Statement create(Object[] args, Subscriber subscriber);
+    Statement create(Object[] args);
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/SelectStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/SelectStatementFactory.java
@@ -24,7 +24,9 @@ public class SelectStatementFactory extends AbstractDbStatementFactory {
             parameterizedQuery.addParameters(args, statement);
             try (ResultSet resultSet = statement.executeQuery()) {
                 while (resultSet.next()) {
-                    subscriber.onNext(deserializer.deserialize(resultSet));
+                    if (subscriber != null) {
+                        subscriber.onNext(deserializer.deserialize(resultSet));
+                    }
                 }
             }
         }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/Statement.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/Statement.java
@@ -1,5 +1,7 @@
 package se.fortnox.reactivewizard.db.statement;
 
+import rx.Subscriber;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -35,4 +37,10 @@ public interface Statement {
      * @return <code>true</code> if the specified statement might be added to the batch.
      */
     boolean sameBatch(Statement statement);
+
+    /**
+     * Set the subscriber
+     * @param subscriber the subscriber
+     */
+    void setSubscriber(Subscriber<?> subscriber);
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementExecutorReturningCountFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementExecutorReturningCountFactory.java
@@ -35,7 +35,9 @@ public class UpdateStatementExecutorReturningCountFactory extends AbstractUpdate
 
     protected void executed(int count, Subscriber subscriber) throws SQLException {
         ensureMinimumReached(count);
-        subscriber.onNext(count);
+        if (subscriber != null) {
+            subscriber.onNext(count);
+        }
     }
 
     @Override

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementReturningGeneratedKeyFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementReturningGeneratedKeyFactory.java
@@ -28,9 +28,11 @@ public class UpdateStatementReturningGeneratedKeyFactory extends AbstractUpdateS
         try (PreparedStatement statement = parameterizedQuery.createStatement(connection, args, Statement.RETURN_GENERATED_KEYS)) {
             parameterizedQuery.addParameters(args, statement);
             ensureMinimumReached(statement.executeUpdate());
-            try (ResultSet resultSet = statement.getGeneratedKeys()) {
-                while (resultSet.next()) {
-                    subscriber.onNext((GeneratedKey)() -> deserializer.deserialize(resultSet));
+            if (subscriber != null) {
+                try (ResultSet resultSet = statement.getGeneratedKeys()) {
+                    while (resultSet.next()) {
+                        subscriber.onNext((GeneratedKey)() -> deserializer.deserialize(resultSet));
+                    }
                 }
             }
         }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementReturningGeneratedKeyFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementReturningGeneratedKeyFactory.java
@@ -28,9 +28,9 @@ public class UpdateStatementReturningGeneratedKeyFactory extends AbstractUpdateS
         try (PreparedStatement statement = parameterizedQuery.createStatement(connection, args, Statement.RETURN_GENERATED_KEYS)) {
             parameterizedQuery.addParameters(args, statement);
             ensureMinimumReached(statement.executeUpdate());
-            if (subscriber != null) {
-                try (ResultSet resultSet = statement.getGeneratedKeys()) {
-                    while (resultSet.next()) {
+            try (ResultSet resultSet = statement.getGeneratedKeys()) {
+                while (resultSet.next()) {
+                    if (subscriber != null) {
                         subscriber.onNext((GeneratedKey)() -> deserializer.deserialize(resultSet));
                     }
                 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoObservable.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoObservable.java
@@ -10,12 +10,10 @@ import java.util.function.Supplier;
 public class DaoObservable<T> extends Observable<T> {
     private final Observable<T> result;
     private final Supplier<Statement> statementSupplier;
-    private Action0 onTransactionCompleted;
+    private final Action0 onTransactionCompleted;
 
     public DaoObservable(Observable<T> result, Supplier<Statement> statementSupplier) {
-        super(result::unsafeSubscribe);
-        this.result = result;
-        this.statementSupplier = statementSupplier;
+        this(result, statementSupplier, null);
     }
 
     private DaoObservable(Observable<T> result, Supplier<Statement> statementSupplier, Action0 onTransactionCompleted) {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoObservable.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoObservable.java
@@ -3,6 +3,7 @@ package se.fortnox.reactivewizard.db.transactions;
 import rx.Observable;
 import rx.functions.Action0;
 import rx.functions.Action1;
+import se.fortnox.reactivewizard.db.statement.Statement;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -10,11 +11,15 @@ public class DaoObservable<T> extends Observable<T> {
 
     private final AtomicReference<TransactionStatement> transactionStatementRef;
     private final Observable<T>                         result;
+    private final Statement                             statement;
 
-    public DaoObservable(Observable<T> result, AtomicReference<TransactionStatement> transactionStatementRef) {
+    public DaoObservable(Observable<T> result,
+        AtomicReference<TransactionStatement> transactionStatementRef,
+        Statement statement) {
         super(result::unsafeSubscribe);
         this.result = result;
         this.transactionStatementRef = transactionStatementRef;
+        this.statement = statement;
     }
 
     void setTransactionStatement(TransactionStatement transactionStatement) {
@@ -22,19 +27,27 @@ public class DaoObservable<T> extends Observable<T> {
     }
 
     public DaoObservable<T> onTerminate(Action0 onTerminate) {
-        return new DaoObservable<>(result.doOnTerminate(onTerminate), transactionStatementRef);
+        return new DaoObservable<>(result.doOnTerminate(onTerminate), transactionStatementRef, statement);
     }
 
     public DaoObservable<T> onSubscribe(Action0 onSubscribe) {
-        return new DaoObservable<>(result.doOnSubscribe(onSubscribe), transactionStatementRef);
+        return new DaoObservable<>(result.doOnSubscribe(onSubscribe), transactionStatementRef, statement);
     }
 
     public DaoObservable<T> onError(Action1<Throwable> onError) {
-        return new DaoObservable<>(result.doOnError(onError), transactionStatementRef);
+        return new DaoObservable<>(result.doOnError(onError), transactionStatementRef, statement);
     }
 
     public DaoObservable<T> doOnTransactionCompleted(Action0 onCompleted) {
-        return new DaoObservable<>(result.doOnCompleted(onCompleted), transactionStatementRef);
+        return new DaoObservable<>(result.doOnCompleted(onCompleted), transactionStatementRef, statement);
+    }
+
+    public TransactionStatement getTransactionStatement() {
+        return transactionStatementRef.get();
+    }
+
+    public Statement getStatement() {
+        return statement;
     }
 }
 

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoObservable.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoObservable.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 public class DaoObservable<T> extends Observable<T> {
     private final Observable<T> result;
     private final Supplier<Statement> statementSupplier;
+    private Action0 onTransactionCompleted;
 
     public DaoObservable(Observable<T> result, Supplier<Statement> statementSupplier) {
         super(result::unsafeSubscribe);
@@ -17,16 +18,33 @@ public class DaoObservable<T> extends Observable<T> {
         this.statementSupplier = statementSupplier;
     }
 
+    private DaoObservable(Observable<T> result, Supplier<Statement> statementSupplier, Action0 onTransactionCompleted) {
+        super(result::unsafeSubscribe);
+        this.result = result;
+        this.statementSupplier = statementSupplier;
+        this.onTransactionCompleted = onTransactionCompleted;
+    }
+
     public DaoObservable<T> onTerminate(Action0 onTerminate) {
-        return new DaoObservable<>(result.doOnTerminate(onTerminate), statementSupplier);
+        return new DaoObservable<>(result.doOnTerminate(onTerminate), statementSupplier, onTransactionCompleted);
     }
 
     public DaoObservable<T> onSubscribe(Action0 onSubscribe) {
-        return new DaoObservable<>(result.doOnSubscribe(onSubscribe), statementSupplier);
+        return new DaoObservable<>(result.doOnSubscribe(onSubscribe), statementSupplier, onTransactionCompleted);
     }
 
     public DaoObservable<T> onError(Action1<Throwable> onError) {
-        return new DaoObservable<>(result.doOnError(onError), statementSupplier);
+        return new DaoObservable<>(result.doOnError(onError), statementSupplier, onTransactionCompleted);
+    }
+
+    public DaoObservable<T> doOnTransactionCompleted(Action0 onCompleted) {
+        return new DaoObservable<>(result.doOnCompleted(onCompleted), statementSupplier, onCompleted);
+    }
+
+    public void onTransactionCompleted() {
+        if (onTransactionCompleted != null) {
+            onTransactionCompleted.call();
+        }
     }
 
     public Supplier<Statement> getStatementSupplier() {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoObservable.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoObservable.java
@@ -5,49 +5,32 @@ import rx.functions.Action0;
 import rx.functions.Action1;
 import se.fortnox.reactivewizard.db.statement.Statement;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 public class DaoObservable<T> extends Observable<T> {
+    private final Observable<T> result;
+    private final Supplier<Statement> statementSupplier;
 
-    private final AtomicReference<TransactionStatement> transactionStatementRef;
-    private final Observable<T>                         result;
-    private final Statement                             statement;
-
-    public DaoObservable(Observable<T> result,
-        AtomicReference<TransactionStatement> transactionStatementRef,
-        Statement statement) {
+    public DaoObservable(Observable<T> result, Supplier<Statement> statementSupplier) {
         super(result::unsafeSubscribe);
         this.result = result;
-        this.transactionStatementRef = transactionStatementRef;
-        this.statement = statement;
-    }
-
-    void setTransactionStatement(TransactionStatement transactionStatement) {
-        transactionStatementRef.set(transactionStatement);
+        this.statementSupplier = statementSupplier;
     }
 
     public DaoObservable<T> onTerminate(Action0 onTerminate) {
-        return new DaoObservable<>(result.doOnTerminate(onTerminate), transactionStatementRef, statement);
+        return new DaoObservable<>(result.doOnTerminate(onTerminate), statementSupplier);
     }
 
     public DaoObservable<T> onSubscribe(Action0 onSubscribe) {
-        return new DaoObservable<>(result.doOnSubscribe(onSubscribe), transactionStatementRef, statement);
+        return new DaoObservable<>(result.doOnSubscribe(onSubscribe), statementSupplier);
     }
 
     public DaoObservable<T> onError(Action1<Throwable> onError) {
-        return new DaoObservable<>(result.doOnError(onError), transactionStatementRef, statement);
+        return new DaoObservable<>(result.doOnError(onError), statementSupplier);
     }
 
-    public DaoObservable<T> doOnTransactionCompleted(Action0 onCompleted) {
-        return new DaoObservable<>(result.doOnCompleted(onCompleted), transactionStatementRef, statement);
-    }
-
-    public TransactionStatement getTransactionStatement() {
-        return transactionStatementRef.get();
-    }
-
-    public Statement getStatement() {
-        return statement;
+    public Supplier<Statement> getStatementSupplier() {
+        return statementSupplier;
     }
 }
 

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactions.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactions.java
@@ -9,8 +9,9 @@ public interface DaoTransactions {
      * this method, when all of the Observables has been subscribed.
      *
      * @param daoCalls dao calls to run as on single transaction
-     *
+     * @deprecated Use executeTransaction instead.
      */
+    @Deprecated
     <T> void createTransaction(Observable<T>... daoCalls);
 
     /**
@@ -19,7 +20,9 @@ public interface DaoTransactions {
      * this method, when all of the Observables has been subscribed.
      *
      * @param daoCalls dao calls to run as on single transaction
+     * @deprecated Use executeTransaction instead.
      */
+    @Deprecated
     <T> void createTransaction(Iterable<Observable<T>> daoCalls);
 
     /**

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactions.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactions.java
@@ -3,27 +3,6 @@ package se.fortnox.reactivewizard.db.transactions;
 import rx.Observable;
 
 public interface DaoTransactions {
-    /**
-     * Creates a transaction for the passed dao-calls, which means that they
-     * will be run as one single transaction, in the order they are passed to
-     * this method, when all of the Observables has been subscribed.
-     *
-     * @param daoCalls dao calls to run as on single transaction
-     * @deprecated Use executeTransaction instead.
-     */
-    @Deprecated
-    <T> void createTransaction(Observable<T>... daoCalls);
-
-    /**
-     * Creates a transaction for the passed dao-calls, which means that they
-     * will be run as one single transaction, in the order they are passed to
-     * this method, when all of the Observables has been subscribed.
-     *
-     * @param daoCalls dao calls to run as on single transaction
-     * @deprecated Use executeTransaction instead.
-     */
-    @Deprecated
-    <T> void createTransaction(Iterable<Observable<T>> daoCalls);
 
     /**
      * Creates and executes a transaction for the passed dao-calls.

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
@@ -53,14 +53,8 @@ public class DaoTransactionsImpl implements DaoTransactions {
             }
         }
 
-        Transaction<T> transaction = new Transaction<T>(connectionProvider, daoCalls);
+        Transaction<T> transaction = new Transaction<>(connectionProvider, daoCalls);
         for (Observable<T> statement : daoCalls) {
-            if (!(statement instanceof DaoObservable)) {
-                String statementString  = statement == null ? "null" : statement.getClass().toString();
-                String exceptionMessage = "All parameters to createTransaction needs to be observables coming from a Dao-class. Statement was %s.";
-                throw new RuntimeException(String.format(exceptionMessage, statementString));
-            }
-
             transaction.add((DaoObservable<T>) statement);
         }
 

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
@@ -1,20 +1,32 @@
 package se.fortnox.reactivewizard.db.transactions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import rx.Observable;
+import rx.Scheduler;
+import se.fortnox.reactivewizard.db.ConnectionProvider;
+import se.fortnox.reactivewizard.db.DbProxy;
 
 import javax.inject.Inject;
 
 import static java.util.Arrays.asList;
 import static rx.Observable.empty;
-import static rx.Observable.merge;
 
 public class DaoTransactionsImpl implements DaoTransactions {
+    private static final Logger LOG = LoggerFactory.getLogger(DaoTransactionsImpl.class);
+
+    private final ConnectionProvider connectionProvider;
+    private final DbProxy            dbProxy;
+
     @Inject
-    public DaoTransactionsImpl() {
+    public DaoTransactionsImpl(ConnectionProvider connectionProvider, DbProxy dbProxy) {
+        this.connectionProvider = connectionProvider;
+        this.dbProxy = dbProxy;
     }
 
     @Override
     public <T> void createTransaction(Observable<T>... daoCalls) {
+        LOG.info("createTransaction used. Remove and rewrite transaction when sure those are no longer used.");
         if (daoCalls == null || daoCalls.length == 0) {
             return;
         }
@@ -24,10 +36,15 @@ public class DaoTransactionsImpl implements DaoTransactions {
 
     @Override
     public <T> void createTransaction(Iterable<Observable<T>> daoCalls) {
+        LOG.info("createTransaction used. Remove and rewrite transaction when sure those are no longer used.");
         if (daoCalls == null || !daoCalls.iterator().hasNext()) {
             return;
         }
 
+        createTransactionWithStatements(daoCalls);
+    }
+
+    public <T> Transaction<T> createTransactionWithStatements(Iterable<Observable<T>> daoCalls) {
         for (Observable statement : daoCalls) {
             if (!(statement instanceof DaoObservable)) {
                 String statementString  = statement == null ? "null" : statement.getClass().toString();
@@ -36,10 +53,18 @@ public class DaoTransactionsImpl implements DaoTransactions {
             }
         }
 
-        Transaction transaction = new Transaction(daoCalls);
-        for (Observable statement : daoCalls) {
-            transaction.add((DaoObservable)statement);
+        Transaction<T> transaction = new Transaction<T>(connectionProvider, daoCalls);
+        for (Observable<T> statement : daoCalls) {
+            if (!(statement instanceof DaoObservable)) {
+                String statementString  = statement == null ? "null" : statement.getClass().toString();
+                String exceptionMessage = "All parameters to createTransaction needs to be observables coming from a Dao-class. Statement was %s.";
+                throw new RuntimeException(String.format(exceptionMessage, statementString));
+            }
+
+            transaction.add((DaoObservable<T>) statement);
         }
+
+        return transaction;
     }
 
     @Override
@@ -47,8 +72,38 @@ public class DaoTransactionsImpl implements DaoTransactions {
         if (!daoCalls.iterator().hasNext()) {
             return empty();
         }
-        createTransaction(daoCalls);
-        return merge(daoCalls).ignoreElements().cast(Void.class);
+        Transaction<T> transaction = createTransactionWithStatements(daoCalls);
+
+        for (Observable<T> statement : daoCalls) {
+            DaoObservable<T> daoCall = (DaoObservable<T>) statement;
+            TransactionStatement transactionStatement = daoCall.getTransactionStatement();
+            transactionStatement.markStatementSubscribed(daoCall.getStatement());
+            transaction.markSubscribed(transactionStatement);
+        }
+
+
+        return Observable.unsafeCreate(subscription -> {
+            transaction.onTransactionFailed(throwable -> {
+                if (!subscription.isUnsubscribed()) {
+                    subscription.onError(throwable);
+                }
+            });
+
+            Scheduler.Worker worker = dbProxy.getScheduler().createWorker();
+            worker.schedule(() -> {
+                try {
+                    transaction.execute();
+                    subscription.onCompleted();
+                } catch (Exception e) {
+                    if (!subscription.isUnsubscribed()) {
+                        subscription.onError(e);
+                    }
+                } finally {
+                    worker.unsubscribe();
+                }
+            });
+        });
+
     }
 
     @Override

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
@@ -48,6 +48,7 @@ public class DaoTransactionsImpl implements DaoTransactions {
                 try {
                     Transaction<T> transaction = createTransactionWithStatements(daoCallsCopy);
                     transaction.execute();
+                    daoCalls.forEach(daoCall -> ((DaoObservable<T>) daoCall).onTransactionCompleted());
                     subscription.onCompleted();
                 } catch (Exception e) {
                     if (!subscription.isUnsubscribed()) {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
@@ -1,20 +1,20 @@
 package se.fortnox.reactivewizard.db.transactions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Scheduler;
 import se.fortnox.reactivewizard.db.ConnectionProvider;
 import se.fortnox.reactivewizard.db.DbProxy;
+import se.fortnox.reactivewizard.db.statement.Statement;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static rx.Observable.empty;
 
 public class DaoTransactionsImpl implements DaoTransactions {
-    private static final Logger LOG = LoggerFactory.getLogger(DaoTransactionsImpl.class);
-
     private final ConnectionProvider connectionProvider;
     private final DbProxy            dbProxy;
 
@@ -24,68 +24,29 @@ public class DaoTransactionsImpl implements DaoTransactions {
         this.dbProxy = dbProxy;
     }
 
-    @Override
-    public <T> void createTransaction(Observable<T>... daoCalls) {
-        LOG.info("createTransaction used. Remove and rewrite transaction when sure those are no longer used.");
-        if (daoCalls == null || daoCalls.length == 0) {
-            return;
+    private  <T> Transaction<T> createTransactionWithStatements(Collection<Observable<T>> daoCalls) {
+        List<TransactionStatement> transactionStatements = new ArrayList<>();
+        for (Observable<T> daoCall : daoCalls) {
+            Statement statement = ((DaoObservable<T>) daoCall).getStatementSupplier().get();
+            TransactionStatement transactionStatement = new TransactionStatement(statement);
+            transactionStatements.add(transactionStatement);
         }
 
-        createTransaction(asList(daoCalls));
-    }
-
-    @Override
-    public <T> void createTransaction(Iterable<Observable<T>> daoCalls) {
-        LOG.info("createTransaction used. Remove and rewrite transaction when sure those are no longer used.");
-        if (daoCalls == null || !daoCalls.iterator().hasNext()) {
-            return;
-        }
-
-        createTransactionWithStatements(daoCalls);
-    }
-
-    public <T> Transaction<T> createTransactionWithStatements(Iterable<Observable<T>> daoCalls) {
-        for (Observable statement : daoCalls) {
-            if (!(statement instanceof DaoObservable)) {
-                String statementString  = statement == null ? "null" : statement.getClass().toString();
-                String exceptionMessage = "All parameters to createTransaction needs to be observables coming from a Dao-class. Statement was %s.";
-                throw new RuntimeException(String.format(exceptionMessage, statementString));
-            }
-        }
-
-        Transaction<T> transaction = new Transaction<>(connectionProvider, daoCalls);
-        for (Observable<T> statement : daoCalls) {
-            transaction.add((DaoObservable<T>) statement);
-        }
-
-        return transaction;
+        return new Transaction<>(connectionProvider, transactionStatements);
     }
 
     @Override
     public <T> Observable<Void> executeTransaction(Iterable<Observable<T>> daoCalls) {
-        if (!daoCalls.iterator().hasNext()) {
+        if (daoCalls == null || !daoCalls.iterator().hasNext()) {
             return empty();
         }
-        Transaction<T> transaction = createTransactionWithStatements(daoCalls);
 
-        for (Observable<T> statement : daoCalls) {
-            DaoObservable<T> daoCall = (DaoObservable<T>) statement;
-            TransactionStatement transactionStatement = daoCall.getTransactionStatement();
-            transactionStatement.markStatementSubscribed(daoCall.getStatement());
-            transaction.markSubscribed(transactionStatement);
-        }
-
-
+        Collection<Observable<T>> daoCallsCopy = copyAndVerifyDaoObservables(daoCalls);
         return Observable.unsafeCreate(subscription -> {
-            transaction.onTransactionFailed(throwable -> {
-                if (!subscription.isUnsubscribed()) {
-                    subscription.onError(throwable);
-                }
-            });
-
             Scheduler.Worker worker = dbProxy.getScheduler().createWorker();
             worker.schedule(() -> {
                 try {
+                    Transaction<T> transaction = createTransactionWithStatements(daoCallsCopy);
                     transaction.execute();
                     subscription.onCompleted();
                 } catch (Exception e) {
@@ -97,7 +58,21 @@ public class DaoTransactionsImpl implements DaoTransactions {
                 }
             });
         });
+    }
 
+    private <T> Collection<Observable<T>> copyAndVerifyDaoObservables(Iterable<Observable<T>> daoCalls) {
+        List<Observable<T>> daoCallsCopy = new ArrayList<>();
+        for (Observable<T> statement : daoCalls) {
+            if (!(statement instanceof DaoObservable)) {
+                String statementString  = statement == null ? "null" : statement.getClass().toString();
+                String exceptionMessage = "All parameters to createTransaction needs to be observables coming from a Dao-class. Statement was %s.";
+                throw new RuntimeException(String.format(exceptionMessage, statementString));
+            }
+
+            daoCallsCopy.add(statement);
+        }
+
+        return daoCallsCopy;
     }
 
     @Override

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
@@ -60,6 +60,11 @@ public class DaoTransactionsImpl implements DaoTransactions {
         });
     }
 
+    @Override
+    public <T> Observable<Void> executeTransaction(Observable<T>... daoCalls) {
+        return executeTransaction(asList(daoCalls));
+    }
+
     private <T> Collection<Observable<T>> copyAndVerifyDaoObservables(Iterable<Observable<T>> daoCalls) {
         List<Observable<T>> daoCallsCopy = new ArrayList<>();
         for (Observable<T> statement : daoCalls) {
@@ -73,10 +78,5 @@ public class DaoTransactionsImpl implements DaoTransactions {
         }
 
         return daoCallsCopy;
-    }
-
-    @Override
-    public <T> Observable<Void> executeTransaction(Observable<T>... daoCalls) {
-        return executeTransaction(asList(daoCalls));
     }
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/Transaction.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/Transaction.java
@@ -27,7 +27,7 @@ public class Transaction<T> {
         try {
             executeTransaction(connection);
             closeConnection(connection);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             rollback(connection);
             closeConnection(connection);
             throw e;

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/Transaction.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/Transaction.java
@@ -2,54 +2,28 @@ package se.fortnox.reactivewizard.db.transactions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import rx.Observable;
 import se.fortnox.reactivewizard.db.ConnectionProvider;
-import se.fortnox.reactivewizard.db.statement.Statement;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedList;
-import java.util.Set;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 public class Transaction<T> {
 
     private static final Logger                                      log                 = LoggerFactory.getLogger(Transaction.class);
     private final        ConnectionProvider                          connectionProvider;
-    private final        Iterable<Observable<T>>                     daoCalls;
-    private final        ConcurrentLinkedQueue<TransactionStatement> statementsToExecute = new ConcurrentLinkedQueue<>();
-    private final        Set<TransactionStatement>                   statementsToSubscribe = new HashSet<>();
+    private final        ConcurrentLinkedQueue<TransactionStatement> statementsToExecute;
     private final        AtomicBoolean                               waitingForExecution = new AtomicBoolean(true);
-    private              Consumer<Throwable>                         transactionFailed;
 
-    Transaction(ConnectionProvider connectionProvider, Iterable<Observable<T>> daoCalls) {
-        this.daoCalls = daoCalls;
+    Transaction(ConnectionProvider connectionProvider, List<TransactionStatement> statements) {
         this.connectionProvider = connectionProvider;
+        this.statementsToExecute = new ConcurrentLinkedQueue<>(statements);
     }
 
-    TransactionStatement add(DaoObservable daoObservable) {
-        TransactionStatement transactionStatement = new TransactionStatement(this);
-        daoObservable.setTransactionStatement(transactionStatement);
-        statementsToExecute.add(transactionStatement);
-        statementsToSubscribe.add(transactionStatement);
-        return transactionStatement;
-    }
-
-
-    public void execute() {
-        if (!isAllSubscribed()) {
-            // all DaoObservables have not been subscribed yet
-            throw new RuntimeException("Transaction execute called before all Observables were subscribed. This should never happen.");
-        }
-
-        if (isModifiedAfterCreation()) {
-            throw new RuntimeException("Transaction cannot be modified after creation.");
-        }
-
+    public void execute() throws Exception {
         if (!waitingForExecution.compareAndSet(true, false)) {
             return;
         }
@@ -58,11 +32,11 @@ public class Transaction<T> {
         try {
             executeTransaction(connection);
             closeConnection(connection);
-            allCompleted();
-        } catch (Throwable e) {
+        } catch (Exception e) {
             rollback(connection);
             closeConnection(connection);
-            allFailed(e);
+            waitingForExecution.compareAndSet(false, true);
+            throw e;
         }
     }
 
@@ -99,63 +73,11 @@ public class Transaction<T> {
         }
     }
 
-    private void allFailed(Throwable throwable) {
-        waitingForExecution.set(true);
-        for (TransactionStatement transactionStatement : statementsToExecute) {
-            final Statement statement = transactionStatement.getStatement();
-            try {
-                transactionStatement.removeStatement();
-                statement.onError(throwable);
-            } catch (Exception onErrorException) {
-                log.error("onError threw exception", onErrorException);
-            }
-        }
-
-        if (transactionFailed != null) {
-            transactionFailed.accept(throwable);
-        }
-    }
-
     private void rollback(Connection connection) {
         try {
             connection.rollback();
         } catch (Exception rollbackException) {
             log.error("Rollback failed", rollbackException);
         }
-    }
-
-    private void allCompleted() {
-        for (TransactionStatement statement : statementsToExecute) {
-            try {
-                statement.getStatement().onCompleted();
-            } catch (Exception onCompletedException) {
-                log.error("onCompleted threw exception", onCompletedException);
-            }
-        }
-    }
-
-    private boolean isModifiedAfterCreation() {
-        int daoCallsSize = 0;
-        if (daoCalls instanceof Collection) {
-            daoCallsSize = ((Collection<?>)daoCalls).size();
-        } else {
-            for (Observable<T> daoCall : daoCalls) {
-                daoCallsSize++;
-            }
-        }
-
-        return daoCallsSize != statementsToExecute.size();
-    }
-
-    public boolean isAllSubscribed() {
-        return statementsToSubscribe.isEmpty();
-    }
-
-    public void markSubscribed(TransactionStatement transactionStatement) {
-        statementsToSubscribe.remove(transactionStatement);
-    }
-
-    public void onTransactionFailed(Consumer<Throwable> transactionFailed) {
-        this.transactionFailed = transactionFailed;
     }
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/Transaction.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/Transaction.java
@@ -54,10 +54,6 @@ public class Transaction<T> {
             return;
         }
 
-        if (connectionProvider == null) {
-            throw new RuntimeException("No Connection Provider found!");
-        }
-
         Connection connection = connectionProvider.get();
         try {
             executeTransaction(connection);
@@ -157,10 +153,6 @@ public class Transaction<T> {
 
     public void markSubscribed(TransactionStatement transactionStatement) {
         statementsToSubscribe.remove(transactionStatement);
-    }
-
-    public void markAllSubscribed() {
-        statementsToSubscribe.clear();
     }
 
     public void onTransactionFailed(Consumer<Throwable> transactionFailed) {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/TransactionStatement.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/TransactionStatement.java
@@ -4,36 +4,16 @@ import se.fortnox.reactivewizard.db.statement.Statement;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class TransactionStatement implements Batchable {
-    private final AtomicReference<Statement> statement;
-    private final Transaction                transaction;
+    private final Statement statement;
 
-    public TransactionStatement(Transaction transaction) {
-        this.transaction = transaction;
-        this.statement = new AtomicReference<>();
-    }
-
-    public TransactionStatement(Transaction transaction, Statement statement) {
-        this.transaction = transaction;
-        this.statement = new AtomicReference<>(statement);
-    }
-
-    public void markStatementSubscribed(Statement statement) {
-        if (this.statement.compareAndSet(null, statement)) {
-            transaction.markSubscribed(this);
-        } else {
-            throw new TransactionAlreadyExecutedException();
-        }
+    public TransactionStatement(Statement statement) {
+        this.statement = statement;
     }
 
     public Statement getStatement() {
-        return statement.get();
-    }
-
-    public void removeStatement() {
-        statement.set(null);
+        return statement;
     }
 
     @Override
@@ -45,9 +25,5 @@ public class TransactionStatement implements Batchable {
     @Override
     public void execute(Connection connection) throws SQLException {
         getStatement().execute(connection);
-    }
-
-    public Transaction getTransaction() {
-        return transaction;
     }
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/TransactionStatement.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/TransactionStatement.java
@@ -1,6 +1,5 @@
 package se.fortnox.reactivewizard.db.transactions;
 
-import se.fortnox.reactivewizard.db.ConnectionProvider;
 import se.fortnox.reactivewizard.db.statement.Statement;
 
 import java.sql.Connection;
@@ -14,6 +13,11 @@ public class TransactionStatement implements Batchable {
     public TransactionStatement(Transaction transaction) {
         this.transaction = transaction;
         this.statement = new AtomicReference<>();
+    }
+
+    public TransactionStatement(Transaction transaction, Statement statement) {
+        this.transaction = transaction;
+        this.statement = new AtomicReference<>(statement);
     }
 
     public void markStatementSubscribed(Statement statement) {

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoObservableTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoObservableTest.java
@@ -1,0 +1,60 @@
+package se.fortnox.reactivewizard.db;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import rx.Observable;
+import se.fortnox.reactivewizard.db.config.DatabaseConfig;
+import se.fortnox.reactivewizard.db.transactions.DaoObservable;
+
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class DaoObservableTest {
+    private MockDb                      db                 = new MockDb();
+    private ConnectionProvider          connectionProvider = db.getConnectionProvider();
+    private DbProxy                     dbProxy            = new DbProxy(new DatabaseConfig(), connectionProvider);
+    private DaoTransactionsTest.TestDao dao                = dbProxy.create(DaoTransactionsTest.TestDao.class);
+
+    @Test
+    public void test() throws SQLException {
+        AtomicInteger terminated = new AtomicInteger();
+        AtomicInteger subscribed = new AtomicInteger();
+        AtomicInteger error = new AtomicInteger();
+
+        Observable<String> find1 = ((DaoObservable<String>) dao.find())
+            .onTerminate(terminated::incrementAndGet)
+            .onSubscribe(subscribed::incrementAndGet)
+            .onError(throwable -> error.incrementAndGet());
+
+        Observable<Integer> updateFail = ((DaoObservable<Integer>) dao.updateFail())
+            .onTerminate(terminated::incrementAndGet)
+            .onSubscribe(subscribed::incrementAndGet)
+            .onError(throwable -> error.incrementAndGet());
+
+        find1.toBlocking().singleOrDefault(null);
+        db.verifyConnectionsUsed(1);
+
+        try {
+            updateFail.toBlocking().singleOrDefault(null);
+            Assertions.fail("expected exception");
+        } catch (Exception e) {}
+
+        db.verifyConnectionsUsed(2);
+        verify(db.getConnection(), times(2)).setAutoCommit(true);
+        verify(db.getConnection(), never()).commit();
+        verify(db.getConnection(), times(1)).prepareStatement("select * from test");
+        verify(db.getConnection(), times(1)).prepareStatement("update foo set other_key=val");
+        verify(db.getConnection(), times(2)).close();
+        verify(db.getPreparedStatement(), times(2)).close();
+        verify(db.getResultSet(), times(1)).close();
+
+        assertThat(subscribed.get()).isEqualTo(2);
+        assertThat(terminated.get()).isEqualTo(2);
+        assertThat(error.get()).isEqualTo(1);
+    }
+}

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoObservableTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoObservableTest.java
@@ -25,15 +25,18 @@ public class DaoObservableTest {
         AtomicInteger terminated = new AtomicInteger();
         AtomicInteger subscribed = new AtomicInteger();
         AtomicInteger error = new AtomicInteger();
+        AtomicInteger completed = new AtomicInteger();
 
         Observable<String> find1 = ((DaoObservable<String>) dao.find())
             .onTerminate(terminated::incrementAndGet)
             .onSubscribe(subscribed::incrementAndGet)
+            .doOnTransactionCompleted(completed::incrementAndGet)
             .onError(throwable -> error.incrementAndGet());
 
         Observable<Integer> updateFail = ((DaoObservable<Integer>) dao.updateFail())
             .onTerminate(terminated::incrementAndGet)
             .onSubscribe(subscribed::incrementAndGet)
+            .doOnTransactionCompleted(completed::incrementAndGet)
             .onError(throwable -> error.incrementAndGet());
 
         find1.toBlocking().singleOrDefault(null);
@@ -56,5 +59,6 @@ public class DaoObservableTest {
         assertThat(subscribed.get()).isEqualTo(2);
         assertThat(terminated.get()).isEqualTo(2);
         assertThat(error.get()).isEqualTo(1);
+        assertThat(completed.get()).isEqualTo(1);
     }
 }

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
@@ -4,27 +4,28 @@ import org.fest.assertions.Fail;
 import org.junit.Test;
 import org.mockito.InOrder;
 import rx.Observable;
-import rx.Observer;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
 import se.fortnox.reactivewizard.db.statement.MinimumAffectedRowsException;
-import se.fortnox.reactivewizard.db.transactions.DaoObservable;
 import se.fortnox.reactivewizard.db.transactions.DaoTransactions;
 import se.fortnox.reactivewizard.db.transactions.DaoTransactionsImpl;
-import se.fortnox.reactivewizard.db.transactions.TransactionAlreadyExecutedException;
-import se.fortnox.reactivewizard.test.TestUtil;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static se.fortnox.reactivewizard.test.TestUtil.assertNestedException;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  */
@@ -40,14 +41,7 @@ public class DaoTransactionsTest {
         Observable<String> find1 = dao.find();
         Observable<String> find2 = dao.find();
 
-        daoTransactions.createTransaction(find1, find2);
-
-        find1.subscribe();
-
-        db.verifyConnectionsUsed(0);
-        verify(db.getConnection(), times(0)).prepareStatement(any());
-
-        find2.toBlocking().singleOrDefault(null);
+        daoTransactions.executeTransaction(find1, find2).toBlocking().subscribe();
 
         db.verifyConnectionsUsed(1);
         verify(db.getConnection(), times(1)).setAutoCommit(false);
@@ -60,87 +54,84 @@ public class DaoTransactionsTest {
     }
 
     @Test
-    public void shouldRunOnTransactionCompletedCallback() throws SQLException {
-        when(db.getPreparedStatement().executeBatch())
-            .thenReturn(new int[]{1, 1});
+    public void subscribingToDaoObservableWillResultInTwoCallsToQuery() throws SQLException {
+        Observable<String> find1 = dao.find();
+        Observable<String> find2 = dao.find();
 
-        final boolean[] cbExecuted   = {false, false, false};
-        DaoObservable   daoObsWithCb = ((DaoObservable)dao.updateSuccess())
-            .doOnTransactionCompleted(() -> cbExecuted[0] = true)
-            .onSubscribe(() -> cbExecuted[1] = true)
-            .onTerminate(() -> cbExecuted[2] = true);
-        // doOnTransactionCompleted will only be called when using createTransaction
+        daoTransactions.executeTransaction(find1, find2).toBlocking().subscribe();
 
-        Observable<Integer> updateSuccess = dao.updateSuccess();
-        daoTransactions.createTransaction(updateSuccess, daoObsWithCb);
-        updateSuccess.subscribe();
-        daoObsWithCb.toBlocking().single();
+        db.verifyConnectionsUsed(1);
+        verify(db.getConnection(), times(2)).prepareStatement(any());
 
-        assertThat(cbExecuted[0]).isTrue();
-        assertThat(cbExecuted[1]).isTrue();
-        assertThat(cbExecuted[2]).isTrue();
+        // TODO: Is this expected? Or do we want this to be handled in some other way?
+        find2.toBlocking().singleOrDefault(null);
+
+        db.verifyConnectionsUsed(2);
+        verify(db.getConnection(), times(1)).setAutoCommit(false);
+        verify(db.getConnection(), times(1)).commit();
+        verify(db.getConnection(), times(3)).prepareStatement("select * from test");
+        verify(db.getConnection(), timeout(500).times(2)).setAutoCommit(true);
+        verify(db.getConnection(), times(2)).close();
+        verify(db.getPreparedStatement(), times(3)).close();
+
+        // TODO: Is this expected in a transaction?
+        verify(db.getResultSet(), times(3)).close();
     }
 
     @Test
-    public void shouldRunTwoQueriesInTransactionOrderAndNotInSubscribeOrder() throws SQLException {
+    public void shouldRunOnCompletedOnceWhenTransactionFinished() throws SQLException {
+        AtomicInteger completed = new AtomicInteger();
+        daoTransactions.executeTransaction(dao.updateSuccess(), dao.updateOtherSuccess(), dao.updateSuccess(), dao.updateOtherSuccess())
+            .doOnCompleted(completed::incrementAndGet)
+            .toBlocking().subscribe();
+
+        assertThat(completed.get()).isEqualTo(1);
+
+        db.verifyConnectionsUsed(1);
+        verify(db.getConnection(), times(2)).prepareStatement("update foo set key=val");
+        verify(db.getConnection(), times(2)).prepareStatement("update foo set key=val2");
+    }
+
+    @Test
+    public void shouldNotRunOnCompletedWhenTransactionFailed() throws SQLException {
+        Observable<Integer> find1 = dao.updateSuccess();
+        Observable<Integer> find2 = dao.updateFail();
+
+        AtomicInteger completed = new AtomicInteger();
+        AtomicInteger failed = new AtomicInteger();
+        try {
+            daoTransactions.executeTransaction(find1, find2)
+                .doOnCompleted(() -> completed.incrementAndGet())
+                .doOnError(throwable -> failed.incrementAndGet())
+                .toBlocking().subscribe();
+            fail("exception expected");
+        } catch (Exception e) {}
+
+        assertThat(completed.get()).isEqualTo(0);
+        assertThat(failed.get()).isEqualTo(1);
+
+        db.verifyConnectionsUsed(1);
+        verify(db.getConnection(), times(1)).setAutoCommit(false);
+        verify(db.getConnection(), times(1)).rollback();
+        verify(db.getConnection()).prepareStatement("update foo set key=val");
+        verify(db.getConnection()).prepareStatement("update foo set other_key=val");
+        verify(db.getConnection(), timeout(500)).setAutoCommit(true);
+        verify(db.getConnection(), times(1)).close();
+        verify(db.getPreparedStatement(), times(2)).close();
+    }
+
+    @Test
+    public void shouldRunTwoQueriesInTransactionOrder() throws SQLException {
         Observable<String> find1 = dao.find();
         Observable<String> find2 = dao.find2();
 
-        daoTransactions.createTransaction(find1, find2);
-
-        find2.subscribe();
-        find1.toBlocking().singleOrDefault(null);
+        daoTransactions.executeTransaction(find1, find2).toBlocking().subscribe();
 
         Connection connection = db.getConnection();
         InOrder    inOrder    = inOrder(connection);
 
         inOrder.verify(connection).prepareStatement("select * from test");
         inOrder.verify(connection).prepareStatement("select * from test2");
-    }
-
-    @Test
-    public void shouldFailAllQueriesIfOneFails() throws SQLException {
-        db.addRows(1);
-        Observable<String> find1 = dao.find();
-        Observable<String> find2 = dao.find();
-
-        when(db.getPreparedStatement().executeQuery())
-            .thenReturn(db.getResultSet())
-            .thenThrow(new SQLException("error"));
-
-        daoTransactions.createTransaction(find1, find2);
-
-        Observer<String> find1Observer = mock(Observer.class);
-
-        find1.subscribe(find1Observer);
-
-        db.verifyConnectionsUsed(0);
-        verify(db.getConnection(), times(0)).prepareStatement(any());
-
-        try {
-            find2.toBlocking().singleOrDefault(null);
-            fail("expected exception");
-        } catch (Exception e) {
-            assertThat(e.getCause().getMessage()).isEqualTo("error");
-        }
-
-        verify(find1Observer).onError(TestUtil.matches(e -> {
-            System.out.println(e.getMessage());
-            assertNestedException(e, SQLException.class)
-                .hasMessage("error");
-        }));
-        verify(find1Observer, times(0)).onCompleted();
-        verify(find1Observer, times(1)).onNext(any());
-
-        db.verifyConnectionsUsed(1);
-        verify(db.getConnection(), times(1)).setAutoCommit(false);
-        verify(db.getConnection(), times(1)).rollback();
-        verify(db.getConnection(), times(2)).prepareStatement("select * from test");
-        verify(db.getConnection(), timeout(500)).setAutoCommit(true);
-        verify(db.getConnection(), times(1)).close();
-        verify(db.getPreparedStatement(), times(2)).close();
-        verify(db.getResultSet(), times(1)).close();
-
     }
 
     @Test
@@ -211,28 +202,6 @@ public class DaoTransactionsTest {
     }
 
     @Test
-    public void shouldFailIfQueryIsSubscribedTwice() throws SQLException {
-        db.setUpdatedRows(1);
-
-        final Observable<Integer> update = dao.updateSuccess();
-        daoTransactions.createTransaction(update);
-
-        update.toBlocking().single();
-        try {
-            update.toBlocking().single();
-            fail("expected exception");
-        } catch (Exception e) {
-            assertNestedException(e, TransactionAlreadyExecutedException.class)
-                .hasMessage("Transaction already executed. You cannot subscribe multiple times to an Observable that is part of a transaction.");
-        }
-
-        Connection conn = db.getConnection();
-        verify(conn, never()).rollback();
-        verify(conn, times(1)).commit();
-        verify(conn).close();
-    }
-
-    @Test
     public void shouldBeAbleToUseRetryOnTransaction() throws SQLException {
 
         when(db.getPreparedStatement().getUpdateCount())
@@ -240,7 +209,6 @@ public class DaoTransactionsTest {
 
         final Observable<Integer> update = dao.updateFail();
 
-        daoTransactions.createTransaction(update);
         daoTransactions.executeTransaction(update).retry(3).test().awaitTerminalEvent();
 
         Connection conn = db.getConnection();
@@ -249,15 +217,15 @@ public class DaoTransactionsTest {
 
     @Test(expected = RuntimeException.class)
     public void shouldThrowExceptionIfObservableIsNotFromDao() {
-        daoTransactions.createTransaction(Observable.empty());
+        daoTransactions.executeTransaction(Observable.empty());
     }
 
     @Test
     public void shouldAllowEmptyAndNull() {
         try {
-            daoTransactions.createTransaction(Collections.emptyList());
-            daoTransactions.createTransaction((Iterable<Observable<Object>>) null);
-            daoTransactions.createTransaction();
+            daoTransactions.executeTransaction(Collections.emptyList());
+            daoTransactions.executeTransaction((Iterable<Observable<Object>>) null);
+            daoTransactions.executeTransaction();
         } catch (Exception e) {
             Fail.fail("Unexpected exception when testing transactions with empty and nulls");
         }
@@ -284,34 +252,24 @@ public class DaoTransactionsTest {
     }
 
     @Test
-    public void shouldFailIfTransactionIsModifiedAfterCreation() throws Exception {
+    public void shouldIgnoreModificationToTransactionList() throws Exception {
         db.addRows(1);
         Observable<String> find1 = dao.find();
 
         List<Observable<String>> transaction = new ArrayList<>();
         transaction.add(find1);
-
-        daoTransactions.createTransaction(transaction);
+        Observable<Void> transactionObservable = daoTransactions.executeTransaction(transaction);
 
         transaction.add(dao.find2());
+        transactionObservable.toBlocking().subscribe();
 
-        try {
-            find1.toBlocking().single();
-            fail("expected exception");
-        } catch (Exception e) {
-            if (e.getCause() != null) {
-                e = (Exception)e.getCause();
-            }
-            assertThat(e)
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("Transaction cannot be modified after creation.");
-        }
-
-        Connection conn = db.getConnection();
-        verify(conn, never()).setAutoCommit(false);
-        verify(conn, never()).commit();
-        verify(conn, never()).rollback();
-        verify(conn, never()).close();
+        db.verifyConnectionsUsed(1);
+        verify(db.getConnection(), times(1)).setAutoCommit(false);
+        verify(db.getConnection(), times(1)).commit();
+        verify(db.getConnection(), times(1)).prepareStatement("select * from test");
+        verify(db.getConnection(), timeout(500)).setAutoCommit(true);
+        verify(db.getConnection(), times(1)).close();
+        verify(db.getPreparedStatement(), times(1)).close();
     }
 
     interface TestDao {

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
@@ -42,7 +42,11 @@ public class DaoTransactionsTest {
         Observable<String> find1 = dao.find();
         Observable<String> find2 = dao.find();
 
-        daoTransactions.executeTransaction(find1, find2).toBlocking().subscribe();
+        Observable<Void> executeTransactionObs = daoTransactions.executeTransaction(find1, find2);
+        db.verifyConnectionsUsed(0);
+        verify(db.getConnection(), times(0)).prepareStatement(any());
+
+        executeTransactionObs.toBlocking().subscribe();
 
         db.verifyConnectionsUsed(1);
         verify(db.getConnection(), times(1)).setAutoCommit(false);

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
@@ -264,13 +264,20 @@ public class DaoTransactionsTest {
     }
 
     @Test
-    public void shouldAllowEmptyAndNull() {
+    public void shouldAllowEmptyAndNullButNotNullInIterable() {
         try {
             daoTransactions.executeTransaction(Collections.emptyList());
             daoTransactions.executeTransaction((Iterable<Observable<Object>>) null);
             daoTransactions.executeTransaction();
         } catch (Exception e) {
             Fail.fail("Unexpected exception when testing transactions with empty and nulls");
+        }
+
+        try {
+            daoTransactions.executeTransaction((DaoObservable<Object>) null);
+            fail("Expected exception");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).startsWith("All parameters to createTransaction needs to be observables coming from a Dao-class");
         }
     }
 

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/ObservableStatementFactoryTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/ObservableStatementFactoryTest.java
@@ -51,20 +51,22 @@ public class ObservableStatementFactoryTest {
             invocationOnMock.getArgument(0, Action0.class).call();
             return Subscriptions.unsubscribed();
         });
-        when(dbStatementFactory.create(any(), any())).then(invocationOnMock -> new Statement() {
+        when(dbStatementFactory.create(any())).then(invocationOnMock -> new Statement() {
+            private Subscriber subscriber;
+
             @Override
             public void execute(Connection connection) {
-                invocationOnMock.getArgument(1, Subscriber.class).onNext("result");
+                subscriber.onNext("result");
             }
 
             @Override
             public void onCompleted() {
-                invocationOnMock.getArgument(1, Subscriber.class).onCompleted();
+                subscriber.onCompleted();
             }
 
             @Override
             public void onError(Throwable throwable) {
-                invocationOnMock.getArgument(1, Subscriber.class).onError(throwable);
+                subscriber.onError(throwable);
             }
 
             @Override
@@ -80,6 +82,11 @@ public class ObservableStatementFactoryTest {
             @Override
             public boolean sameBatch(Statement statement) {
                 return false;
+            }
+
+            @Override
+            public void setSubscriber(Subscriber<?> subscriber) {
+                this.subscriber = subscriber;
             }
         });
         Function<Object[], String> paramSerializer = objects -> "";


### PR DESCRIPTION
Instead of creating multiple observables, now one is created that executes the transaction.

It should be backwards compatible. I deprecated the createTransaction-methods, and when we are sure that no one uses them we can rewrite the transaction-stuff totally and get rid of those cross-references between objects and make a more clean implementation.

Commiting a transaction with 24.000 inserts takes around 20 seconds, 100.000 took more than 15 minutes.
This change gets it down to 3 seconds for 24k and around 20-30 seconds for 100k.

And the problem was that it creates so many observables. RxJava simply had too much to do. It creates the observables sequentially.