### PR TITLE
restore @Inject annotated empty constructor

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
@@ -3,6 +3,7 @@ package se.fortnox.reactivewizard.db.transactions;
 import rx.Observable;
 import se.fortnox.reactivewizard.db.statement.Statement;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -11,6 +12,9 @@ import static java.util.Arrays.asList;
 import static rx.Observable.empty;
 
 public class DaoTransactionsImpl implements DaoTransactions {
+
+    @Inject
+    public DaoTransactionsImpl() {}
 
     private  <T> Transaction<T> createTransactionWithStatements(Collection<Observable<T>> daoCalls) {
         List<TransactionStatement> transactionStatements = new ArrayList<>();

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
@@ -13,6 +13,7 @@ import se.fortnox.reactivewizard.db.transactions.DaoTransactions;
 import se.fortnox.reactivewizard.db.transactions.DaoTransactionsImpl;
 import se.fortnox.reactivewizard.json.JsonSerializerFactory;
 
+import javax.inject.Inject;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -40,6 +41,15 @@ public class DaoTransactionsTest {
     private DbProxy            dbProxy            = new DbProxy(new DatabaseConfig(), connectionProvider);
     private TestDao            dao                = dbProxy.create(TestDao.class);
     private DaoTransactions    daoTransactions    = new DaoTransactionsImpl();
+
+    @Test
+    public void shouldHaveEmptyInjectAnnotatedConstructor() {
+        try {
+            assertThat(DaoTransactionsImpl.class.getConstructor().getAnnotation(Inject.class)).isNotNull();
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+    }
 
     @Test
     public void shouldRunTwoQueriesInOneTransaction() throws SQLException {


### PR DESCRIPTION
The @Inject annotated constructor must be present for dependency injection to work for this interface.