### PR TITLE
execute transaction will now accept Mono and Flux.

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsFlux.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsFlux.java
@@ -1,5 +1,6 @@
 package se.fortnox.reactivewizard.db.transactions;
 
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 public interface DaoTransactionsFlux {
@@ -10,7 +11,7 @@ public interface DaoTransactionsFlux {
      * @param daoCalls dao calls to run as on single transaction
      * @return empty Flux
      */
-    <T> Mono<Void> executeTransaction(Iterable<Mono<T>> daoCalls);
+    <T> Mono<Void> executeTransaction(Iterable<? extends Publisher<T>> daoCalls);
 
     /**
      * Creates and executes a transaction for the passed dao-calls.
@@ -19,5 +20,5 @@ public interface DaoTransactionsFlux {
      * @param daoCalls dao calls to run as on single transaction
      * @return  empty Flux
      */
-    <T> Mono<Void> executeTransaction(Mono<T>... daoCalls);
+    <T> Mono<Void> executeTransaction(Publisher<T>... daoCalls);
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsFlux.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsFlux.java
@@ -1,6 +1,6 @@
 package se.fortnox.reactivewizard.db.transactions;
 
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface DaoTransactionsFlux {
     /**
@@ -10,7 +10,7 @@ public interface DaoTransactionsFlux {
      * @param daoCalls dao calls to run as on single transaction
      * @return empty Flux
      */
-    <T> Flux<Void> executeTransaction(Iterable<Flux<T>> daoCalls);
+    <T> Mono<Void> executeTransaction(Iterable<Mono<T>> daoCalls);
 
     /**
      * Creates and executes a transaction for the passed dao-calls.
@@ -19,5 +19,5 @@ public interface DaoTransactionsFlux {
      * @param daoCalls dao calls to run as on single transaction
      * @return  empty Flux
      */
-    <T> Flux<Void> executeTransaction(Flux<T>... daoCalls);
+    <T> Mono<Void> executeTransaction(Mono<T>... daoCalls);
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsFluxImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsFluxImpl.java
@@ -1,5 +1,6 @@
 package se.fortnox.reactivewizard.db.transactions;
 
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import se.fortnox.reactivewizard.util.ReactiveDecorator;
 
@@ -20,7 +21,7 @@ public class DaoTransactionsFluxImpl implements DaoTransactionsFlux {
     }
 
     @Override
-    public <T> Mono<Void> executeTransaction(Iterable<Mono<T>> daoCalls) {
+    public <T> Mono<Void> executeTransaction(Iterable<? extends Publisher<T>> daoCalls) {
         if (daoCalls == null) {
             return Mono.empty();
         }
@@ -38,7 +39,7 @@ public class DaoTransactionsFluxImpl implements DaoTransactionsFlux {
     }
 
     @Override
-    public <T> Mono<Void> executeTransaction(Mono<T>... daoCalls) {
+    public <T> Mono<Void> executeTransaction(Publisher<T>... daoCalls) {
         return executeTransaction(asList(daoCalls));
     }
 }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsFluxImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/transactions/DaoTransactionsFluxImpl.java
@@ -1,6 +1,6 @@
 package se.fortnox.reactivewizard.db.transactions;
 
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import se.fortnox.reactivewizard.util.ReactiveDecorator;
 
 import javax.inject.Inject;
@@ -20,25 +20,25 @@ public class DaoTransactionsFluxImpl implements DaoTransactionsFlux {
     }
 
     @Override
-    public <T> Flux<Void> executeTransaction(Iterable<Flux<T>> daoCalls) {
+    public <T> Mono<Void> executeTransaction(Iterable<Mono<T>> daoCalls) {
         if (daoCalls == null) {
-            return Flux.empty();
+            return Mono.empty();
         }
         List<StatementContext> statementContexts = transactionExecutor.getStatementContexts(daoCalls, ReactiveDecorator::getDecoration);
         if (statementContexts.isEmpty()) {
-            return Flux.empty();
+            return Mono.empty();
         }
-        return Flux.create(subscription -> {
+        return Mono.create(subscription -> {
             ConnectionScheduler connectionScheduler = transactionExecutor.getConnectionScheduler(statementContexts);
             connectionScheduler.schedule(subscription::error, connection -> {
                 transactionExecutor.executeTransaction(statementContexts, connection);
-                subscription.complete();
+                subscription.success();
             });
         });
     }
 
     @Override
-    public <T> Flux<Void> executeTransaction(Flux<T>... daoCalls) {
+    public <T> Mono<Void> executeTransaction(Mono<T>... daoCalls) {
         return executeTransaction(asList(daoCalls));
     }
 }

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/ReactiveDecorator.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/ReactiveDecorator.java
@@ -73,6 +73,24 @@ public class ReactiveDecorator {
     }
 
     /**
+     * Get the decoration of a Publisher.
+     * @param wrapper the Publisher
+     * @param <T> the type of the decoration
+     * @return an Optional containing the decoration, if any
+     */
+    public static <T> Optional<T> getDecoration(Publisher<?> wrapper) {
+        if (wrapper instanceof DecoratedFlux decoratedFlux) {
+            return getDecoration(decoratedFlux);
+        }
+
+        if (wrapper instanceof DecoratedMono decoratedMono) {
+            return getDecoration(decoratedMono);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
      * Get the decoration of a Mono.
      * @param wrapper the Mono
      * @param <T> the type of the decoration


### PR DESCRIPTION
Since commands sent to a database is typically inserts or updates which normally would return a single integer (number of rows affected) or empty if specified as Mono<Void>