### PR TITLE
Changed DAO behavior when MonoSink is involved.

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -69,6 +69,12 @@
             <classifier>tests</classifier>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
@@ -78,7 +78,7 @@ public class ReactiveStatementFactory {
     }
 
     private Mono<Object> getResultMono(StatementContext statementContext) {
-        return Mono.create(monoSink -> {
+        return Mono.create(monoSink -> monoSink.onRequest(unusedRequestedAmount -> {
             try {
                 statementContext.getConnectionScheduler()
                     .schedule(monoSink::error, connection -> {
@@ -89,7 +89,7 @@ public class ReactiveStatementFactory {
             } catch (Exception e) {
                 monoSink.error(e);
             }
-        });
+        }));
     }
 
     /**

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/AbstractDbStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/AbstractDbStatementFactory.java
@@ -91,10 +91,6 @@ public abstract class AbstractDbStatementFactory implements DbStatementFactory {
             if (fluxSink != null) {
                 fluxSink.complete();
             }
-            if (monoSink != null) {
-                // Should already be completed, but calling again is ok.
-                monoSink.success();
-            }
         }
 
         @Override

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTest.java
@@ -2,11 +2,20 @@ package se.fortnox.reactivewizard.db;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
+import se.fortnox.reactivewizard.db.statement.DbStatementFactoryFactory;
+import se.fortnox.reactivewizard.json.JsonSerializerFactory;
 
 import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -21,7 +30,12 @@ class DaoTest {
     @BeforeEach
     public void reset() {
         db  = new MockDb();
-        dao = new DbProxy(new DatabaseConfig(), db.getConnectionProvider()).create(DaoTransactionsTest.TestDao.class);
+        dao = new DbProxy(
+            new DatabaseConfig(),
+            Schedulers.newBoundedElastic(1, Integer.MAX_VALUE, "DaoTestDbProxy"),
+            db.getConnectionProvider(),
+            new DbStatementFactoryFactory(),
+            new JsonSerializerFactory()).create(DaoTransactionsTest.TestDao.class);
     }
 
     @Test
@@ -45,5 +59,29 @@ class DaoTest {
         verify(db.getConnection(), times(2)).close();
         verify(db.getPreparedStatement(), times(2)).close();
         verify(db.getResultSet()).close();
+    }
+
+    @Test
+    void subscriberShouldGetExactlyOneElementWhenRequestingOneElementFromConcatMap() throws SQLException, InterruptedException {
+        db.addRows(1);
+
+        AtomicInteger numNext = new AtomicInteger(0);
+        AtomicReference<Throwable> error = new AtomicReference<>(null);
+
+        Flux.just(1,2,3).concatMap(x -> dao.findMono().switchIfEmpty(Mono.error(RuntimeException::new)))
+            .subscribe(
+                next -> numNext.incrementAndGet(),
+                error::set,
+                () -> { },
+                subscription -> subscription.request(1));
+
+        Thread.sleep(3000);
+
+        Throwable throwable = error.get();
+        if (throwable != null) {
+            fail("Expected one single next, got an error.", throwable);
+        }
+
+        assertThat(numNext.get()).isEqualTo(1);
     }
 }

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
@@ -460,6 +460,9 @@ class DaoTransactionsTest {
         @Query("select * from test")
         Flux<String> find();
 
+        @Query("select * from test")
+        Mono<String> findMono();
+
         @Query("select * from test2")
         Flux<String> find2();
 


### PR DESCRIPTION
Changed DAO behavior when MonoSink is involved such that a call is made to either MonoSink::success(T) or MonoSink::success() but never both.

Despite the fact that a MonoSink::success() should be able to be called multiple times, this resolves an ambiguous backpressure behavior when a DAO method is returned in a concatMap.