### PR TITLE
Convert Observable to Mono without restricting it to .single()

### DIFF
--- a/utils/src/main/java/se/fortnox/reactivewizard/util/FluxRxConverter.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/FluxRxConverter.java
@@ -14,6 +14,10 @@ public class FluxRxConverter {
         return Flux.from(RxReactiveStreams.toPublisher(result));
     }
 
+    public static <T> Mono<T> observableToMono(Observable<T> result) {
+        return Mono.from(RxReactiveStreams.toPublisher(result));
+    }
+
     /**
      * Create converter from a reactive type to Flux.
      * @param returnType the return type
@@ -114,7 +118,7 @@ public class FluxRxConverter {
         } else if (Flux.class.isAssignableFrom(targetReactiveType)) {
             return FluxRxConverter::observableToFlux;
         } else if (Mono.class.isAssignableFrom(targetReactiveType)) {
-            return result -> observableToFlux(result).single();
+            return FluxRxConverter::observableToMono;
         }
         return null;
     }

--- a/utils/src/test/java/se/fortnox/reactivewizard/util/FluxRxConverterTest.java
+++ b/utils/src/test/java/se/fortnox/reactivewizard/util/FluxRxConverterTest.java
@@ -40,6 +40,9 @@ public class FluxRxConverterTest {
 
         Mono<String> monoResult = (Mono<String>) FluxRxConverter.converterFromObservable(Mono.class).apply(Observable.just(nbrSingle));
         assertThat(monoResult.block()).isEqualTo(nbrSingle);
+
+        Mono<String> emptyMonoResult = (Mono<String>) FluxRxConverter.converterFromObservable(Mono.class).apply(Observable.empty());
+        assertThat(emptyMonoResult.block()).isNull();
     }
 
     @Test


### PR DESCRIPTION
This follows the expectations of using a Mono vs. using a Single.
A Mono emits 0 to 1 value or error while a Single emits 1 value or
error.

Also adds observableToMono(Observable) static converter. Useful when
interacting with third-party apis.