### PR TITLE
Add support for streaming upload using HttpClient

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Sets;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.timeout.ReadTimeoutException;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -441,9 +442,13 @@ public class HttpClient implements InvocationHandler {
                         } else if (value instanceof byte[] bytes) {
                             requestBuilder.setContent(bytes);
                             return;
+                        } else if (value instanceof Publisher publisher) {
+                            requestBuilder.setContent(publisher);
+                            return;
                         }
                         throw new IllegalArgumentException("When content type is not " + APPLICATION_JSON
-                            + " the body param must be String or byte[], but was " + value.getClass());
+                            + " the body param must be String, byte[] or Publisher<? extends byte[]>, but was "
+                            + value.getClass());
                     }
                     return;
                 } catch (JsonProcessingException e) {

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientStreamingTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientStreamingTest.java
@@ -1,0 +1,158 @@
+package se.fortnox.reactivewizard.client;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+import reactor.netty.http.server.HttpServerRequest;
+import se.fortnox.reactivewizard.jaxrs.RequestLogger;
+import se.fortnox.reactivewizard.metrics.HealthRecorder;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.core.publisher.Flux.empty;
+
+public class HttpClientStreamingTest {
+    private static final Random RANDOM = new Random();
+
+    private final HealthRecorder healthRecorder = new HealthRecorder();
+
+    private TestResource getHttpProxy(int port) {
+        return getHttpProxy(port, Duration.ofSeconds(10));
+    }
+
+    private TestResource getHttpProxy(int port, Duration maxRequestTime) {
+        return getHttpProxy(port, 1, maxRequestTime);
+    }
+
+    private TestResource getHttpProxy(int port, int maxConn, Duration maxRequestTime) {
+        try {
+            HttpClientConfig config = new HttpClientConfig("localhost:" + port);
+            config.setMaxConnections(maxConn);
+            config.setReadTimeoutMs((int) maxRequestTime.toMillis());
+            return getHttpProxy(config);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private TestResource getHttpProxy(HttpClientConfig config) {
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        RequestLogger requestLogger = new RequestLogger();
+        HttpClient client = new HttpClient(config,
+            new ReactorRxClientProvider(config, healthRecorder),
+            mapper,
+            new RequestParameterSerializers(),
+            Collections.emptySet(),
+            requestLogger);
+        return client.create(TestResource.class);
+    }
+
+    @Test
+    public void shouldSupportSendingStreamAsChunkedTransfer() {
+        AtomicReference<HttpServerRequest> recordedRequest = new AtomicReference<>();
+        AtomicReference<String> recordedRequestBody = new AtomicReference<>("");
+
+        DisposableServer server = HttpServer.create().port(0).handle((request, response) -> {
+            recordedRequest.set(request);
+            response.status(HttpResponseStatus.NO_CONTENT);
+            return request.receive().flatMap(buf -> {
+                recordedRequestBody.updateAndGet(value -> value.concat(buf.toString(Charset.defaultCharset())));
+                return Flux.empty();
+            });
+        }).bindNow();
+
+        TestResource resource = getHttpProxy(server.port());
+
+        Flux<byte[]> body = Flux.just("Chu", "nke", "d te", "st", "b", "ody")
+            .map(str -> str.getBytes(Charset.defaultCharset()));
+
+        resource.sendChunked(body).block();
+        assertThat(recordedRequestBody.get()).isEqualTo("Chunked testbody");
+        assertThat(recordedRequest.get().requestHeaders().get("Transfer-Encoding")).isEqualTo("chunked");
+
+        server.disposeNow();
+    }
+
+    private Flux<byte[]> generateFile(long bytes) {
+        AtomicLong generatedBytes = new AtomicLong(0);
+        return Flux.generate(sink -> {
+            int length = RANDOM.nextInt(1000, 8000);
+            byte[] randomBytes = new byte[length];
+            RANDOM.nextBytes(randomBytes);
+            generatedBytes.addAndGet(length);
+            sink.next(randomBytes);
+            if (generatedBytes.get() > bytes) {
+                sink.complete();
+            }
+        });
+    }
+
+    @Test
+    public void shouldSupportStreamingResponseToRequest() {
+        var bytesDownloaded = new AtomicLong(0);
+        var bytesUploaded = new AtomicLong(0);
+        Flux<? extends byte[]> file = generateFile(1024L * 1024 * 1024);
+
+        DisposableServer server = HttpServer.create().port(0).handle((request, response) -> {
+            if (request.method().equals(HttpMethod.GET)) {
+                response.status(HttpResponseStatus.OK);
+                return response.sendByteArray(file.doOnNext(
+                    bytes -> bytesDownloaded.addAndGet(bytes.length)
+                )).then();
+            } else if (request.method().equals(HttpMethod.POST)) {
+                response.status(HttpResponseStatus.OK);
+                return request.receive()
+                    .map(ByteBuf::readableBytes)
+                    .reduce(0L, Long::sum)
+                    .doOnSuccess(bytesUploaded::set)
+                    .then();
+            } else {
+                response.status(HttpResponseStatus.NOT_FOUND);
+                return empty();
+            }
+        }).bindNow();
+
+        TestResource testResource = getHttpProxy(server.port(), 2, Duration.ofMinutes(10));
+        HttpClient.setTimeout(testResource, 10, ChronoUnit.MINUTES);
+
+        testResource.sendChunked(testResource.getByteStream()).block();
+
+        assertThat(bytesUploaded.get()).isEqualTo(bytesDownloaded.get());
+
+        server.dispose();
+    }
+
+    @Path("/")
+    public interface TestResource {
+        @GET
+        @Produces("application/octet-stream")
+        @Path("get")
+        Flux<byte[]> getByteStream();
+
+        @POST
+        @Consumes("application/octet-stream")
+        @Path("post")
+        Mono<Void> sendChunked(Flux<byte[]> content);
+    }
+}

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -1677,7 +1677,7 @@ public class HttpClientTest {
             resource.sendXml(new Pojo()).toBlocking().lastOrDefault(null);
             fail("expected exception");
         } catch (IllegalArgumentException e) {
-            assertThat(e).hasMessage("When content type is not application/json the body param must be String or byte[], but was class se.fortnox.reactivewizard.client.HttpClientTest$Pojo");
+            assertThat(e).hasMessage("When content type is not application/json the body param must be String, byte[] or Publisher<? extends byte[]>, but was class se.fortnox.reactivewizard.client.HttpClientTest$Pojo");
         }
 
         server.disposeNow();


### PR DESCRIPTION
RequestBuilder now holds content in a Publisher<? extends byte[]> instead of byte[]. This allows for methods in jaxrs interfaces to take Publisher<? extends byte[]> as a body argument, resulting in a streamed upload since Netty is ok with that.

HttpClientStreamingTest verifies that a streamed upload is using a chunked transfer and that an upload can be streamed from a file that is being downloaded.
Perhaps verifying that the size downloaded equals the size uploaded doesn't help much. I used the test to verify that memory usage didn't increase with large files (gigabytes).