### PR TITLE
Make smart-nulls the default Mockito answer

### DIFF
--- a/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProviderTest.java
+++ b/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProviderTest.java
@@ -17,6 +17,7 @@ public class LiquibaseMigrateProviderTest {
 
         when(liquibaseConfig.getUrl()).thenReturn("jdbc:h2:mem:test");
         when(liquibaseConfig.getMigrationsFile()).thenReturn("migrations.xml");
+        when(liquibaseConfig.getSchema()).thenReturn(null);
 
         ConfigFactory configFactory = mock(ConfigFactory.class);
         when(configFactory.get(LiquibaseConfig.class)).thenReturn(liquibaseConfig);

--- a/server/src/test/java/se/fortnox/reactivewizard/server/CompositeRequestHandlerTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/CompositeRequestHandlerTest.java
@@ -21,7 +21,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CompositeRequestHandlerTest {
@@ -83,6 +86,7 @@ public class CompositeRequestHandlerTest {
 
     @Test
     public void exceptionHandlerShallBeInvokedWhenNoRequestHandlerIsGiven() {
+        when(response.status()).thenReturn(null);
         when(exceptionHandler.handleException(any(), any(), any())).thenReturn(Flux.empty());
 
         Flux.from(compositeRequestHandler.apply(request, response)).count().block();

--- a/test/src/main/java/org/mockito/configuration/MockitoConfiguration.java
+++ b/test/src/main/java/org/mockito/configuration/MockitoConfiguration.java
@@ -1,0 +1,25 @@
+package org.mockito.configuration;
+
+import org.mockito.Answers;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Custom Mockito configuration that sets the default answer to use smart-nulls to make finding test errors easier.
+ * See {@link org.mockito.Mockito#RETURNS_SMART_NULLS}.
+ */
+public class MockitoConfiguration implements IMockitoConfiguration {
+    @Override
+    public Answer<Object> getDefaultAnswer() {
+        return Answers.RETURNS_SMART_NULLS;
+    }
+
+    @Override
+    public boolean cleansStackTrace() {
+        return true;
+    }
+
+    @Override
+    public boolean enableClassCache() {
+        return true;
+    }
+}


### PR DESCRIPTION
Make smart-nulls the default answer in Mockito in order to find test errors easier.
See https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#RETURNS_SMART_NULLS