### PR TITLE
Fix support for hot reload of dao-method annotations

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
@@ -106,7 +106,7 @@ public class DbProxy implements InvocationHandler {
         if (observableStatementFactory == null || DebugUtil.IS_DEBUG) {
             if (DebugUtil.IS_DEBUG) {
                 // Need to get the actual interface method in order to get updated annotations
-                method = Optional.ofNullable(ReflectionUtil.getOverriddenMethod(method)).orElse(method);
+                method = ReflectionUtil.getRedefinedMethod(method);
             }
             DbStatementFactory statementFactory = dbStatementFactoryFactory.createStatementFactory(method);
             PagingOutput       pagingOutput     = new PagingOutput(method);

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/ReflectionUtil.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/ReflectionUtil.java
@@ -95,6 +95,18 @@ public class ReflectionUtil {
         return found.orElse(null);
     }
 
+    /**
+     * Fetches the (possibly) redefined version of a method for a class that has been hot-reloaded.
+     *
+     * Intended to be used while debugging stuff and using the hot reload feature in the IDE.
+     * @param method the method that may have been redefined
+     * @return a redefined version of that method, or the passed in method if no new version is found
+     */
+    public static Method getRedefinedMethod(Method method) {
+        Class<?> declaringClass = getUserDefinedClass(method.getDeclaringClass());
+        return findMethodInClass(method, declaringClass).orElse(method);
+    }
+
     private static Class<?> getUserDefinedClass(Class<?> clazz) {
         if (clazz.getName().contains(CGLIB_CLASS_SEPARATOR)) {
             Class<?> superclass = clazz.getSuperclass();

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/ReflectionUtilTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/ReflectionUtilTest.java
@@ -299,6 +299,12 @@ public class ReflectionUtilTest {
         assertThat(method).isEqualTo(TestResource.class.getMethod("resourceGet", String.class, String.class));
     }
 
+    @Test
+    public void shouldGetRedefinedVersionOfMethod() throws NoSuchMethodException {
+        Method method = TestResource.class.getMethod("resourceGet", String.class, String.class);
+        assertThat(ReflectionUtil.getRedefinedMethod(method)).isEqualTo(method);
+    }
+
     private static class InstanceExposingInvocationHandler implements InvocationHandler, Provider {
 
         private final Object instance;


### PR DESCRIPTION
When you recompile a class during a debug session, it will be hot reloaded and replace the existing class. However, dao instances that has already been injected will still be using the old version of the interface and queries will therefore not update. This PR fixes that bug and allows for hot reloading to work again.