### PR TITLE
Add support to provide custom parameter Deserializers

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/BigDecimalDeserializer.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/BigDecimalDeserializer.java
@@ -1,0 +1,13 @@
+package se.fortnox.reactivewizard.jaxrs.params.deserializing;
+
+import java.math.BigDecimal;
+
+/**
+ * Deserializes BigDecimals.
+ */
+public class BigDecimalDeserializer extends NumberDeserializer<BigDecimal> {
+
+    public BigDecimalDeserializer() {
+        super(BigDecimal::new, "invalid.bigdecimal");
+    }
+}

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactory.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactory.java
@@ -10,8 +10,10 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.ws.rs.core.MediaType;
 import java.lang.reflect.ParameterizedType;
+import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Date;
 import java.util.HashMap;
@@ -58,12 +60,14 @@ public class DeserializerFactory {
             entry(Integer.class, new IntegerDeserializer()),
             entry(Long.class, new LongDeserializer()),
             entry(Double.class, new DoubleDeserializer()),
+            entry(BigDecimal.class, new BigDecimalDeserializer()),
             entry(String.class, (val) -> val),
             entry(UUID.class, new UUIDDeserializer()),
             entry(Date.class, new DateDeserializer(dateFormatProvider)),
             entry(LocalDate.class, new LocalDateDeserializer()),
-            entry(LocalTime.class, new LocalTimeDeserializer())
-        ));
+            entry(LocalTime.class, new LocalTimeDeserializer()),
+            entry(LocalDateTime.class, new LocalDateTimeDeserializer())
+            ));
 
         customDeserializers.forEach(deserializer -> stringDeserializers.put(getAppliedClass(deserializer), deserializer));
     }

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/LocalDateTimeDeserializer.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/LocalDateTimeDeserializer.java
@@ -1,0 +1,31 @@
+package se.fortnox.reactivewizard.jaxrs.params.deserializing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Deserializes strings such as "2007-12-03T10:15:30" using
+ * {@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME}.
+ */
+public class LocalDateTimeDeserializer implements Deserializer<LocalDateTime> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalDateTimeDeserializer.class);
+
+    @Override
+    public LocalDateTime deserialize(String value) throws DeserializerException {
+        if (value == null || value.length() == 0) {
+            return null;
+        }
+
+        try {
+            return LocalDateTime.parse(value);
+        } catch (DateTimeParseException e) {
+            LOG.warn("Unable to parse " + value + " as LocalDateTime", e);
+            throw new DeserializerException("invalid.localdatetime");
+        }
+
+    }
+}

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/JaxRsResourceTest.java
@@ -15,6 +15,7 @@ import rx.Observable;
 import rx.Single;
 import se.fortnox.reactivewizard.jaxrs.params.*;
 import se.fortnox.reactivewizard.jaxrs.params.annotated.AnnotatedParamResolverFactories;
+import se.fortnox.reactivewizard.jaxrs.params.deserializing.Deserializer;
 import se.fortnox.reactivewizard.jaxrs.params.deserializing.DeserializerFactory;
 import se.fortnox.reactivewizard.jaxrs.response.JaxRsResult;
 import se.fortnox.reactivewizard.jaxrs.response.JaxRsResultFactoryFactory;
@@ -481,6 +482,8 @@ class JaxRsResourceTest {
                 bind(new TypeLiteral<Set<ParamResolver>>() {{
                 }}).toInstance(Collections.EMPTY_SET);
                 bind(new TypeLiteral<Set<ParamResolverFactory>>() {{
+                }}).toInstance(Collections.EMPTY_SET);
+                bind(new TypeLiteral<Set<Deserializer>>() {{
                 }}).toInstance(Collections.EMPTY_SET);
                 bind(ResultTransformerFactories.class).toInstance(new ResultTransformerFactories());
                 bind(ObjectMapper.class).toInstance(new ObjectMapper()

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/BigDecimalDeserializerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/BigDecimalDeserializerTest.java
@@ -1,0 +1,36 @@
+package se.fortnox.reactivewizard.jaxrs.params.deserializing;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class BigDecimalDeserializerTest {
+    private final static Deserializer<BigDecimal> DESERIALIZER = new BigDecimalDeserializer();
+
+    @Test
+    public void shouldDeserializeBigDecimal() throws DeserializerException {
+        assertThat(DESERIALIZER.deserialize("5")).isEqualTo(BigDecimal.valueOf(5));
+        assertThat(DESERIALIZER.deserialize("7.2")).isEqualTo(BigDecimal.valueOf(7.2d));
+        assertThat(DESERIALIZER.deserialize("1234.56789")).isEqualTo(new BigDecimal("1234.56789"));
+    }
+
+    @Test
+    public void shouldDeserializeNull() throws DeserializerException {
+        BigDecimal deserialized = DESERIALIZER.deserialize(null);
+        assertThat(deserialized).isNull();
+    }
+
+    @Test
+    public void shouldThrowDeserializerExceptionForUnparsableStrings() {
+        try {
+            DESERIALIZER.deserialize("not a recognized value");
+            fail("Expected exception, but none was thrown");
+        } catch (Exception exception) {
+            assertThat(exception).isInstanceOf(DeserializerException.class);
+            assertThat(exception.getMessage()).isEqualTo("invalid.bigdecimal");
+        }
+    }
+}

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactoryTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/DeserializerFactoryTest.java
@@ -1,0 +1,54 @@
+package se.fortnox.reactivewizard.jaxrs.params.deserializing;
+
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.multibindings.Multibinder;
+import org.junit.Before;
+import org.junit.Test;
+import se.fortnox.reactivewizard.json.JsonDeserializerFactory;
+
+import java.text.DateFormat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeserializerFactoryTest {
+    private static final Deserializer<Foo> FOO_DESERIALIZER = new FooDeserializer();
+    private static final Deserializer<Boolean> BOOLEAN_DESERIALIZER = new BooleanDeserializer();
+
+    private DeserializerFactory deserializerFactory;
+
+    @Before
+    public void setUp() {
+        deserializerFactory = Guice.createInjector(new TestModule()).getInstance(DeserializerFactory.class);
+    }
+
+    @Test
+    public void shouldUseCustomDeserializer() {
+        assertThat(deserializerFactory.getClassDeserializer(Foo.class)).isSameAs(FOO_DESERIALIZER);
+    }
+
+    @Test
+    public void shouldUseOverriddenCustomDeserializer() {
+        assertThat(deserializerFactory.getClassDeserializer(Boolean.class)).isSameAs(BOOLEAN_DESERIALIZER);
+    }
+
+    private static class TestModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(DateFormat.class).toInstance(new StdDateFormat());
+            bind(JsonDeserializerFactory.class).toInstance(new JsonDeserializerFactory());
+            var multibinder = Multibinder.newSetBinder(binder(), Deserializer.class);
+            multibinder.addBinding().toInstance(FOO_DESERIALIZER);
+            multibinder.addBinding().toInstance(BOOLEAN_DESERIALIZER);
+        }
+    }
+
+    private record Foo(String value) {}
+    private static class FooDeserializer implements Deserializer<Foo> {
+        @Override
+        public Foo deserialize(String value) throws DeserializerException {
+            return new Foo(value);
+        }
+    }
+}

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/LocalDateTimeDeserializerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/jaxrs/params/deserializing/LocalDateTimeDeserializerTest.java
@@ -1,0 +1,35 @@
+package se.fortnox.reactivewizard.jaxrs.params.deserializing;
+
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class LocalDateTimeDeserializerTest {
+    private final static Deserializer<LocalDateTime> DESERIALIZER = new LocalDateTimeDeserializer();
+
+    @Test
+    public void shouldDeserialize() throws DeserializerException {
+        LocalDateTime deserialized = DESERIALIZER.deserialize("2023-04-01T14:10:15");
+        assertThat(deserialized.toString()).isEqualTo("2023-04-01T14:10:15");
+    }
+
+    @Test
+    public void shouldDeserializeNull() throws DeserializerException {
+        LocalDateTime deserialized = DESERIALIZER.deserialize(null);
+        assertThat(deserialized).isNull();
+    }
+
+    @Test
+    public void shouldThrowDeserializerExceptionForBadInput() {
+        try {
+            DESERIALIZER.deserialize("not a datetime");
+            fail("Expected exception, but none was thrown");
+        } catch (Exception exception) {
+            assertThat(exception).isInstanceOf(DeserializerException.class);
+            assertThat(exception.getMessage()).isEqualTo("invalid.localdatetime");
+        }
+    }
+}

--- a/server/src/main/java/se/fortnox/reactivewizard/server/ServerModule.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/ServerModule.java
@@ -14,6 +14,7 @@ import se.fortnox.reactivewizard.jaxrs.JaxRsRequestHandler;
 import se.fortnox.reactivewizard.jaxrs.JaxRsResourcesProvider;
 import se.fortnox.reactivewizard.jaxrs.params.ParamResolver;
 import se.fortnox.reactivewizard.jaxrs.params.ParamResolverFactory;
+import se.fortnox.reactivewizard.jaxrs.params.deserializing.Deserializer;
 import se.fortnox.reactivewizard.jaxrs.response.NoContentTransformer;
 import se.fortnox.reactivewizard.jaxrs.response.ResponseDecoratorTransformer;
 import se.fortnox.reactivewizard.jaxrs.response.ResultTransformerFactory;
@@ -47,6 +48,7 @@ public class ServerModule implements AutoBindModule {
             new TypeLiteral<RequestHandler>() { });
         requestHandlers.addBinding().to(JaxRsRequestHandler.class);
 
+        Multibinder.newSetBinder(binder, TypeLiteral.get(Deserializer.class));
         Multibinder.newSetBinder(binder, TypeLiteral.get(ParamResolverFactory.class));
 
         Multibinder<ResultTransformerFactory> resultTransformers = Multibinder.newSetBinder(binder,


### PR DESCRIPTION
This provides the possibility for framework users to extend the functionality by registering custom parameter Deserializers. This is done the same way as for RequestParameterSerializers, letting implementers use Guice Multibinder to add more.