### PR TITLE
Switched from RxJava to Reactor in dao module

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
@@ -1,18 +1,16 @@
 package se.fortnox.reactivewizard.db;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import rx.Scheduler;
-import rx.internal.util.RxThreadFactory;
-import rx.schedulers.Schedulers;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
 import se.fortnox.reactivewizard.db.paging.PagingOutput;
 import se.fortnox.reactivewizard.db.statement.DbStatementFactory;
 import se.fortnox.reactivewizard.db.statement.DbStatementFactoryFactory;
 import se.fortnox.reactivewizard.db.transactions.ConnectionScheduler;
 import se.fortnox.reactivewizard.json.JsonSerializerFactory;
-import se.fortnox.reactivewizard.metrics.Metrics;
+import se.fortnox.reactivewizard.metrics.PublisherMetrics;
 import se.fortnox.reactivewizard.util.DebugUtil;
-import se.fortnox.reactivewizard.util.FluxRxConverter;
 import se.fortnox.reactivewizard.util.ReflectionUtil;
 
 import javax.annotation.Nullable;
@@ -23,60 +21,61 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.function.Function;
+
+import static java.text.MessageFormat.format;
+import static se.fortnox.reactivewizard.util.FluxRxConverter.converterFromFlux;
 
 @Singleton
 public class DbProxy implements InvocationHandler {
 
-    private static final TypeReference<Object[]>                 OBJECT_ARRAY_TYPE_REFERENCE = new TypeReference<>() {
+    private static final TypeReference<Object[]> OBJECT_ARRAY_TYPE_REFERENCE = new TypeReference<>() {
     };
-    private final       DbStatementFactoryFactory               dbStatementFactoryFactory;
-    private final       Scheduler                               scheduler;
-    protected final     Map<Method, ObservableStatementFactory> statementFactories;
-    private final       ConnectionScheduler                     connectionScheduler;
-    protected final     Function<Object[], String>              paramSerializer;
-    private final       DatabaseConfig                          databaseConfig;
+    private final DbStatementFactoryFactory dbStatementFactoryFactory;
+    private final Scheduler scheduler;
+    protected final Map<Method, ReactiveStatementFactory> statementFactories;
+    private final ConnectionScheduler connectionScheduler;
+    protected final Function<Object[], String> paramSerializer;
+    private final DatabaseConfig databaseConfig;
 
     @Inject
     public DbProxy(DatabaseConfig databaseConfig,
-        @Nullable ConnectionProvider connectionProvider,
-        DbStatementFactoryFactory dbStatementFactoryFactory,
-        JsonSerializerFactory jsonSerializerFactory
+                   @Nullable ConnectionProvider connectionProvider,
+                   DbStatementFactoryFactory dbStatementFactoryFactory,
+                   JsonSerializerFactory jsonSerializerFactory
     ) {
         this(databaseConfig,
-            threadPool(databaseConfig.getPoolSize()),
-            connectionProvider,
-            dbStatementFactoryFactory,
-            jsonSerializerFactory);
+                threadPool(databaseConfig.getPoolSize()),
+                connectionProvider,
+                dbStatementFactoryFactory,
+                jsonSerializerFactory);
     }
 
     public DbProxy(DatabaseConfig databaseConfig,
-        Scheduler scheduler,
-        ConnectionProvider connectionProvider,
-        DbStatementFactoryFactory dbStatementFactoryFactory,
-        JsonSerializerFactory jsonSerializerFactory
+                   Scheduler scheduler,
+                   ConnectionProvider connectionProvider,
+                   DbStatementFactoryFactory dbStatementFactoryFactory,
+                   JsonSerializerFactory jsonSerializerFactory
     ) {
         this(databaseConfig, scheduler, connectionProvider, dbStatementFactoryFactory,
-            jsonSerializerFactory.createStringSerializer(OBJECT_ARRAY_TYPE_REFERENCE),
-            new ConcurrentHashMap<>());
+                jsonSerializerFactory.createStringSerializer(OBJECT_ARRAY_TYPE_REFERENCE),
+                new ConcurrentHashMap<>());
     }
 
     public DbProxy(DatabaseConfig databaseConfig, ConnectionProvider connectionProvider) {
         this(databaseConfig,
-            Schedulers.io(),
-            connectionProvider,
-            new DbStatementFactoryFactory(),
-            new JsonSerializerFactory());
+                Schedulers.boundedElastic(),
+                connectionProvider,
+                new DbStatementFactoryFactory(),
+                new JsonSerializerFactory());
     }
 
     protected DbProxy(DatabaseConfig databaseConfig,
-        Scheduler scheduler,
-        ConnectionProvider connectionProvider,
-        DbStatementFactoryFactory dbStatementFactoryFactory,
-        Function<Object[], String> paramSerializer,
-        Map<Method, ObservableStatementFactory> statementFactories
+                      Scheduler scheduler,
+                      ConnectionProvider connectionProvider,
+                      DbStatementFactoryFactory dbStatementFactoryFactory,
+                      Function<Object[], String> paramSerializer,
+                      Map<Method, ReactiveStatementFactory> statementFactories
     ) {
         this.scheduler = scheduler;
         this.dbStatementFactoryFactory = dbStatementFactoryFactory;
@@ -86,53 +85,53 @@ public class DbProxy implements InvocationHandler {
         this.connectionScheduler = new ConnectionScheduler(connectionProvider, scheduler);
     }
 
-
-
     private static Scheduler threadPool(int poolSize) {
         if (poolSize == -1) {
-            return Schedulers.io();
+            return Schedulers.boundedElastic();
         }
-        Executor executor = Executors.newFixedThreadPool(poolSize, new RxThreadFactory("DbProxy"));
-        return Schedulers.from(executor);
+        return Schedulers.newBoundedElastic(10, Integer.MAX_VALUE, "DbProxy");
     }
 
     /**
      * Create proxy from interface.
+     *
      * @param daoInterface the interface
-     * @param <T> the type of the interface
+     * @param <T>          the type of the interface
      * @return the proxy
      */
     public <T> T create(Class<T> daoInterface) {
-        return (T)Proxy.newProxyInstance(daoInterface.getClassLoader(),
-            new Class[]{daoInterface},
-            this);
+        return (T) Proxy.newProxyInstance(daoInterface.getClassLoader(),
+                new Class[]{daoInterface},
+                this);
     }
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        ObservableStatementFactory observableStatementFactory = statementFactories.get(method);
-        if (observableStatementFactory == null || DebugUtil.IS_DEBUG) {
+        ReactiveStatementFactory reactiveStatementFactory = statementFactories.get(method);
+        if (reactiveStatementFactory == null || DebugUtil.IS_DEBUG) {
             if (DebugUtil.IS_DEBUG) {
                 // Need to get the actual interface method in order to get updated annotations
                 method = ReflectionUtil.getRedefinedMethod(method);
             }
             DbStatementFactory statementFactory = dbStatementFactoryFactory.createStatementFactory(method);
-            PagingOutput       pagingOutput     = new PagingOutput(method);
-            observableStatementFactory = new ObservableStatementFactory(
-                statementFactory,
-                pagingOutput,
-                paramSerializer,
-                createMetrics(method),
-                databaseConfig,
-                FluxRxConverter.converterFromObservable(method.getReturnType()));
-            statementFactories.put(method, observableStatementFactory);
+            PagingOutput pagingOutput = new PagingOutput(method);
+            reactiveStatementFactory = new ReactiveStatementFactory(
+                    statementFactory,
+                    pagingOutput,
+                    createMetrics(method),
+                    databaseConfig,
+                    converterFromFlux(method.getReturnType()));
+            statementFactories.put(method, reactiveStatementFactory);
         }
-        return observableStatementFactory.create(args, connectionScheduler);
+        return reactiveStatementFactory.create(args, connectionScheduler);
     }
 
-    private Metrics createMetrics(Method method) {
+    private PublisherMetrics createMetrics(Method method) {
         String type = method.isAnnotationPresent(Query.class) ? "query" : "update";
-        return Metrics.get("DAO_type:" + type + "_method:" + method.getDeclaringClass().getName() + "." + method.getName() + "_" + method.getParameterCount());
+        String metricsName = format(
+                "DAO_type:{0}_method:{1}.{2}_{3}",
+                type, method.getDeclaringClass().getName(), method.getName(), method.getParameterCount());
+        return PublisherMetrics.get(metricsName);
     }
 
     public DbProxy usingConnectionProvider(ConnectionProvider connectionProvider) {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
@@ -2,44 +2,45 @@ package se.fortnox.reactivewizard.db;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import rx.Observable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
 import se.fortnox.reactivewizard.db.paging.PagingOutput;
 import se.fortnox.reactivewizard.db.statement.DbStatementFactory;
 import se.fortnox.reactivewizard.db.statement.Statement;
 import se.fortnox.reactivewizard.db.transactions.ConnectionScheduler;
 import se.fortnox.reactivewizard.db.transactions.StatementContext;
-import se.fortnox.reactivewizard.metrics.Metrics;
+import se.fortnox.reactivewizard.metrics.PublisherMetrics;
 import se.fortnox.reactivewizard.util.DebugUtil;
-import se.fortnox.reactivewizard.util.ReactiveDecorator;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.function.Function;
 
 import static java.lang.String.format;
-import static rx.Observable.error;
+import static reactor.core.publisher.Flux.error;
+import static se.fortnox.reactivewizard.util.ReactiveDecorator.decorated;
 
-public class ObservableStatementFactory {
+public class ReactiveStatementFactory {
 
-    private static final  int    RECORD_BUFFER_SIZE     = 100000;
-    private static final Logger LOG                    = LoggerFactory.getLogger("Dao");
-    private final DbStatementFactory         statementFactory;
-    private final PagingOutput               pagingOutput;
-    private final Metrics                    metrics;
-    private final DatabaseConfig             config;
-    private final Function<Observable<Object>, Object> resultConverter;
+    private static final int RECORD_BUFFER_SIZE = 100000;
+    private static final Logger LOG = LoggerFactory.getLogger("Dao");
+    private final DbStatementFactory statementFactory;
+    private final PagingOutput pagingOutput;
+    private final Function<Flux, Object> resultConverter;
+    private final PublisherMetrics publisherMetrics;
 
-    public ObservableStatementFactory(
-        DbStatementFactory statementFactory,
-        PagingOutput pagingOutput,
-        Function<Object[], String> paramSerializer,
-        Metrics metrics,
-        DatabaseConfig config,
-        Function<Observable<Object>, Object> resultConverter) {
+    private final DatabaseConfig config;
+
+    public ReactiveStatementFactory(
+            DbStatementFactory statementFactory,
+            PagingOutput pagingOutput,
+            PublisherMetrics publisherMetrics,
+            DatabaseConfig config,
+            Function<Flux, Object> resultConverter) {
         this.statementFactory = statementFactory;
         this.pagingOutput = pagingOutput;
-        this.metrics = metrics;
+        this.publisherMetrics = publisherMetrics;
         this.config = config;
         this.resultConverter = resultConverter;
     }
@@ -54,41 +55,41 @@ public class ObservableStatementFactory {
 
     /**
      * Create observable statement.
-     * @param args the arguments
-     * @param connectionScheduler the sheduler
+     *
+     * @param args                the arguments
+     * @param connectionScheduler the scheduler
      * @return the observable statement
      */
     public Object create(Object[] args, ConnectionScheduler connectionScheduler) {
         StatementContext statementContext = new StatementContext(() -> statementFactory.create(args), connectionScheduler);
-
-        Observable<Object> result = Observable.unsafeCreate(subscription -> {
+        Flux<Object> result = Flux.create(fluxSink -> {
             try {
                 statementContext.getConnectionScheduler()
-                    .schedule(subscription::onError, (connection) -> {
-                        Statement dbStatement = statementContext.getStatement();
-                        dbStatement.setSubscriber(subscription);
-                        executeStatement(dbStatement, connection);
-                    });
+                        .schedule(fluxSink::error, connection -> {
+                            Statement dbStatement = statementContext.getStatement();
+                            dbStatement.setFluxSink(fluxSink);
+                            executeStatement(dbStatement, connection);
+                        });
             } catch (Exception e) {
-                if (!subscription.isUnsubscribed()) {
-                    subscription.onError(e);
+                if (!fluxSink.isCancelled()) {
+                    fluxSink.error(e);
                 }
             }
-        });
+        }, FluxSink.OverflowStrategy.ERROR);
 
         if (DebugUtil.IS_DEBUG || LOG.isDebugEnabled()) {
             Exception queryFailure = new RuntimeException("Query failed");
-            result = result.onErrorResumeNext(thrown -> {
+            result = result.onErrorResume(thrown -> {
                 queryFailure.initCause(thrown);
                 return error(queryFailure);
             });
         }
 
         result = pagingOutput.apply(result, args);
-        result = metrics.measure(result, this::logSlowQuery);
+        result = Flux.from(publisherMetrics.measure(result, this::logSlowQuery));
         result = result.onBackpressureBuffer(RECORD_BUFFER_SIZE);
 
-        return ReactiveDecorator.decorated(resultConverter.apply(result), statementContext);
+        return decorated(resultConverter.apply(result), statementContext);
     }
 
     private void logSlowQuery(long time) {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/paging/PagingOutput.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/paging/PagingOutput.java
@@ -1,6 +1,6 @@
 package se.fortnox.reactivewizard.db.paging;
 
-import rx.Observable;
+import reactor.core.publisher.Flux;
 import se.fortnox.reactivewizard.CollectionOptions;
 import se.fortnox.reactivewizard.db.Query;
 
@@ -9,6 +9,7 @@ import java.lang.reflect.Method;
 import static com.google.common.collect.Iterables.indexOf;
 import static java.lang.Math.min;
 import static java.util.Arrays.asList;
+import static reactor.core.publisher.Operators.liftPublisher;
 
 public class PagingOutput {
     private final int index;
@@ -30,17 +31,18 @@ public class PagingOutput {
 
     /**
      * Apply paging to result.
+     *
      * @param result the result
-     * @param args the arguments
-     * @param <T> the type of result
+     * @param args   the arguments
+     * @param <T>    the type of result
      * @return the paged result
      */
-    public <T> Observable<T> apply(Observable<T> result, Object[] args) {
+    public <T> Flux<T> apply(Flux<T> result, Object[] args) {
         if (index == -1) {
             return result;
         }
 
-        CollectionOptions collectionOptions = (CollectionOptions)args[index];
+        CollectionOptions collectionOptions = (CollectionOptions) args[index];
         if (collectionOptions == null) {
             return result;
         }
@@ -50,7 +52,6 @@ public class PagingOutput {
         }
 
         collectionOptions.setLimit(min(maxLimit, collectionOptions.getLimit()));
-
-        return result.lift(new PagingOperator(collectionOptions));
+        return result.transformDeferred(liftPublisher(new PagingOperator(collectionOptions)));
     }
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/SelectStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/SelectStatementFactory.java
@@ -1,6 +1,6 @@
 package se.fortnox.reactivewizard.db.statement;
 
-import rx.Subscriber;
+import reactor.core.publisher.FluxSink;
 import se.fortnox.reactivewizard.db.deserializing.DbResultSetDeserializer;
 import se.fortnox.reactivewizard.db.query.ParameterizedQuery;
 
@@ -18,14 +18,14 @@ public class SelectStatementFactory extends AbstractDbStatementFactory {
     }
 
     @Override
-    protected void executeStatement(Connection connection, Object[] args, Subscriber subscriber)
+    protected void executeStatement(Connection connection, Object[] args, FluxSink fluxSink)
         throws SQLException {
         try (PreparedStatement statement = parameterizedQuery.createStatement(connection, args)) {
             parameterizedQuery.addParameters(args, statement);
             try (ResultSet resultSet = statement.executeQuery()) {
                 while (resultSet.next()) {
-                    if (subscriber != null) {
-                        subscriber.onNext(deserializer.deserialize(resultSet));
+                    if (fluxSink != null) {
+                        fluxSink.next(deserializer.deserialize(resultSet));
                     }
                 }
             }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/Statement.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/Statement.java
@@ -1,10 +1,11 @@
 package se.fortnox.reactivewizard.db.statement;
 
-import rx.Subscriber;
+import reactor.core.publisher.FluxSink;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+
 
 public interface Statement {
     void execute(Connection connection) throws SQLException;
@@ -35,13 +36,15 @@ public interface Statement {
 
     /**
      * Checks compatibility with other batch.
+     *
      * @return <code>true</code> if the specified statement might be added to the batch.
      */
     boolean sameBatch(Statement statement);
 
     /**
-     * Set the subscriber.
-     * @param subscriber the subscriber
+     * Set the FluxSink.
+     *
+     * @param fluxSink the FluxSink
      */
-    void setSubscriber(Subscriber<?> subscriber);
+    void setFluxSink(FluxSink<?> fluxSink);
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementExecutorReturningCountFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementExecutorReturningCountFactory.java
@@ -1,6 +1,6 @@
 package se.fortnox.reactivewizard.db.statement;
 
-import rx.Subscriber;
+import reactor.core.publisher.FluxSink;
 import se.fortnox.reactivewizard.db.query.ParameterizedQuery;
 
 import java.sql.Connection;
@@ -14,11 +14,11 @@ public class UpdateStatementExecutorReturningCountFactory extends AbstractUpdate
     }
 
     @Override
-    protected void executeStatement(Connection connection, Object[] args, Subscriber subscriber)
-        throws SQLException {
+    protected void executeStatement(Connection connection, Object[] args, FluxSink fluxSink)
+            throws SQLException {
         try (PreparedStatement statement = parameterizedQuery.createStatement(connection, args)) {
             parameterizedQuery.addParameters(args, statement);
-            executed(statement.executeUpdate(), subscriber);
+            executed(statement.executeUpdate(), fluxSink);
         }
     }
 
@@ -33,16 +33,16 @@ public class UpdateStatementExecutorReturningCountFactory extends AbstractUpdate
         return preparedStatement;
     }
 
-    protected void executed(int count, Subscriber subscriber) throws SQLException {
+    protected void executed(int count, FluxSink fluxSink) throws SQLException {
         ensureMinimumReached(count);
-        if (subscriber != null) {
-            subscriber.onNext(count);
+        if (fluxSink != null) {
+            fluxSink.next(count);
         }
     }
 
     @Override
-    protected void batchExecuted(int count, Subscriber subscriber) throws SQLException {
-        executed(count, subscriber);
+    protected void batchExecuted(int count, FluxSink fluxSink) throws SQLException {
+        executed(count, fluxSink);
     }
 
     @Override

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementReturningVoidFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/UpdateStatementReturningVoidFactory.java
@@ -1,6 +1,6 @@
 package se.fortnox.reactivewizard.db.statement;
 
-import rx.Subscriber;
+import reactor.core.publisher.FluxSink;
 import se.fortnox.reactivewizard.db.query.ParameterizedQuery;
 
 import java.sql.SQLException;
@@ -12,7 +12,7 @@ public class UpdateStatementReturningVoidFactory extends UpdateStatementExecutor
     }
 
     @Override
-    protected void executed(int count, Subscriber subscriber) throws SQLException {
+    protected void executed(int count, FluxSink fluxSink) throws SQLException {
         ensureMinimumReached(count);
     }
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/ConnectionScheduler.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/ConnectionScheduler.java
@@ -1,6 +1,6 @@
 package se.fortnox.reactivewizard.db.transactions;
 
-import rx.Scheduler;
+import reactor.core.scheduler.Scheduler;
 import se.fortnox.reactivewizard.db.ConnectionProvider;
 
 import java.sql.Connection;
@@ -21,8 +21,9 @@ public class ConnectionScheduler {
 
     /**
      * Schedule action.
+     *
      * @param onError the error handler
-     * @param action the action
+     * @param action  the action
      */
     public void schedule(Consumer<Throwable> onError, ThrowableAction action) {
         Scheduler.Worker worker = scheduler.createWorker();
@@ -32,7 +33,7 @@ public class ConnectionScheduler {
             } catch (Exception e) {
                 onError.accept(e);
             } finally {
-                worker.unsubscribe();
+                worker.dispose();
             }
         });
     }

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTestDao.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTestDao.java
@@ -32,6 +32,9 @@ public interface DbProxyTestDao {
     @Update("insert into table")
     Observable<GeneratedKey<Long>> insert();
 
+    @Update("insert into table")
+    Flux<GeneratedKey<Long>> insertFlux();
+
     @Update("insert into table (date) values (:date)")
     Observable<GeneratedKey<Long>> insertWithGeneratedKey(LocalDate date);
 


### PR DESCRIPTION
Most of the dao module now uses Reactor instead of RxJava.
Renamed ObservableStatementFactory to ReactiveStatementFactory.