### PR TITLE
removed test scope from reactor-test

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -59,7 +59,6 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
So that we can use the reactor test module wherever we use this testmodule