### PR TITLE
Using first available ConnectionScheduler where connectionProvider is set.

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/ConnectionScheduler.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/ConnectionScheduler.java
@@ -15,6 +15,10 @@ public class ConnectionScheduler {
         this.scheduler = scheduler;
     }
 
+    boolean hasConnectionProvider() {
+        return connectionProvider != null;
+    }
+
     public void schedule(Subscriber<?> subscription, ThrowableAction action) {
         Scheduler.Worker worker = scheduler.createWorker();
         worker.schedule(() -> {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
@@ -68,8 +68,9 @@ public class DaoTransactionsImpl implements DaoTransactions {
 
     private <T> ConnectionScheduler getConnectionScheduler(Collection<Observable<T>> daoCallsCopy) {
         Observable<T> daoObservable = daoCallsCopy.stream()
+            .filter(obs -> ((DaoObservable<T>)obs).getStatementContextSupplier().get().getConnectionScheduler().hasConnectionProvider())
             .findFirst()
-            .orElseThrow(() -> new RuntimeException("No DaoObservable found"));
+            .orElseThrow(() -> new RuntimeException("No DaoObservable with a valid connection provider was found"));
 
         return ((DaoObservable<T>) daoObservable).getStatementContextSupplier().get().getConnectionScheduler();
     }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsImpl.java
@@ -67,11 +67,10 @@ public class DaoTransactionsImpl implements DaoTransactions {
     }
 
     private <T> ConnectionScheduler getConnectionScheduler(Collection<Observable<T>> daoCallsCopy) {
-        Observable<T> daoObservable = daoCallsCopy.stream()
-            .filter(obs -> ((DaoObservable<T>)obs).getStatementContextSupplier().get().getConnectionScheduler().hasConnectionProvider())
+        return daoCallsCopy.stream()
+            .map(obs -> ((DaoObservable<T>)obs).getStatementContextSupplier().get().getConnectionScheduler())
+            .filter(ConnectionScheduler::hasConnectionProvider)
             .findFirst()
             .orElseThrow(() -> new RuntimeException("No DaoObservable with a valid connection provider was found"));
-
-        return ((DaoObservable<T>) daoObservable).getStatementContextSupplier().get().getConnectionScheduler();
     }
 }


### PR DESCRIPTION
having a ConnectionScheduler with a connectionProvider set.
A daoobservable could have connectionProvider null when created from a DbProxy without a connectionProvier set.