### PR TITLE
Introduce "json.useLambdaSerializerModifier" configuration

### DIFF
--- a/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
+++ b/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import se.fortnox.reactivewizard.binding.AutoBindModules;
 import se.fortnox.reactivewizard.config.ConfigFactory;
 import se.fortnox.reactivewizard.config.TestInjector;
+import se.fortnox.reactivewizard.json.JsonConfig;
 import se.fortnox.reactivewizard.server.ServerConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -135,6 +136,10 @@ public class LiquibaseAutoBindModuleTest {
                 }};
                 when(configFactory.get(ServerConfig.class)).thenReturn(serverConfig);
                 bind(ServerConfig.class).toInstance(serverConfig);
+
+                JsonConfig jsonConfig = new JsonConfig();
+                when(configFactory.get(JsonConfig.class)).thenReturn(jsonConfig);
+                bind(JsonConfig.class).toInstance(jsonConfig);
 
                 LiquibaseConfig liquibaseConfig = new LiquibaseConfig();
                 liquibaseConfig.setUrl("jdbc:h2:mem:test");

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
 
         <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-config</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/json/src/main/java/se/fortnox/reactivewizard/json/JsonConfig.java
+++ b/json/src/main/java/se/fortnox/reactivewizard/json/JsonConfig.java
@@ -1,0 +1,24 @@
+package se.fortnox.reactivewizard.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import se.fortnox.reactivewizard.config.Config;
+
+/**
+ * Configures JSON behavior
+ */
+@Config(value = "json")
+public class JsonConfig {
+    /**
+     * Note: @JsonUnwrapped annotation doesn't work during serialization when lambda serializer modifier is enabled
+     */
+    @JsonProperty("useLambdaSerializerModifier")
+    private boolean useLambdaSerializerModifier = true;
+
+    public boolean isUseLambdaSerializerModifier() {
+        return useLambdaSerializerModifier;
+    }
+
+    public void setUseLambdaSerializerModifier(boolean useLambdaSerializerModifier) {
+        this.useLambdaSerializerModifier = useLambdaSerializerModifier;
+    }
+}

--- a/json/src/main/java/se/fortnox/reactivewizard/json/JsonSerializerFactory.java
+++ b/json/src/main/java/se/fortnox/reactivewizard/json/JsonSerializerFactory.java
@@ -21,9 +21,11 @@ public class JsonSerializerFactory {
     private final ObjectMapper mapper;
 
     @Inject
-    public JsonSerializerFactory(ObjectMapper mapper) {
-        this.mapper = mapper.setSerializerFactory(mapper.getSerializerFactory()
-            .withSerializerModifier(new LambdaSerializerModifier()));
+    public JsonSerializerFactory(ObjectMapper mapper, JsonConfig jsonConfig) {
+        this.mapper = jsonConfig.isUseLambdaSerializerModifier()
+            ? mapper.setSerializerFactory(mapper.getSerializerFactory()
+                .withSerializerModifier(new LambdaSerializerModifier()))
+            : mapper;
     }
 
     public JsonSerializerFactory() {
@@ -32,7 +34,7 @@ public class JsonSerializerFactory {
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .defaultDateFormat(new StdDateFormat().withColonInTimeZone(false)) // Preserve behavior prior to Jackson 2.11
-            .build());
+            .build(), new JsonConfig());
     }
 
     public <T> Function<T, String> createStringSerializer(TypeReference<T> paramType) {


### PR DESCRIPTION
* which is "true" by default, but is not compatible with "@JsonUnwrapped" annotation usage at the same time;
* so if one would like to use the aforementioned annotation one could switch serializer modifier configuration off.