### PR TITLE
Added body of error response to WebException

### DIFF
--- a/binding/pom.xml
+++ b/binding/pom.xml
@@ -36,49 +36,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>${jacoco.version}</version>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>default-report</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>default-check</id>
-						<goals>
-							<goal>check</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<!-- implmentation is needed only for Maven 2 -->
-								<rule implementation="org.jacoco.maven.RuleConfiguration">
-									<element>BUNDLE</element>
-									<limits>
-										<!-- implmentation is needed only for Maven 2 -->
-										<limit implementation="org.jacoco.report.check.Limit">
-											<counter>COMPLEXITY</counter>
-											<value>COVEREDRATIO</value>
-											<minimum>0.90</minimum>
-										</limit>
-									</limits>
-								</rule>
-							</rules>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -41,48 +41,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>default-report</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>default-check</id>
-						<goals>
-							<goal>check</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<!-- implmentation is needed only for Maven 2 -->
-								<rule implementation="org.jacoco.maven.RuleConfiguration">
-									<element>BUNDLE</element>
-									<limits>
-										<!-- implmentation is needed only for Maven 2 -->
-										<limit implementation="org.jacoco.report.check.Limit">
-											<counter>COMPLEXITY</counter>
-											<value>COVEREDRATIO</value>
-											<minimum>0.90</minimum>
-										</limit>
-									</limits>
-								</rule>
-							</rules>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -481,7 +481,7 @@ public class HttpClient implements InvocationHandler {
                     .code(),
                     reasonPhrase);
 
-                throw new WebException(responseStatus, detailedError, false);
+                throw new WebException(responseStatus, detailedError, false, data);
             });
         }
         return null;

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>reactivewizard-dao</artifactId>
+    <artifactId>coverage</artifactId>
 
     <dependencies>
 
@@ -17,7 +17,15 @@
         </dependency>
         <dependency>
             <groupId>se.fortnox.reactivewizard</groupId>
-            <artifactId>reactivewizard-json</artifactId>
+            <artifactId>reactivewizard-binding</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-bootstrap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-client</artifactId>
         </dependency>
         <dependency>
             <groupId>se.fortnox.reactivewizard</groupId>
@@ -25,8 +33,35 @@
         </dependency>
         <dependency>
             <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-dbmigrate</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-jaxrs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-jaxrs-api-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
             <artifactId>reactivewizard-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>se.fortnox.reactivewizard</groupId>
@@ -34,72 +69,30 @@
         </dependency>
         <dependency>
             <groupId>se.fortnox.reactivewizard</groupId>
-            <artifactId>reactivewizard-binding</artifactId>
+            <artifactId>reactivewizard-validation</artifactId>
         </dependency>
-        <dependency>
-            <groupId>se.fortnox.reactivewizard</groupId>
-            <artifactId>reactivewizard-metrics</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>se.fortnox.reactivewizard</groupId>
-            <artifactId>reactivewizard-config</artifactId>
-            <scope>test</scope>
-            <classifier>tests</classifier>
-        </dependency>
-
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>report</id>
                         <goals>
-                            <goal>test-jar</goal>
+                            <goal>report-aggregate</goal>
                         </goals>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
-                    <argLine>@{argLine} -Dfile.encoding=UTF-8 -Xmx64m --add-opens
-                        java.base/java.lang.invoke=ALL-UNNAMED
-                    </argLine>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/dbmigrate/pom.xml
+++ b/dbmigrate/pom.xml
@@ -1,40 +1,40 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<artifactId>reactivewizard-dbmigrate</artifactId>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>reactivewizard-dbmigrate</artifactId>
 
-	<parent>
-		<groupId>se.fortnox.reactivewizard</groupId>
-		<artifactId>reactivewizard-parent</artifactId>
-		<version>999.9.9-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>se.fortnox.reactivewizard</groupId>
+        <artifactId>reactivewizard-parent</artifactId>
+        <version>999.9.9-SNAPSHOT</version>
+    </parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>se.fortnox.reactivewizard</groupId>
-			<artifactId>reactivewizard-dao</artifactId>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-dao</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>se.fortnox.reactivewizard</groupId>
-			<artifactId>reactivewizard-config</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-config</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>se.fortnox.reactivewizard</groupId>
-			<artifactId>reactivewizard-binding</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-binding</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>se.fortnox.reactivewizard</groupId>
-			<artifactId>reactivewizard-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.liquibase</groupId>
-			<artifactId>liquibase-core</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -46,16 +46,16 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
 
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>com.mattbertolini</groupId>
-			<artifactId>liquibase-slf4j</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.mattbertolini</groupId>
+            <artifactId>liquibase-slf4j</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>se.fortnox.reactivewizard</groupId>

--- a/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/WebException.java
+++ b/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/WebException.java
@@ -10,7 +10,7 @@ import org.slf4j.event.Level;
 import java.util.UUID;
 
 @SuppressWarnings("serial")
-@JsonIgnoreProperties({"cause", "stackTrace", "localizedMessage", "suppressed", "logLevel"})
+@JsonIgnoreProperties({"cause", "stackTrace", "localizedMessage", "suppressed", "logLevel", "body"})
 public class WebException extends RuntimeException {
 
     private   String             id;
@@ -21,12 +21,26 @@ public class WebException extends RuntimeException {
     private   String             message;
     protected Level              logLevel;
 
+
+    private final String body;
+
+
+    public WebException(HttpResponseStatus httpStatus, Throwable throwable, boolean stacktrace, String body) {
+        super(null, throwable, false, stacktrace);
+        this.error = errorCodeFromStatus(httpStatus);
+        this.status = httpStatus;
+        this.id = UUID.randomUUID().toString();
+        this.logLevel = logLevelFromStatus(httpStatus);
+        this.body = body;
+    }
+
     public WebException(HttpResponseStatus httpStatus, Throwable throwable, boolean stacktrace) {
         super(null, throwable, false, stacktrace);
         this.error = errorCodeFromStatus(httpStatus);
         this.status = httpStatus;
         this.id = UUID.randomUUID().toString();
         this.logLevel = logLevelFromStatus(httpStatus);
+        this.body = null;
     }
 
     public WebException(HttpResponseStatus httpStatus, String errorCode, Throwable throwable) {
@@ -52,6 +66,7 @@ public class WebException extends RuntimeException {
         }
         this.id = UUID.randomUUID().toString();
         this.logLevel = logLevelFromStatus(httpStatus);
+        this.body = null;
     }
 
     public WebException(FieldError... fieldErrors) {
@@ -67,6 +82,7 @@ public class WebException extends RuntimeException {
         this.error = errorCode;
         this.id = UUID.randomUUID().toString();
         this.logLevel = logLevelFromStatus(httpStatus);
+        this.body = null;
     }
 
     public WebException(HttpResponseStatus httpStatus, String errorCode) {
@@ -129,6 +145,10 @@ public class WebException extends RuntimeException {
     public WebException withLogLevel(Level logLevel) {
         setLogLevel(logLevel);
         return this;
+    }
+
+    public String getBody() {
+        return body;
     }
 
     private Level logLevelFromStatus(HttpResponseStatus httpStatus) {

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -80,48 +80,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <!-- implmentation is needed only for Maven 2 -->
-                                <rule implementation="org.jacoco.maven.RuleConfiguration">
-                                    <element>BUNDLE</element>
-                                    <limits>
-                                        <!-- implmentation is needed only for Maven 2 -->
-                                        <limit implementation="org.jacoco.report.check.Limit">
-                                            <counter>COMPLEXITY</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,14 @@
         <module>client</module>
         <module>validation</module>
         <module>dbmigrate</module>
+        <module>coverage</module>
     </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/../coverage/target/site/jacoco-aggregate/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
 
         <reactor-bom.version>2022.0.8</reactor-bom.version>
         <netty.version>4.1.93.Final</netty.version>
@@ -564,13 +568,6 @@
                         <id>default-prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -49,52 +49,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>default-report</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>default-check</id>
-						<goals>
-							<goal>check</goal>
-						</goals>
-						<configuration>
-                            <excludes>
-                                <exclude>**/*se/fortnox/reactivewizard/server/JaxRsResourceRegistry.class</exclude>
-                                <exclude>**/*se/fortnox/reactivewizard/server/ServerModule.class</exclude>
-                            </excludes>
-                            <rules>
-								<!-- implmentation is needed only for Maven 2 -->
-								<rule implementation="org.jacoco.maven.RuleConfiguration">
-									<element>BUNDLE</element>
-									<limits>
-										<!-- implmentation is needed only for Maven 2 -->
-										<limit implementation="org.jacoco.report.check.Limit">
-											<counter>COMPLEXITY</counter>
-											<value>COVEREDRATIO</value>
-											<minimum>0.75</minimum>
-										</limit>
-									</limits>
-								</rule>
-							</rules>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>


### PR DESCRIPTION
If the body of an error didn't correspond to a DetailedError, but was valid json, some or all of it was discarded.
Now, the error response body will also be in WebException.body, regardless of whether it's valid json.