### PR TITLE
Add type info on deserialization errors

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -590,9 +590,14 @@ public class HttpClient implements InvocationHandler {
 
         try {
             JavaType     javaType = TypeFactory.defaultInstance().constructType(type);
-            ObjectReader reader   = objectMapper.readerFor(javaType);
-            Object       value    = reader.readValue(string);
-            return Mono.justOrEmpty(value);
+            try {
+                ObjectReader reader = objectMapper.readerFor(javaType);
+                Object       value    = reader.readValue(string);
+                return Mono.justOrEmpty(value);
+            } catch (NoClassDefFoundError e) {
+                // Add type info on serialization errors to help with debugging
+                throw new RuntimeException(String.format("Could not create deserializer for class %s", type.getTypeName()), e);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Improve troubleshooting bad type serialization in framework. These errors might occur for example when migrating from old `jackson-annotations` versions that move from the package `javax.validation` to `jakarta.validation`.