### PR TITLE
Changed log level for decode failure

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequest.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsRequest.java
@@ -111,7 +111,7 @@ public class JaxRsRequest {
             try {
                 queryParameters = queryStringDecoder.parameters();
             } catch (IllegalArgumentException e) {
-                LOG.error("Failed to decode HTTP query params for request {} {}", req.method().name(), req.uri(), e);
+                LOG.info("Failed to decode HTTP query params for request {} {}", req.method().name(), req.uri(), e);
                 throw new WebException(HttpResponseStatus.BAD_REQUEST);
             }
         }


### PR DESCRIPTION
Changed log level from error to info for failure to decode http query params.