### PR TITLE
Make MockConfigFactory work with strict mock settings

### DIFF
--- a/config/src/test/java/se/fortnox/reactivewizard/config/MockConfigFactory.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/MockConfigFactory.java
@@ -3,6 +3,8 @@ package se.fortnox.reactivewizard.config;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.mockito.quality.Strictness.LENIENT;
 
 public class MockConfigFactory {
 
@@ -10,7 +12,7 @@ public class MockConfigFactory {
     }
 
     public static ConfigFactory create() {
-        ConfigFactory configFactory = mock(ConfigFactory.class);
+        ConfigFactory configFactory = mock(ConfigFactory.class, withSettings().strictness(LENIENT));
         when(configFactory.get(any())).thenAnswer(call -> call.getArgument(0, Class.class).newInstance());
         return configFactory;
     }

--- a/config/src/test/java/se/fortnox/reactivewizard/config/MockConfigFactoryTest.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/MockConfigFactoryTest.java
@@ -1,0 +1,16 @@
+package se.fortnox.reactivewizard.config;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.quality.Strictness;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockingDetails;
+
+class MockConfigFactoryTest {
+
+    @Test
+    void shouldCreateLenientMock() {
+        assertThat(mockingDetails(MockConfigFactory.create()).getMockCreationSettings().getStrictness())
+            .isEqualTo(Strictness.LENIENT);
+    }
+}


### PR DESCRIPTION
MockConfigFactory now creates a lenient mock in order to work with TestInjector under strict settings.