### PR TITLE
DbProxy with both new Scheduler and ConnectionProvider

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ObservableStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ObservableStatementFactory.java
@@ -28,21 +28,18 @@ public class ObservableStatementFactory {
     private static final Logger LOG                    = LoggerFactory.getLogger("Dao");
     private final DbStatementFactory         statementFactory;
     private final PagingOutput               pagingOutput;
-    private final Scheduler                  scheduler;
     private final Metrics                    metrics;
     private final DatabaseConfig             config;
 
     public ObservableStatementFactory(
         DbStatementFactory statementFactory,
         PagingOutput pagingOutput,
-        Scheduler scheduler,
         Function<Object[], String> paramSerializer,
         Metrics metrics,
         DatabaseConfig config
     ) {
         this.statementFactory = statementFactory;
         this.pagingOutput = pagingOutput;
-        this.scheduler = scheduler;
         this.metrics = metrics;
         this.config = config;
     }
@@ -55,9 +52,9 @@ public class ObservableStatementFactory {
         }
     }
 
-    public Observable<Object> create(Object[] args, ConnectionProvider connectionProvider) {
+    public Observable<Object> create(Object[] args, ConnectionScheduler connectionScheduler) {
         Supplier<StatementContext> transactionHolderSupplier =
-            () -> new StatementContext(statementFactory.create(args), new ConnectionScheduler(connectionProvider, scheduler));
+            () -> new StatementContext(statementFactory.create(args), connectionScheduler);
         Observable<Object> result = Observable.unsafeCreate(subscription -> {
             try {
                 transactionHolderSupplier.get().getConnectionScheduler()

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
@@ -4,9 +4,11 @@ import com.google.inject.Injector;
 import org.junit.Before;
 import org.junit.Test;
 import rx.Observable;
+import rx.Scheduler;
 import rx.Subscriber;
 import rx.exceptions.MissingBackpressureException;
 import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
 import se.fortnox.reactivewizard.config.TestInjector;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
 
@@ -211,6 +213,30 @@ public class DbProxyTest {
         assertThat(newDbProxy.getDatabaseConfig()).isNotSameAs(oldConfig);
         assertThat(newDbProxy.getDatabaseConfig()).isSameAs(newConfig);
         assertThat(newDbProxy.getDatabaseConfig().getUrl()).isSameAs("bar");
+    }
+
+    @Test
+    public void shouldCreateNewDbProxyInstanceWithNewConnectionProviderAndNewScheduler() {
+        // given
+        DatabaseConfig config = new DatabaseConfig();
+        config.setUrl("fooo");
+
+        ConnectionProvider newConnectionProvider = mock(ConnectionProvider.class);
+        when(newConnectionProvider.get()).thenReturn(mockDb.getConnection());
+
+        Scheduler newScheduler = mock(Scheduler.class);
+        when(newScheduler.createWorker()).thenReturn(Schedulers.io().createWorker());
+
+        // when
+        DbProxy oldDbProxy = new DbProxy(config,mock(ConnectionProvider.class));
+
+        DbProxy newDbProxy = oldDbProxy.usingConnectionProvider(newConnectionProvider, newScheduler);
+        newDbProxy.create(DbProxyTestDao.class).select("").subscribe();
+
+        // then
+        assertThat(oldDbProxy).isNotSameAs(newDbProxy);
+        verify(newScheduler).createWorker();
+        verify(newConnectionProvider).get();
     }
 
     @Test

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
@@ -231,7 +231,7 @@ public class DbProxyTest {
         DbProxy oldDbProxy = new DbProxy(config,mock(ConnectionProvider.class));
 
         DbProxy newDbProxy = oldDbProxy.usingConnectionProvider(newConnectionProvider, newScheduler);
-        newDbProxy.create(DbProxyTestDao.class).select("").subscribe();
+        newDbProxy.create(DbProxyTestDao.class).select("").toBlocking().subscribe();
 
         // then
         assertThat(oldDbProxy).isNotSameAs(newDbProxy);

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/ObservableStatementFactoryTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/ObservableStatementFactoryTest.java
@@ -14,6 +14,7 @@ import se.fortnox.reactivewizard.db.config.DatabaseConfig;
 import se.fortnox.reactivewizard.db.paging.PagingOutput;
 import se.fortnox.reactivewizard.db.statement.DbStatementFactory;
 import se.fortnox.reactivewizard.db.statement.Statement;
+import se.fortnox.reactivewizard.db.transactions.ConnectionScheduler;
 import se.fortnox.reactivewizard.metrics.Metrics;
 
 import java.sql.Connection;
@@ -90,13 +91,13 @@ public class ObservableStatementFactoryTest {
             }
         });
         Function<Object[], String> paramSerializer = objects -> "";
-        statementFactory = new ObservableStatementFactory(dbStatementFactory, pagingOutput, scheduler, paramSerializer,
+        statementFactory = new ObservableStatementFactory(dbStatementFactory, pagingOutput, paramSerializer,
             Metrics.get("test"), databaseConfig);
     }
 
     @Test
     public void shouldReleaseSchedulerWorkers() {
-        Observable<Object> stmt = statementFactory.create(new Object[0], () -> mock(Connection.class));
+        Observable<Object> stmt = statementFactory.create(new Object[0], new ConnectionScheduler(() -> mock(Connection.class), scheduler));
         stmt.toBlocking().single();
         verify(scheduler, times(1)).createWorker();
         verify(worker).unsubscribe();


### PR DESCRIPTION
This is needed for cases when the scheduler needs to be customized per connection. Also makes sense now that ConnectionScheduler exists.