### PR TITLE
Added an error message when trying to return null values from the database as part of the reactive stream.

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/SelectStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/SelectStatementFactory.java
@@ -28,8 +28,8 @@ public class SelectStatementFactory extends AbstractDbStatementFactory {
             try (ResultSet resultSet = statement.executeQuery()) {
                 while (resultSet.next()) {
                     if (fluxSink != null) {
-                        var val = deserializer.deserialize(resultSet);
-                        if(val == null){
+                        var value = deserializer.deserialize(resultSet);
+                        if (value == null) {
                             throw new NullPointerException("""
                                 One or more selected values from the database is null.
                                 Project Reactor does not allow emitting null values in a stream. Wrap the return value from the dao interface
@@ -39,10 +39,8 @@ public class SelectStatementFactory extends AbstractDbStatementFactory {
                                     String maybeNullValue
                                 }
                                 """);
-                        } else {
-                            fluxSink.next(val);
                         }
-
+                        fluxSink.next(value);
                     }
                 }
             }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/SelectStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/SelectStatementFactory.java
@@ -30,15 +30,16 @@ public class SelectStatementFactory extends AbstractDbStatementFactory {
                     if (fluxSink != null) {
                         var value = deserializer.deserialize(resultSet);
                         if (value == null) {
+                            var sqlQuery = parameterizedQuery.toString();
                             throw new NullPointerException("""
-                                One or more selected values from the database is null.
+                                One or more of the values returned in the resultset of the following query was null:
+                                {{sqlQuery}}
+                                  
                                 Project Reactor does not allow emitting null values in a stream. Wrap the return value from the dao interface
-                                in a 'wrapping class' to solve the issue.
+                                in a 'wrapper' to solve the issue.
                                 Example: 
-                                class WrappingClass {    
-                                    String maybeNullValue
-                                }
-                                """);
+                                record Wrapper(String nullableValue) {};
+                                """.replace("{{sqlQuery}}", sqlQuery));
                         }
                         fluxSink.next(value);
                     }

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
@@ -13,6 +13,7 @@ import rx.observers.TestSubscriber;
 import se.fortnox.reactivewizard.config.TestInjector;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
 import se.fortnox.reactivewizard.json.JsonSerializerFactory;
+import se.fortnox.reactivewizard.util.DebugUtil;
 
 import java.sql.SQLException;
 import java.time.LocalDate;
@@ -58,14 +59,16 @@ public class DbProxyTest {
     @Test
     public void shouldThrowExceptionWhenDirectlySelectingNullValues() throws SQLException {
         mockDb.addRowColumn(1, 1, "sql_val", String.class, null);
-
         StepVerifier.create(dbProxyTestDao.selectSpecificColumn("mykey"))
                 .expectErrorSatisfies((throwable -> {
-                    assertThat(throwable)
-                        .isInstanceOf(RuntimeException.class);
-                    assertThat(throwable.getCause())
+                    Throwable throwableToAssert = throwable;
+                    if(DebugUtil.IS_DEBUG) {
+                        throwableToAssert = throwable.getCause();
+                    }
+                    assertThat(throwableToAssert)
                         .isInstanceOf(NullPointerException.class);
-                    assertThat(throwable.getCause().getMessage())
+
+                    assertThat(throwableToAssert.getMessage())
                         .isEqualTo("""
                                 One or more selected values from the database is null.
                                 Project Reactor does not allow emitting null values in a stream. Wrap the return value from the dao interface

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
@@ -70,13 +70,13 @@ public class DbProxyTest {
 
                     assertThat(throwableToAssert.getMessage())
                         .isEqualTo("""
-                                One or more selected values from the database is null.
-                                Project Reactor does not allow emitting null values in a stream. Wrap the return value from the dao interface
-                                in a 'wrapping class' to solve the issue.
-                                Example: 
-                                class WrappingClass {    
-                                    String maybeNullValue
-                                }
+                            One or more of the values returned in the resultset of the following query was null:
+                            select sql_val from table where key=:key
+                              
+                            Project Reactor does not allow emitting null values in a stream. Wrap the return value from the dao interface
+                            in a 'wrapper' to solve the issue.
+                            Example: 
+                            record Wrapper(String nullableValue) {};
                                 """);
                 }))
                 .verify();

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTestDao.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTestDao.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
+import java.util.Optional;
 
 public interface DbProxyTestDao {
     @Update("update table set val=:val where key=:key")
@@ -19,6 +20,9 @@ public interface DbProxyTestDao {
 
     @Query("select * from table where key=:key")
     Observable<DbTestObj> select(String key);
+
+    @Query("select sql_val from table where key=:key")
+    Flux<String> selectSpecificColumn(String key);
 
     @Query("select * from table where key=:key")
     Flux<DbTestObj> selectFlux(String key);


### PR DESCRIPTION
The reactive streams specification disallows null values in a sequence. Now when the dao module has been migrated to project reactor we cannot return null values in a reactive stream. We do that when we select specific columns from a database, that may be null.  Consider the following:


```
@Select( "select may_be_null_column from table where id = :id" )
Flux<String> getStuff(Integer id);
```
Here may_be_null_column may be null.

Backward compatibility is hard to get here.  we can either: 
* Ignore the null values returned in the sequence
* Throw an exception stating that returning null values cannot be done. 

We went with the "throw an exception" since ignoring values might be more dangerous because it will hide the problem. As well the user can get around the issue by wrapping the possible null values. 

So one can say the dao migration is breaking because it will changed the behavior on null values. This will only make it clearer for developers to understand the problem.

