### PR TITLE
Make it easier to use custom classes as request parameters

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/CustomClassDeserializerFactory.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/CustomClassDeserializerFactory.java
@@ -6,6 +6,10 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
 class CustomClassDeserializerFactory {
+
+    private CustomClassDeserializerFactory() {
+    }
+
     @Nullable
     public static <T> Deserializer<T> createOrNull(Class<T> cls) {
         var methods = cls.getMethods();

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/CustomClassDeserializerFactory.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/CustomClassDeserializerFactory.java
@@ -1,30 +1,37 @@
 package se.fortnox.reactivewizard.jaxrs.params.deserializing;
 
+import se.fortnox.reactivewizard.util.LambdaCompiler;
+
 import javax.annotation.Nullable;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.function.Function;
 
 class CustomClassDeserializerFactory {
 
     private CustomClassDeserializerFactory() {
     }
 
+    private static final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
     @Nullable
     public static <T> Deserializer<T> createOrNull(Class<T> cls) {
         var methods = cls.getMethods();
 
-        var valueOfDeserializer = findStaticMethodDeserializer(methods, "valueOf", cls);
+        var valueOfDeserializer = getStaticMethodDeserializerOrNull(methods, "valueOf", cls);
         if (valueOfDeserializer != null) {
             return valueOfDeserializer;
         }
 
-        var fromStringDeserializer = findStaticMethodDeserializer(methods, "fromString", cls);
+        var fromStringDeserializer = getStaticMethodDeserializerOrNull(methods, "fromString", cls);
         if (fromStringDeserializer != null) {
             return fromStringDeserializer;
         }
 
-        var constructorDeserializer = findConstructorDeserializer(cls);
+        var constructorDeserializer = getConstructorDeserializerOrNull(cls);
         if (constructorDeserializer != null) {
             return constructorDeserializer;
         }
@@ -32,9 +39,8 @@ class CustomClassDeserializerFactory {
         return null;
     }
 
-    @SuppressWarnings("unchecked")
     @Nullable
-    private static <T> Deserializer<T> findStaticMethodDeserializer(Method[] methods, String methodName, Class<T> cls) {
+    private static <T> Deserializer<T> getStaticMethodDeserializerOrNull(Method[] methods, String methodName, Class<T> cls) {
         var method = Arrays.stream(methods)
             .filter(it -> it.getName().equals(methodName)
                 && it.getParameterCount() == 1
@@ -44,49 +50,59 @@ class CustomClassDeserializerFactory {
             .findFirst()
             .orElse(null);
 
-        if (method != null) {
-            return value -> {
-                try {
-                    if (value == null) {
-                        return null;
-                    }
-
-                    return (T)method.invoke(null, value);
-                } catch (Exception e) {
-                    throw deserializerExceptionFor(cls);
-                }
-            };
+        if (method == null) {
+            return null;
         }
 
-        return null;
+        var compiledFunction = compileMethod(method, cls);
+
+        return createDeserializerFromFunction(compiledFunction, cls);
     }
 
     @SuppressWarnings("unchecked")
     @Nullable
-    private static <T> Deserializer<T> findConstructorDeserializer(Class<T> cls) {
-        var constructor = Arrays.stream(cls.getConstructors())
+    private static <T> Deserializer<T> getConstructorDeserializerOrNull(Class<T> cls) {
+        var constructor = (Constructor<T>)Arrays.stream(cls.getConstructors())
             .filter(it -> it.getParameterCount() == 1 && it.getParameterTypes()[0].equals(String.class))
             .findFirst()
             .orElse(null);
 
-        if (constructor != null) {
-            return value -> {
-                try {
-                    if (value == null) {
-                        return null;
-                    }
-
-                    return (T)constructor.newInstance(value);
-                } catch (Exception e) {
-                    throw deserializerExceptionFor(cls);
-                }
-            };
+        if (constructor == null) {
+            return null;
         }
 
-        return null;
+        var compiledFunction = compileConstructor(constructor, cls);
+
+        return createDeserializerFromFunction(compiledFunction, cls);
     }
 
-    private static DeserializerException deserializerExceptionFor(Class<?> cls)   {
-        return new DeserializerException(String.format("invalid.%s", cls.getSimpleName()));
+    private static <T> Function<String, T> compileMethod(Method method, Class<T> cls) {
+        try {
+            return LambdaCompiler.compileLambdaFunction(lookup, lookup.unreflect(method));
+        } catch (Throwable t) {
+            throw new RuntimeException(String.format("Unable to compile '%s' method for '%s'", method.getName(), cls.getSimpleName()), t);
+        }
+    }
+
+    private static <T> Function<String, T> compileConstructor(Constructor<T> constructor, Class<T> cls) {
+        try {
+            return LambdaCompiler.compileLambdaFunction(lookup, lookup.unreflectConstructor(constructor));
+        } catch (Throwable t) {
+            throw new RuntimeException(String.format("Unable to compile constructor for '%s'", cls.getSimpleName()), t);
+        }
+    }
+
+    private static <T> Deserializer<T> createDeserializerFromFunction(Function<String, T> function, Class<T> cls) {
+        return value -> {
+            try {
+                if (value == null) {
+                    return null;
+                }
+
+                return function.apply(value);
+            } catch (Exception e) {
+                throw new DeserializerException(String.format("invalid.%s", cls.getSimpleName()));
+            }
+        };
     }
 }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/CustomClassDeserializerFactory.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/CustomClassDeserializerFactory.java
@@ -1,0 +1,88 @@
+package se.fortnox.reactivewizard.jaxrs.params.deserializing;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+
+class CustomClassDeserializerFactory {
+    @Nullable
+    public static <T> Deserializer<T> createOrNull(Class<T> cls) {
+        var methods = cls.getMethods();
+
+        var valueOfDeserializer = findStaticMethodDeserializer(methods, "valueOf", cls);
+        if (valueOfDeserializer != null) {
+            return valueOfDeserializer;
+        }
+
+        var fromStringDeserializer = findStaticMethodDeserializer(methods, "fromString", cls);
+        if (fromStringDeserializer != null) {
+            return fromStringDeserializer;
+        }
+
+        var constructorDeserializer = findConstructorDeserializer(cls);
+        if (constructorDeserializer != null) {
+            return constructorDeserializer;
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private static <T> Deserializer<T> findStaticMethodDeserializer(Method[] methods, String methodName, Class<T> cls) {
+        var method = Arrays.stream(methods)
+            .filter(it -> it.getName().equals(methodName)
+                && it.getParameterCount() == 1
+                && it.getParameterTypes()[0].equals(String.class)
+                && Modifier.isStatic(it.getModifiers())
+            )
+            .findFirst()
+            .orElse(null);
+
+        if (method != null) {
+            return value -> {
+                try {
+                    if (value == null) {
+                        return null;
+                    }
+
+                    return (T)method.invoke(null, value);
+                } catch (Exception e) {
+                    throw deserializerExceptionFor(cls);
+                }
+            };
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private static <T> Deserializer<T> findConstructorDeserializer(Class<T> cls) {
+        var constructor = Arrays.stream(cls.getConstructors())
+            .filter(it -> it.getParameterCount() == 1 && it.getParameterTypes()[0].equals(String.class))
+            .findFirst()
+            .orElse(null);
+
+        if (constructor != null) {
+            return value -> {
+                try {
+                    if (value == null) {
+                        return null;
+                    }
+
+                    return (T)constructor.newInstance(value);
+                } catch (Exception e) {
+                    throw deserializerExceptionFor(cls);
+                }
+            };
+        }
+
+        return null;
+    }
+
+    private static DeserializerException deserializerExceptionFor(Class<?> cls)   {
+        return new DeserializerException(String.format("invalid.%s", cls.getSimpleName()));
+    }
+}

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactory.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactory.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.util.StdDateFormat;
 import se.fortnox.reactivewizard.json.JsonDeserializerFactory;
 import se.fortnox.reactivewizard.util.ReflectionUtil;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.ws.rs.core.MediaType;
@@ -24,13 +25,13 @@ import java.util.function.Function;
 public class DeserializerFactory {
 
     private final JsonDeserializerFactory     jsonDeserializerFactory;
-    private final Map<Class<?>, Deserializer> stringDeserializers;
+    private final Map<Class<?>, Deserializer<?>> stringDeserializers;
 
     @Inject
     public DeserializerFactory(Provider<DateFormat> dateFormatProvider, JsonDeserializerFactory jsonDeserializerFactory) {
         this.jsonDeserializerFactory = jsonDeserializerFactory;
 
-        stringDeserializers = new HashMap<Class<?>, Deserializer>() {
+        stringDeserializers = new HashMap<>() {
             {
                 put(Boolean.class, new BooleanDeserializer());
                 put(boolean.class, new BooleanNotNullDeserializer());
@@ -50,55 +51,77 @@ public class DeserializerFactory {
     }
 
     public DeserializerFactory() {
-        this(() -> new StdDateFormat(), new JsonDeserializerFactory());
+        this(StdDateFormat::new, new JsonDeserializerFactory());
     }
 
     /**
      * Return Deserializer from param type.
+     *
      * @param paramType the param type
-     * @param <T> the type of the deserializer
+     * @param <T>       the type of the deserializer
      * @return the deserializer
      */
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public <T> Deserializer<T> getParamDeserializer(TypeReference<T> paramType) {
-        Class<?>        paramCls     = ReflectionUtil.getRawType(paramType.getType());
-        Deserializer<T> deserializer = (Deserializer<T>)stringDeserializers.get(paramCls);
-
-        if (deserializer != null) {
-            return deserializer;
-        }
-
-        if (paramCls.isEnum()) {
-            return new EnumDeserializer(paramCls);
-        }
+        var paramCls = ReflectionUtil.getRawType(paramType.getType());
 
         if (List.class.isAssignableFrom(paramCls)) {
-            Class<?>     elementType = ReflectionUtil.getGenericParameter(paramType.getType());
+            var          elementCls = ReflectionUtil.getGenericParameter(paramType.getType());
             Deserializer elementDeserializer;
 
-            if (elementType.isEnum()) {
-                elementDeserializer = new EnumDeserializer(elementType);
+            if (elementCls.isEnum()) {
+                elementDeserializer = new EnumDeserializer(elementCls);
             } else {
-                elementDeserializer = stringDeserializers.get(elementType);
+                elementDeserializer = getClassDeserializer(elementCls);
             }
 
             return new ListDeserializer(elementDeserializer);
         }
 
         if (paramCls.isArray()) {
-            final Deserializer elementDeserializer = stringDeserializers.get(paramCls.getComponentType());
+            final Deserializer elementDeserializer = getClassDeserializer(paramCls.getComponentType());
             return new ArrayDeserializer(elementDeserializer, paramCls.getComponentType());
+        }
+
+        var deserializer = (Deserializer<T>)getClassDeserializer(paramCls);
+        if (deserializer != null) {
+            return deserializer;
         }
 
         throw new RuntimeException("Field of type " + paramType.getType() + " is not allowed to be used in query/form/header");
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Nullable
+    public <T> Deserializer<T> getClassDeserializer(Class<T> paramCls) {
+        var existingDeserializer = (Deserializer<T>)stringDeserializers.get(paramCls);
+        if (existingDeserializer != null) {
+            return existingDeserializer;
+        }
+
+        if (paramCls.isEnum()) {
+            return new EnumDeserializer(paramCls);
+        }
+
+        var customClassDeserializer = (Deserializer<T>)CustomClassDeserializerFactory.createOrNull(paramCls);
+        if (customClassDeserializer != null) {
+            stringDeserializers.put(paramCls, customClassDeserializer);
+
+            return customClassDeserializer;
+        }
+
+        return null;
+    }
+
     /**
      * Return the body deserializer for param type.
+     *
      * @param paramType the param type
-     * @param consumes the consumes requirements
-     * @param <T> type of deserializer
+     * @param consumes  the consumes requirements
+     * @param <T>       type of deserializer
      * @return the deserializer
      */
+    @SuppressWarnings("unchecked")
     public <T> BodyDeserializer<T> getBodyDeserializer(TypeReference<T> paramType, String[] consumes) {
         // Only support a single consumes for now
         String consume = consumes[0];

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactory.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactory.java
@@ -66,14 +66,8 @@ public class DeserializerFactory {
         var paramCls = ReflectionUtil.getRawType(paramType.getType());
 
         if (List.class.isAssignableFrom(paramCls)) {
-            var          elementCls = ReflectionUtil.getGenericParameter(paramType.getType());
-            Deserializer elementDeserializer;
-
-            if (elementCls.isEnum()) {
-                elementDeserializer = new EnumDeserializer(elementCls);
-            } else {
-                elementDeserializer = getClassDeserializer(elementCls);
-            }
+            var elementCls          = ReflectionUtil.getGenericParameter(paramType.getType());
+            var elementDeserializer = getClassDeserializer(elementCls);
 
             return new ListDeserializer(elementDeserializer);
         }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactory.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactory.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 
+import static java.util.Map.entry;
+
 /**
  * Creates deserializers from Strings to a given type.
  */
@@ -31,23 +33,21 @@ public class DeserializerFactory {
     public DeserializerFactory(Provider<DateFormat> dateFormatProvider, JsonDeserializerFactory jsonDeserializerFactory) {
         this.jsonDeserializerFactory = jsonDeserializerFactory;
 
-        stringDeserializers = new HashMap<>() {
-            {
-                put(Boolean.class, new BooleanDeserializer());
-                put(boolean.class, new BooleanNotNullDeserializer());
-                put(int.class, new IntegerNotNullDeserializer());
-                put(long.class, new LongNotNullDeserializer());
-                put(double.class, new DoubleNotNullDeserializer());
-                put(Integer.class, new IntegerDeserializer());
-                put(Long.class, new LongDeserializer());
-                put(Double.class, new DoubleDeserializer());
-                put(String.class, (val) -> val);
-                put(UUID.class, new UUIDDeserializer());
-                put(Date.class, new DateDeserializer(dateFormatProvider));
-                put(LocalDate.class, new LocalDateDeserializer());
-                put(LocalTime.class, new LocalTimeDeserializer());
-            }
-        };
+        stringDeserializers = new HashMap<>(Map.ofEntries(
+            entry(Boolean.class, new BooleanDeserializer()),
+            entry(boolean.class, new BooleanNotNullDeserializer()),
+            entry(int.class, new IntegerNotNullDeserializer()),
+            entry(long.class, new LongNotNullDeserializer()),
+            entry(double.class, new DoubleNotNullDeserializer()),
+            entry(Integer.class, new IntegerDeserializer()),
+            entry(Long.class, new LongDeserializer()),
+            entry(Double.class, new DoubleDeserializer()),
+            entry(String.class, (val) -> val),
+            entry(UUID.class, new UUIDDeserializer()),
+            entry(Date.class, new DateDeserializer(dateFormatProvider)),
+            entry(LocalDate.class, new LocalDateDeserializer()),
+            entry(LocalTime.class, new LocalTimeDeserializer())
+        ));
     }
 
     public DeserializerFactory() {
@@ -103,7 +103,7 @@ public class DeserializerFactory {
             return new EnumDeserializer(paramCls);
         }
 
-        var customClassDeserializer = (Deserializer<T>)CustomClassDeserializerFactory.createOrNull(paramCls);
+        var customClassDeserializer = CustomClassDeserializerFactory.createOrNull(paramCls);
         if (customClassDeserializer != null) {
             stringDeserializers.put(paramCls, customClassDeserializer);
 

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -34,6 +34,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static java.util.Arrays.asList;
@@ -166,7 +167,30 @@ class JaxRsResourceTest {
 
         assertThat(body(get(service, "/test/acceptsEnum?myarg=")))
             .isEqualTo("\"Enum: null\"");
+    }
 
+    @Test
+    void shouldSupportCustomClassesAsQueryParams() {
+        assertThat(body(get(service, "/test/acceptsCustomClass/valueOf?myarg=the-custom-value")))
+            .isEqualTo("\"the-custom-value\"");
+
+        assertThat(body(get(service, "/test/acceptsCustomClass/fromString?myarg=the-custom-value")))
+            .isEqualTo("\"the-custom-value\"");
+
+        assertThat(body(get(service, "/test/acceptsCustomClass/constructor?myarg=the-custom-value")))
+            .isEqualTo("\"the-custom-value\"");
+    }
+
+    @Test
+    void shouldSupportCustomClassesAsNullableQueryParams() {
+        assertThat(body(get(service, "/test/acceptsCustomClass/valueOf")))
+            .isEqualTo("\"null\"");
+
+        assertThat(body(get(service, "/test/acceptsCustomClass/fromString")))
+            .isEqualTo("\"null\"");
+
+        assertThat(body(get(service, "/test/acceptsCustomClass/constructor")))
+            .isEqualTo("\"null\"");
     }
 
     @Test
@@ -188,7 +212,18 @@ class JaxRsResourceTest {
 
         assertThat(body(get(service, "/test/acceptsEnum/ONE")))
             .isEqualTo("\"Enum: ONE\"");
+    }
 
+    @Test
+    void shouldSupportCustomClassesAsPathParams() {
+        assertThat(body(get(service, "/test/acceptsCustomClass/valueOf/the-custom-value")))
+            .isEqualTo("\"the-custom-value\"");
+
+        assertThat(body(get(service, "/test/acceptsCustomClass/fromString/the-custom-value")))
+            .isEqualTo("\"the-custom-value\"");
+
+        assertThat(body(get(service, "/test/acceptsCustomClass/constructor/the-custom-value")))
+            .isEqualTo("\"the-custom-value\"");
     }
 
     @Test
@@ -242,42 +277,76 @@ class JaxRsResourceTest {
     }
 
     @Test
+    void shouldSupportCustomClassesAsFormParams() {
+        assertThat(body(post(service, "/test/acceptsPostCustomClass/valueOf", "myarg=the-custom-value")))
+            .isEqualTo("\"the-custom-value\"");
+
+        assertThat(body(post(service, "/test/acceptsPostCustomClass/fromString", "myarg=the-custom-value")))
+            .isEqualTo("\"the-custom-value\"");
+
+        assertThat(body(post(service, "/test/acceptsPostCustomClass/constructor", "myarg=the-custom-value")))
+            .isEqualTo("\"the-custom-value\"");
+    }
+
+    @Test
+    void shouldSupportCustomClassesAsNullableFormParams() {
+        assertThat(body(post(service, "/test/acceptsPostCustomClass/valueOf", "")))
+            .isEqualTo("\"null\"");
+
+        assertThat(body(post(service, "/test/acceptsPostCustomClass/fromString", "")))
+            .isEqualTo("\"null\"");
+
+        assertThat(body(post(service, "/test/acceptsPostCustomClass/constructor", "")))
+            .isEqualTo("\"null\"");
+    }
+
+    @Test
     void shouldSupportSimpleHeaderParamTypes() {
-        assertThat(body(JaxRsTestUtil.getWithHeaders(service,
-            "/test/acceptsHeaderString",
-            new HashMap<>() {
-                {
-                    put("myHeader", asList("accepts"));
-                }
-            }
+        assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderString",
+            Map.of("myHeader", List.of("accepts"))
         ))).isEqualTo("\"header: accepts\"");
 
-        assertThat(body(JaxRsTestUtil.getWithHeaders(service,
-            "/test/acceptsHeaderInteger",
-            new HashMap<>() {
-                {
-                    put("myHeader", asList("4"));
-                }
-            }
+        assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderInteger",
+            Map.of("myHeader", List.of("4"))
         ))).isEqualTo("\"header: 4\"");
+
         assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderEnum",
-            new HashMap<>() {
-                {
-                    put("myHeader", asList("ONE"));
-                }
-            }
+            Map.of("myHeader", List.of("ONE"))
         ))).isEqualTo("\"header: ONE\"");
     }
 
     @Test
+    void shouldSupportCustomClassesAsHeaderParams() {
+        assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderCustomClass/valueOf",
+            Map.of("myHeader", List.of("the-custom-value"))
+        ))).isEqualTo("\"the-custom-value\"");
+
+
+        assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderCustomClass/fromString",
+            Map.of("myHeader", List.of("the-custom-value"))
+        ))).isEqualTo("\"the-custom-value\"");
+
+        assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderCustomClass/constructor",
+            Map.of("myHeader", List.of("the-custom-value"))
+        ))).isEqualTo("\"the-custom-value\"");
+    }
+
+    @Test
+    void shouldSupportCustomClassesAsNullableHeaderParams() {
+        assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderCustomClass/valueOf", Map.of())))
+            .isEqualTo("\"null\"");
+
+        assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderCustomClass/fromString", Map.of())))
+            .isEqualTo("\"null\"");
+
+        assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderCustomClass/constructor", Map.of())))
+            .isEqualTo("\"null\"");
+    }
+
+    @Test
     void shouldSupportMissingHeaderParams() {
-        assertThat(body(JaxRsTestUtil.getWithHeaders(service,
-            "/test/acceptsHeaderString",
-            new HashMap<String, List<String>>() {
-                {
-                    put("dummy", asList("accepts"));
-                }
-            }
+        assertThat(body(JaxRsTestUtil.getWithHeaders(service, "/test/acceptsHeaderString",
+            Map.of("dummy", List.of("accepts"))
         ))).isEqualTo("\"header: null\"");
     }
 
@@ -659,6 +728,33 @@ class JaxRsResourceTest {
     }
 
     @Test
+    void shouldResolveCustomClassesAsCookieParam() {
+        assertThat(body(getWithHeaders(service, "/test/acceptsCookieParamCustomClass/valueOf",
+            Map.of("Cookie", List.of("myarg=the-custom-value"))
+        ))).isEqualTo("\"the-custom-value\"");
+
+        assertThat(body(getWithHeaders(service, "/test/acceptsCookieParamCustomClass/fromString",
+            Map.of("Cookie", List.of("myarg=the-custom-value"))
+        ))).isEqualTo("\"the-custom-value\"");
+
+        assertThat(body(getWithHeaders(service, "/test/acceptsCookieParamCustomClass/constructor",
+            Map.of("Cookie", List.of("myarg=the-custom-value"))
+        ))).isEqualTo("\"the-custom-value\"");
+    }
+
+    @Test
+    void shouldResolveCustomClassesAsNullableCookieParam() {
+        assertThat(body(getWithHeaders(service, "/test/acceptsCookieParamCustomClass/valueOf", Map.of())))
+            .isEqualTo("\"null\"");
+
+        assertThat(body(getWithHeaders(service, "/test/acceptsCookieParamCustomClass/fromString", Map.of())))
+            .isEqualTo("\"null\"");
+
+        assertThat(body(getWithHeaders(service, "/test/acceptsCookieParamCustomClass/constructor", Map.of())))
+            .isEqualTo("\"null\"");
+    }
+
+    @Test
     void shouldAcceptBodyForPut() {
         assertThat(body(put(service, "/test/acceptBodyPut", "{\"name\":\"test\"}"))).isEqualTo("{\"name\":\"test\",\"age\":0,\"items\":null}");
     }
@@ -726,6 +822,16 @@ class JaxRsResourceTest {
     @Test
     void shouldAcceptQueryParamListWithEnumValues() {
         assertThat(get(service, "/test/acceptsQueryListWithEnum?EnumList=ONE,TWO,THREE").getOutp()).isEqualTo("3");
+    }
+
+    @Test
+    void shouldAcceptQueryParamListWithCustomClasses() {
+        assertThat(get(service, "/test/acceptsQueryListWithCustomClasses?list=ONE,TWO,THREE").getOutp()).isEqualTo("\"ONETWOTHREE\"");
+    }
+
+    @Test
+    void shouldAcceptQueryParamArrayWithCustomClasses() {
+        assertThat(get(service, "/test/acceptsQueryArrayWithCustomClasses?array=ONE,TWO,THREE").getOutp()).isEqualTo("\"ONETWOTHREE\"");
     }
 
     @Test
@@ -874,6 +980,18 @@ class JaxRsResourceTest {
         @GET
         Observable<String> acceptsEnum(@QueryParam("myarg") TestEnum myarg);
 
+        @Path("acceptsCustomClass/valueOf")
+        @GET
+        Observable<String> acceptsCustomClassQueryParamWithValueOf(@QueryParam("myarg") CustomParamWithValueOf myarg);
+
+        @Path("acceptsCustomClass/fromString")
+        @GET
+        Observable<String> acceptsCustomClassQueryParamWithFromString(@QueryParam("myarg") CustomParamWithFromString myarg);
+
+        @Path("acceptsCustomClass/constructor")
+        @GET
+        Observable<String> acceptsCustomClassQueryParamWithConstructor(@QueryParam("myarg") CustomParamWithConstructor myarg);
+
         @Path("defaultQuery")
         @GET
         Observable<String> acceptDefaultQueryParam(@QueryParam("myarg") @DefaultValue("5") int myarg);
@@ -909,6 +1027,18 @@ class JaxRsResourceTest {
         @Path("acceptsSlashVar/{myarg:.*}")
         @GET
         Observable<String> acceptsSlashVar(@PathParam("myarg") String myarg);
+
+        @Path("acceptsCustomClass/valueOf/{myarg}")
+        @GET
+        Observable<String> acceptsCustomClassPathParamWithValueOf(@PathParam("myarg") CustomParamWithValueOf myarg);
+
+        @Path("acceptsCustomClass/fromString/{myarg}")
+        @GET
+        Observable<String> acceptsCustomClassPathParamWithFromString(@PathParam("myarg") CustomParamWithFromString myarg);
+
+        @Path("acceptsCustomClass/constructor/{myarg}")
+        @GET
+        Observable<String> acceptsCustomClassPathParamWithConstructor(@PathParam("myarg") CustomParamWithConstructor myarg);
 
         @Path("acceptsPostString")
         @POST
@@ -954,6 +1084,18 @@ class JaxRsResourceTest {
         @POST
         Observable<String> acceptsPostNotNullDouble(@FormParam("myDouble") double myarg);
 
+        @Path("acceptsPostCustomClass/valueOf")
+        @POST
+        Observable<String> acceptsPostCustomClassWithValueOf(@FormParam("myarg") CustomParamWithValueOf myarg);
+
+        @Path("acceptsPostCustomClass/fromString")
+        @POST
+        Observable<String> acceptsPostCustomClassWithFromString(@FormParam("myarg") CustomParamWithFromString myarg);
+
+        @Path("acceptsPostCustomClass/constructor")
+        @POST
+        Observable<String> acceptsPostCustomClassWithConstructor(@FormParam("myarg") CustomParamWithConstructor myarg);
+
         @Path("acceptsDefaultForm")
         @POST
         Observable<String> acceptsDefaultFormParam(@FormParam("myarg") @DefaultValue("5") int myarg);
@@ -969,6 +1111,18 @@ class JaxRsResourceTest {
         @Path("acceptsHeaderEnum")
         @GET
         Observable<String> acceptsHeaderEnum(@HeaderParam("myHeader") TestEnum myHeader);
+
+        @Path("acceptsHeaderCustomClass/valueOf")
+        @GET
+        Observable<String> acceptsHeaderCustomClassWithValueOf(@HeaderParam("myHeader") CustomParamWithValueOf myHeader);
+
+        @Path("acceptsHeaderCustomClass/fromString")
+        @GET
+        Observable<String> acceptsHeaderCustomClassWithFromString(@HeaderParam("myHeader") CustomParamWithFromString myHeader);
+
+        @Path("acceptsHeaderCustomClass/constructor")
+        @GET
+        Observable<String> acceptsHeaderCustomClassWithConstructor(@HeaderParam("myHeader") CustomParamWithConstructor myHeader);
 
         @Path("acceptsDefaultHeader")
         @GET
@@ -1050,6 +1204,18 @@ class JaxRsResourceTest {
         @GET
         Observable<String> acceptsCookieParam(@CookieParam("fnox_session") String cookie);
 
+        @Path("acceptsCookieParamCustomClass/valueOf")
+        @GET
+        Observable<String> acceptsCookieParamCustomClassesWithValueOf(@CookieParam("myarg") CustomParamWithValueOf myarg);
+
+        @Path("acceptsCookieParamCustomClass/fromString")
+        @GET
+        Observable<String> acceptsCookieParamCustomClassesWithFromString(@CookieParam("myarg") CustomParamWithValueOf myarg);
+
+        @Path("acceptsCookieParamCustomClass/constructor")
+        @GET
+        Observable<String> acceptsCookieParamCustomClassesWithConstructor(@CookieParam("myarg") CustomParamWithValueOf myarg);
+
         @Path("acceptsDefaultCookie")
         @GET
         Observable<String> acceptsDefaultCookieParam(@CookieParam("myCookie") @DefaultValue("5") int myCookie);
@@ -1105,6 +1271,14 @@ class JaxRsResourceTest {
         @Path("acceptsQueryListWithEnum")
         @GET
         Observable<Integer> acceptsQueryListWithEnum(@QueryParam("EnumList") List<TestEnum> enums);
+
+        @Path("acceptsQueryListWithCustomClasses")
+        @GET
+        Observable<String> acceptsQueryListWithCustomClasses(@QueryParam("list") List<CustomParamWithValueOf> objects);
+
+        @Path("acceptsQueryArrayWithCustomClasses")
+        @GET
+        Observable<String> acceptsQueryArrayWithCustomClasses(@QueryParam("array") CustomParamWithValueOf[] objects);
 
         @Path("shouldIgnoreHeadersAnnotationOnInterface")
         @GET
@@ -1168,6 +1342,21 @@ class JaxRsResourceTest {
         @Override
         public Observable<String> acceptsEnum(TestEnum myarg) {
             return just("Enum: " + myarg);
+        }
+
+        @Override
+        public Observable<String> acceptsCustomClassQueryParamWithValueOf(CustomParamWithValueOf myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsCustomClassQueryParamWithFromString(CustomParamWithFromString myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsCustomClassQueryParamWithConstructor(CustomParamWithConstructor myarg) {
+            return just(myarg != null ? myarg.value : "null");
         }
 
         @Override
@@ -1271,6 +1460,21 @@ class JaxRsResourceTest {
         }
 
         @Override
+        public Observable<String> acceptsHeaderCustomClassWithValueOf(CustomParamWithValueOf myHeader) {
+            return just(myHeader != null ? myHeader.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsHeaderCustomClassWithFromString(CustomParamWithFromString myHeader) {
+            return just(myHeader != null  ? myHeader.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsHeaderCustomClassWithConstructor(CustomParamWithConstructor myHeader) {
+            return just(myHeader != null  ? myHeader.value : "null");
+        }
+
+        @Override
         public Observable<String> acceptsDefaultHeaderParam(int myHeader) {
             return just("Default: " + myHeader);
         }
@@ -1351,6 +1555,21 @@ class JaxRsResourceTest {
         }
 
         @Override
+        public Observable<String> acceptsCookieParamCustomClassesWithValueOf(CustomParamWithValueOf myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsCookieParamCustomClassesWithFromString(CustomParamWithValueOf myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsCookieParamCustomClassesWithConstructor(CustomParamWithValueOf myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
         public Observable<String> acceptsDefaultCookieParam(int myCookie) {
             return just("Default: " + myCookie);
         }
@@ -1428,6 +1647,16 @@ class JaxRsResourceTest {
         }
 
         @Override
+        public Observable<String> acceptsQueryListWithCustomClasses(List<CustomParamWithValueOf> objects) {
+            return just(objects.stream().map(it -> it.value).collect(Collectors.joining()));
+        }
+
+        @Override
+        public Observable<String> acceptsQueryArrayWithCustomClasses(CustomParamWithValueOf[] objects) {
+            return just(Arrays.stream(objects).map(it -> it.value).collect(Collectors.joining()));
+        }
+
+        @Override
         public Observable<String> ignoresHeaderAnnotationOnInterface() {
             return just("");
         }
@@ -1459,6 +1688,21 @@ class JaxRsResourceTest {
         }
 
         @Override
+        public Observable<String> acceptsCustomClassPathParamWithValueOf(CustomParamWithValueOf myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsCustomClassPathParamWithFromString(CustomParamWithFromString myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsCustomClassPathParamWithConstructor(CustomParamWithConstructor myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
         public Observable<String> acceptsDouble(Double myarg) {
             return just("Double: " + myarg);
         }
@@ -1471,6 +1715,21 @@ class JaxRsResourceTest {
         @Override
         public Observable<String> acceptsPostNotNullDouble(double myarg) {
             return just("double: " + myarg);
+        }
+
+        @Override
+        public Observable<String> acceptsPostCustomClassWithValueOf(CustomParamWithValueOf myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsPostCustomClassWithFromString(CustomParamWithFromString myarg) {
+            return just(myarg != null ? myarg.value : "null");
+        }
+
+        @Override
+        public Observable<String> acceptsPostCustomClassWithConstructor(CustomParamWithConstructor myarg) {
+            return just(myarg != null ? myarg.value : "null");
         }
 
         @Override
@@ -1538,6 +1797,42 @@ class JaxRsResourceTest {
         }
     }
 
+    public static class CustomParamWithValueOf {
+
+        public final String value;
+
+        private CustomParamWithValueOf(String value) {
+            this.value = value;
+        }
+
+        @SuppressWarnings("unused")
+        public static CustomParamWithValueOf valueOf(String value) {
+            return new CustomParamWithValueOf(value);
+        }
+    }
+
+    public static class CustomParamWithFromString {
+
+        public final String value;
+
+        private CustomParamWithFromString(String value) {
+            this.value = value;
+        }
+
+        @SuppressWarnings("unused")
+        public static CustomParamWithFromString fromString(String value) {
+            return new CustomParamWithFromString(value);
+        }
+    }
+
+    public static class CustomParamWithConstructor {
+
+        public final String value;
+
+        public CustomParamWithConstructor(String value) {
+            this.value = value;
+        }
+    }
 }
 
 interface Foo {

--- a/utils/src/main/java/se/fortnox/reactivewizard/util/LambdaCompiler.java
+++ b/utils/src/main/java/se/fortnox/reactivewizard/util/LambdaCompiler.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 public class LambdaCompiler {
     static boolean useLambdas = "true".equals(System.getProperty("useLambdas", "true"));
 
-    static <T> Supplier<T> compileLambdaSupplier(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
+    public static <T> Supplier<T> compileLambdaSupplier(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
         if (!useLambdas) {
             return () -> {
                 try {
@@ -33,7 +33,7 @@ public class LambdaCompiler {
         return (Supplier<T>)callSite.getTarget().invoke();
     }
 
-    static <I,T> BiConsumer<I,T> compileLambdaBiConsumer(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
+    public static <I,T> BiConsumer<I,T> compileLambdaBiConsumer(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
         if (!useLambdas) {
             return (instance, arg) -> {
                 try {
@@ -54,7 +54,7 @@ public class LambdaCompiler {
         return (BiConsumer<I,T>) callSite.getTarget().invoke();
     }
 
-    static <I,T> Function<I, T> compileLambdaFunction(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
+    public static <I,T> Function<I, T> compileLambdaFunction(MethodHandles.Lookup lookup, MethodHandle methodHandle) throws Throwable {
         if (!useLambdas) {
             return (instance) -> {
                 try {


### PR DESCRIPTION
Follows the JAX-RS spec by allowing classes with:
* A static `valueOf(String)`-method
* A static `fromString(String)`-method
* A `String`-constructor