### PR TITLE
Add error message when a resource is not found

### DIFF
--- a/server/src/main/java/se/fortnox/reactivewizard/server/CompositeRequestHandler.java
+++ b/server/src/main/java/se/fortnox/reactivewizard/server/CompositeRequestHandler.java
@@ -1,6 +1,5 @@
 package se.fortnox.reactivewizard.server;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
 import jakarta.inject.Inject;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -15,12 +14,15 @@ import se.fortnox.reactivewizard.jaxrs.WebException;
 
 import java.util.Set;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+
 /**
  * Calls each @{@link RequestHandler} with a request until one returns a result.
  * Delegates to @{@link ExceptionHandler} when any error occurrs.
  */
 public class CompositeRequestHandler implements RequestHandler {
     private static final Logger log = LoggerFactory.getLogger(CompositeRequestHandler.class);
+    private static final String ERROR_RESOURCE_NOT_FOUND = "resource.not.found";
     private final Set<RequestHandler> handlers;
     private final ExceptionHandler exceptionHandler;
     private final ConnectionCounter connectionCounter;
@@ -44,7 +46,7 @@ public class CompositeRequestHandler implements RequestHandler {
                 if (result != null) {
 
                     return Flux.from(result).onErrorResume(exception -> exceptionHandler
-                            .handleException(request, response, exception));
+                        .handleException(request, response, exception));
                 }
             }
         } catch (Exception exception) {
@@ -52,9 +54,9 @@ public class CompositeRequestHandler implements RequestHandler {
         }
         return Flux.from(exceptionHandler.handleException(request,
                 response,
-                new WebException(HttpResponseStatus.NOT_FOUND)))
-                .doOnTerminate(() -> requestLogger.logRequestResponse(request, response, requestStartTime, log))
-                .doOnSubscribe(s -> connectionCounter.increase())
-                .doFinally(s -> connectionCounter.decrease());
+                new WebException(NOT_FOUND, ERROR_RESOURCE_NOT_FOUND)))
+            .doOnTerminate(() -> requestLogger.logRequestResponse(request, response, requestStartTime, log))
+            .doOnSubscribe(s -> connectionCounter.increase())
+            .doFinally(s -> connectionCounter.decrease());
     }
 }


### PR DESCRIPTION
Add error message when a resource is not found, to help differentiate from the case when an entity at a valid resource is not found.