### PR TITLE
Use ConcurrentHashMap in HttpClientProvider

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientProvider.java
@@ -5,8 +5,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import se.fortnox.reactivewizard.jaxrs.RequestLogger;
 import se.fortnox.reactivewizard.metrics.HealthRecorder;
-
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientProvider.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClientProvider.java
@@ -9,6 +9,7 @@ import se.fortnox.reactivewizard.metrics.HealthRecorder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Handles creation of HttpClients from a given config, for easy creation of custom clients.
@@ -19,7 +20,7 @@ public class HttpClientProvider {
     protected final RequestParameterSerializers                              requestParameterSerializers;
     protected final Set<PreRequestHook>                                             preRequestHooks;
     private final HealthRecorder healthRecorder;
-    private final   Map<Class<? extends HttpClientConfig>, ReactorRxClientProvider> rxClientProviderCache = new HashMap<>();
+    private final   Map<Class<? extends HttpClientConfig>, ReactorRxClientProvider> rxClientProviderCache = new ConcurrentHashMap<>();
     private final RequestLogger requestLogger;
 
     @Inject


### PR DESCRIPTION
When creating new httpclients in parallell, sometimes a ConcurrentModificationException would be thrown.