### PR TITLE
Add possibility to turn off lambda generation

### DIFF
--- a/json/pom.xml
+++ b/json/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
 
         <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-utils</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>1</version>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -51,4 +51,16 @@
             <version>1</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} --add-opens java.base/java.lang.invoke=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/json/src/main/java/com/fasterxml/jackson/databind/ser/LambdaWriter.java
+++ b/json/src/main/java/com/fasterxml/jackson/databind/ser/LambdaWriter.java
@@ -4,12 +4,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap;
+import se.fortnox.reactivewizard.util.Getter;
+import se.fortnox.reactivewizard.util.MethodGetter;
 
-import java.lang.invoke.CallSite;
-import java.lang.invoke.LambdaMetafactory;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Modifier;
 import java.util.function.Function;
 
@@ -31,18 +28,9 @@ public class LambdaWriter extends BeanPropertyWriter {
             if (!Modifier.isPublic(_accessorMethod.getModifiers()) || !Modifier.isPublic(_accessorMethod.getDeclaringClass().getModifiers())) {
                 return;
             }
-            final MethodHandles.Lookup lookup = MethodHandles.lookup();
             try {
-                MethodHandle methodHandle = lookup.unreflect(_accessorMethod);
-                CallSite callSite = LambdaMetafactory.metafactory(
-                        lookup,
-                        "apply",
-                        MethodType.methodType(Function.class),
-                        MethodType.methodType(Object.class, Object.class),
-                        methodHandle,
-                        methodHandle.type()
-                );
-                lambda = (Function<Object,Object>) callSite.getTarget().invoke();
+                Getter<Object,Object> getter = MethodGetter.create(_accessorMethod.getDeclaringClass(), _accessorMethod);
+                lambda = getter.getterFunction();
             } catch (Throwable t) {
                 throw new RuntimeException(t);
             }

--- a/json/src/main/java/se/fortnox/reactivewizard/json/JsonSerializerFactory.java
+++ b/json/src/main/java/se/fortnox/reactivewizard/json/JsonSerializerFactory.java
@@ -9,12 +9,14 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.lang.reflect.Type;
 import java.util.function.Function;
 
 /**
  * Creates instances of JSON serializers.
  */
+@Singleton
 public class JsonSerializerFactory {
     private final ObjectMapper mapper;
 

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/LambdaCompiler.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/LambdaCompiler.java
@@ -1,0 +1,77 @@
+package se.fortnox.reactivewizard.util;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class LambdaCompiler {
+    static boolean useLambdas = "true".equals(System.getProperty("useLambdas", "true"));
+
+    static <T> Supplier<T> compileLambdaSupplier(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
+        if (!useLambdas) {
+            return () -> {
+                try {
+                    return (T) methodHandle.invoke();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            };
+        }
+        CallSite callSite = LambdaMetafactory.metafactory(
+            lookup,
+            "get",
+            MethodType.methodType(Supplier.class),
+            MethodType.methodType(Object.class),
+            methodHandle,
+            methodHandle.type()
+        );
+        return (Supplier<T>)callSite.getTarget().invoke();
+    }
+
+    static <I,T> BiConsumer<I,T> compileLambdaBiConsumer(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
+        if (!useLambdas) {
+            return (instance, arg) -> {
+                try {
+                    methodHandle.bindTo(instance).invokeWithArguments(arg);
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            };
+        }
+        CallSite callSite = LambdaMetafactory.metafactory(
+            lookup,
+            "accept",
+            MethodType.methodType(BiConsumer.class),
+            MethodType.methodType(void.class, Object.class, Object.class),
+            methodHandle,
+            methodHandle.type().wrap().changeReturnType(void.class)
+        );
+        return (BiConsumer<I,T>) callSite.getTarget().invoke();
+    }
+
+    static <I,T> Function<I, T> compileLambdaFunction(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
+        if (!useLambdas) {
+            return (instance) -> {
+                try {
+                    return (T)methodHandle.bindTo(instance).invoke();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            };
+        }
+        CallSite callSite = LambdaMetafactory.metafactory(
+            lookup,
+            "apply",
+            MethodType.methodType(Function.class),
+            MethodType.methodType(Object.class, Object.class),
+            methodHandle,
+            methodHandle.type()
+        );
+        return (Function<I,T>) callSite.getTarget().invoke();
+    }
+}

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/MethodGetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/MethodGetter.java
@@ -6,17 +6,15 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.function.Function;
 
-import static se.fortnox.reactivewizard.util.ReflectionUtil.lambdaForFunction;
-
 /**
  * Represents a getter method.
  */
 public class MethodGetter<I,T> implements Getter<I,T> {
     private final Function<I, T> getterLambda;
 
-    public static Getter create(Class<?> cls, Method method) {
+    public static <I,T> Getter<I,T> create(Class<?> cls, Method method) {
         AccessorUtil.MemberTypeInfo memberTypeInfo = AccessorUtil.getterTypeInfo(cls, method);
-        return new MethodGetter(method, memberTypeInfo.getReturnType(), memberTypeInfo.getGenericReturnType());
+        return new MethodGetter<I,T>(method, memberTypeInfo.getReturnType(), memberTypeInfo.getGenericReturnType());
     }
 
     private final Class<?> returnType;
@@ -30,7 +28,7 @@ public class MethodGetter<I,T> implements Getter<I,T> {
 
         try {
             MethodHandle methodHandle = lookup.unreflect(method);
-            getterLambda = lambdaForFunction(lookup, methodHandle);
+            getterLambda = LambdaCompiler.compileLambdaFunction(lookup, methodHandle);
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/MethodSetter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/MethodSetter.java
@@ -1,11 +1,8 @@
 package se.fortnox.reactivewizard.util;
 
 
-import java.lang.invoke.CallSite;
-import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.function.BiConsumer;
@@ -32,30 +29,10 @@ public class MethodSetter<I,T> implements Setter<I,T> {
 
         try {
             MethodHandle methodHandle = lookup.unreflect(method);
-            setterLambda = compileLambda(lookup, methodHandle);
+            setterLambda = LambdaCompiler.compileLambdaBiConsumer(lookup, methodHandle);
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }
-
-    }
-
-    private BiConsumer<I,T> compileLambda(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
-        CallSite callSite = LambdaMetafactory.metafactory(
-                lookup,
-                "accept",
-                MethodType.methodType(BiConsumer.class),
-                MethodType.methodType(void.class, Object.class, Object.class),
-                methodHandle,
-                wrapMethodType(methodHandle.type())
-        );
-        return (BiConsumer<I,T>) callSite.getTarget().invoke();
-    }
-
-    private MethodType wrapMethodType(MethodType methodType) {
-        // JDK9+ has made changes to LambdaMetaFactory that prevent lambdas from being able to do proper
-        // adaptation of types. In particular boxed types are no longer widened appropriately and
-        // Object can no longer be adapted to primitive types.
-        return methodType.wrap().changeReturnType(void.class);
     }
 
     @Override

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/MethodGetterTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/MethodGetterTest.java
@@ -1,12 +1,16 @@
 package se.fortnox.reactivewizard.util;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(Parameterized.class)
 public class MethodGetterTest extends AccessorTest {
     private Getter value;
     private Getter longObservable;
@@ -15,14 +19,19 @@ public class MethodGetterTest extends AccessorTest {
     private Getter superKey;
     private Getter superValue;
 
-    @Before
-    public void setUp() {
+    public MethodGetterTest(boolean useLambdas) {
+        LambdaCompiler.useLambdas = useLambdas;
         value = ReflectionUtil.getGetter(GenericMethodSubclass.class, "value");
         longObservable = ReflectionUtil.getGetter(GenericMethodSubclass.class, "longObservable");
         genericSuperKey = ReflectionUtil.getGetter(GenericMethodSubclass.class, "superKey");
         genericSuperValue = ReflectionUtil.getGetter(GenericMethodSubclass.class, "superValue");
         superKey = ReflectionUtil.getGetter(MethodSubclass.class, "superKey");
         superValue = ReflectionUtil.getGetter(MethodSubclass.class, "superValue");
+    }
+
+    @Parameterized.Parameters
+    public static Collection useLambdasParameters() {
+        return List.of(new Object[][] {{ true }, { false }});
     }
 
     @Test

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/MethodSetterTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/MethodSetterTest.java
@@ -2,11 +2,16 @@ package se.fortnox.reactivewizard.util;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(Parameterized.class)
 public class MethodSetterTest extends AccessorTest {
     private Setter value;
     private Setter longObservable;
@@ -15,14 +20,19 @@ public class MethodSetterTest extends AccessorTest {
     private Setter superKey;
     private Setter superValue;
 
-    @Before
-    public void setUp() {
+    public MethodSetterTest(boolean useLambdas) {
+        LambdaCompiler.useLambdas = useLambdas;
         value = ReflectionUtil.getSetter(GenericMethodSubclass.class, "value");
         longObservable = ReflectionUtil.getSetter(GenericMethodSubclass.class, "longObservable");
         genericSuperKey = ReflectionUtil.getSetter(GenericMethodSubclass.class, "superKey");
         genericSuperValue = ReflectionUtil.getSetter(GenericMethodSubclass.class, "superValue");
         superKey = ReflectionUtil.getSetter(MethodSubclass.class, "superKey");
         superValue = ReflectionUtil.getSetter(MethodSubclass.class, "superValue");
+    }
+
+    @Parameterized.Parameters
+    public static Collection useLambdasParameters() {
+        return List.of(new Object[][] {{ true }, { false }});
     }
 
     @Test

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/MethodSetterTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/MethodSetterTest.java
@@ -1,6 +1,5 @@
 package se.fortnox.reactivewizard.util;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/ReflectionUtilTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/ReflectionUtilTest.java
@@ -6,6 +6,8 @@ import com.google.inject.Injector;
 import com.google.inject.matcher.Matchers;
 import org.aopalliance.intercept.Joinpoint;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import rx.Observable;
 
 import javax.inject.Provider;
@@ -16,6 +18,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -26,7 +29,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
+@RunWith(Parameterized.class)
 public class ReflectionUtilTest {
+
+    public ReflectionUtilTest(boolean useLambdas) {
+        LambdaCompiler.useLambdas = useLambdas;
+    }
+
+    @Parameterized.Parameters
+    public static Collection useLambdasParameters() {
+        return List.of(new Object[][] {{ true }, { false }});
+    }
+
     @Test
     public void shouldFindDeclaredMethods() {
         Getter getter = ReflectionUtil.getGetter(Child.class, "j");


### PR DESCRIPTION
By starting the system with -DuseLambdas=false all reflection will use standard reflection calls instead of compiling lambdas.