### PR TITLE
Force releases any locks by Liquibase 4 to avoid crash loops due to unclean shutdowns.

### DIFF
--- a/dbmigrate/src/main/resources/META-INF/services/liquibase.lockservice.LockService
+++ b/dbmigrate/src/main/resources/META-INF/services/liquibase.lockservice.LockService
@@ -1,0 +1,1 @@
+liquibase.ext.TimeoutLockService


### PR DESCRIPTION
Before 4.0, Liquibase had a custom ServiceLocator class to find classes that implemented Liquibase interfaces. Starting with major version 4, Liquibase switched to the standard java.util.ServiceLoader system to find extension classes.

 When we updated to major version 4 of Liquibase our own TimeoutLockService was not loaded anymore. This fix will make sure that Liquibase loads our TimeoutLockService class that solves the shortcomings of Liquibase's own LockService.

https://docs.liquibase.com/tools-integrations/extensions/extension-upgrade-guides/lb-4.0-upgrade-guide.html?Highlight=extension