### PR TITLE
Changed StreamReadConstraints' maxStringLength

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -120,7 +120,7 @@ public class HttpClient implements InvocationHandler {
         this.requestLogger = requestLogger;
         this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         var constraints = StreamReadConstraints.builder()
-            .maxStringLength(config.getMaxResponseSize())
+            .maxStringLength(20_000_000)
             .build();
         this.objectMapper.getFactory()
             .setStreamReadConstraints(constraints);


### PR DESCRIPTION
Changed StreamReadConstraints' maxStringLength from the value given in HttpClientConfig::getMaxResponse to a constant 20 million. This value is what the default value was in Jackson 2.14. Change to HttpClientConfig::maxResponseSize was made when Jackson was upgraded to 2.15. This can cause issues for applications that have multiple instances of HttpClient with different HttpClientConfigs. It is an issue because every HttpClient instantiation is changing the maxStringLength constraint on the same ObjectMapper(and JsonFactory) instance.

An alternative solution here would be to make copies of the ObjectMapper(and JsonFactory) for HttpClients with different HttpClientConfig.  