### PR TITLE
Objects contained in iterables are now validated

### DIFF
--- a/validation/src/main/java/se/fortnox/reactivewizard/validation/ValidatorUtil.java
+++ b/validation/src/main/java/se/fortnox/reactivewizard/validation/ValidatorUtil.java
@@ -1,10 +1,11 @@
 package se.fortnox.reactivewizard.validation;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.lang.reflect.Method;
 import java.util.Set;
 
@@ -28,6 +29,13 @@ public class ValidatorUtil {
     }
 
     public void validate(Object obj) {
+        if (obj == null) {
+            return;
+        }
+        Class<?> cls = obj.getClass();
+        if (cls.isPrimitive() || cls.getName().startsWith("java.")) {
+            return;
+        }
         throwIfError(validator.validate(obj));
     }
 
@@ -40,11 +48,10 @@ public class ValidatorUtil {
     public void validateParameters(Object object, Method method, Object[] parameterValues) {
         throwIfError(validator.forExecutables().validateParameters(object, method, parameterValues));
         for (Object obj : parameterValues) {
-            if (obj != null) {
-                Class<?> cls = obj.getClass();
-                if (!cls.isPrimitive() && !cls.getName().startsWith("java.")) {
-                    validate(obj);
-                }
+            if (obj instanceof Iterable<?>) {
+                ((Iterable<?>) obj).forEach(this::validate);
+            } else {
+                validate(obj);
             }
         }
     }

--- a/validation/src/test/java/se/fortnox/reactivewizard/validation/InputValidationTest.java
+++ b/validation/src/test/java/se/fortnox/reactivewizard/validation/InputValidationTest.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+
 import java.text.ParseException;
 import java.util.Date;
 import java.util.HashMap;
@@ -30,7 +31,7 @@ import static org.mockito.Mockito.verify;
  * The purpose of this document is to show you how you can do some simple and
  * some more advanced validation of your input.
  */
-public class ValidationExamples {
+public class InputValidationTest {
 
     /**
      * Create a class representing the input that should be validated


### PR DESCRIPTION
Our team noticed an inconsistency between validating single objects and iterables passed as parameters in the API. Consider the following:

_// someObject is validated by default if it has validation annotations_
someResource.create(**SomeObject** object);

_// The same someObject contained in a list is NOT validated by default_
someResource.create(List<**SomeObject**> objects);

_// For iterables, you have to explicitly ask for validation of the list using the @Valid annotation, which will cascade to the objects contained in the iterable_
someResource.create(@Valid List<**SomeObject**> objects);

The risk with this inconsistency is that developers assumes that iterables are validated the same as single objects. This PR contains a suggestion for an implementation that introduces validation of objects contained in iterables as a default behavior.