### PR TITLE
Added a nullcheck in the HttpClient for parameters annotated with a PathParam

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -632,6 +632,13 @@ public class HttpClient implements InvocationHandler {
                     query.append('=');
                     query.append(urlEncode(serialize(value)));
                 } else if (annotation instanceof PathParam pathParam) {
+                    if (value == null) {
+                        throw new IllegalArgumentException(
+                            format("Failed to send http request, unexpected null argument for path param '%s' when calling %s::%s",
+                                pathParam.value(),
+                                method.getDeclaringClass().getCanonicalName(),
+                                method.getName()));
+                    }
                     if (path.contains("{" + pathParam.value() + ":.*}")) {
                         path = path.replaceAll("\\{" + pathParam.value() + ":.*\\}", this.encode(this.serialize(value)));
                     } else {

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -608,6 +608,15 @@ class HttpClientTest {
     }
 
     @Test
+    void shouldThrowIllegalArgumentExceptionWhenPathParamIsNull() {
+        server = startServer(HttpResponseStatus.OK, generateLargeString(10));
+        TestResource resource = getHttpProxy(server.port());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> resource.getPathParam(null).block())
+            .withMessage("Failed to send http request, unexpected null argument for path param 'myParam' when calling se.fortnox.reactivewizard.client.HttpClientTest.TestResource::getPathParam");
+    }
+
+    @Test
     void shouldLogErrorOnTooLargeResponse() {
         server = startServer(HttpResponseStatus.OK, generateLargeString(11));
         TestResource resource = getHttpProxy(server.port());
@@ -1559,6 +1568,10 @@ class HttpClientTest {
         @POST
         Observable<String> postHello();
 
+        @GET
+        @Path("/with-path-param/{myParam}")
+        Mono<String> getPathParam(@PathParam("myParam") String myParam);
+
         @Path("{fid}/{key}")
         Observable<String> withPathAndQueryParam(@PathParam("key") String key, @QueryParam("value") String value);
 
@@ -1642,6 +1655,7 @@ class HttpClientTest {
         @POST
         @Consumes("application/xml")
         Observable<Void> sendXml(Pojo pojo);
+
     }
 
     static class Wrapper {


### PR DESCRIPTION
When passing a null value to a parameter annotated with PathParam in proxied resource method a NullPointerException is thrown with an obscure message.

In this commit, we add a null check and handle the null by throwing an IllegalArgumentException with a message that is more friendly and improves the traceability.