### PR TITLE
Disregard charset in Content-Type when parsing response

### DIFF
--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.google.common.collect.Sets;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.timeout.ReadTimeoutException;
 import jakarta.inject.Inject;
 import org.reactivestreams.Publisher;
@@ -281,7 +282,7 @@ public class HttpClient implements InvocationHandler {
     }
 
     private String resolveContentType(Method method, RwHttpClientResponse response) {
-        String contentType = response.getHttpClientResponse().responseHeaders().get(CONTENT_TYPE);
+        String contentType = HttpUtil.getMimeType(response.getHttpClientResponse().responseHeaders().get(CONTENT_TYPE)).toString();
 
         // Override response content-type if resource method is annotated with a non-empty @Produces
         JaxRsMeta jaxRsMeta = new JaxRsMeta(method);

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -234,7 +234,7 @@ public class HttpClient implements InvocationHandler {
      */
     public static <T> Mono<Response<Flux<T>>> getFullResponse(Flux<T> source) {
         Optional<Mono<Response<Flux<T>>>> responseFlux = ReactiveDecorator.getDecoration(source);
-        if (!responseFlux.isPresent()) {
+        if (responseFlux.isEmpty()) {
             throw new IllegalArgumentException("Must be used with Flux returned from api call");
         }
         return responseFlux.get();
@@ -249,7 +249,7 @@ public class HttpClient implements InvocationHandler {
      */
     public static <T> Mono<Response<T>> getFullResponse(Mono<T> source) {
         Optional<Mono<Response<Flux<T>>>> responseFlux = ReactiveDecorator.getDecoration(source);
-        if (!responseFlux.isPresent()) {
+        if (responseFlux.isEmpty()) {
             throw new IllegalArgumentException("Must be used with Mono returned from api call");
         }
         return flattenResponse(responseFlux.get());
@@ -434,13 +434,13 @@ public class HttpClient implements InvocationHandler {
                 }
             }
         }
-        if (output.length() > 0) {
+        if (!output.isEmpty()) {
             requestBuilder.setContent(output.toString());
         }
     }
 
     protected void addFormParamToOutput(StringBuilder output, Object value, FormParam formParam) {
-        if (output.length() != 0) {
+        if (!output.isEmpty()) {
             output.append("&");
         }
         output.append(formParam.value()).append("=").append(urlEncode(value.toString()));
@@ -496,7 +496,7 @@ public class HttpClient implements InvocationHandler {
 
     private HttpClient.DetailedError getDetailedError(String data, Throwable cause) {
         HttpClient.DetailedError detailedError = new HttpClient.DetailedError(cause);
-        if (data != null && data.length() > 0) {
+        if (data != null && !data.isEmpty()) {
             try {
                 objectMapper.readerForUpdating(detailedError).readValue(data);
             } catch (IOException e) {
@@ -667,13 +667,12 @@ public class HttpClient implements InvocationHandler {
     private List<BeanParamProperty> getBeanParamGetters(Class beanParamType) {
         List<BeanParamProperty> result = new ArrayList<>();
         for (Field field : getDeclaredFieldsFromClassAndAncestors(beanParamType)) {
-            Optional<Function<Object, Object>> getter = ReflectionUtil.getter(beanParamType, field.getName());
-            if (getter.isPresent()) {
+            Optional<Function<Object, Object>> optionalGetter = ReflectionUtil.getter(beanParamType, field.getName());
+            optionalGetter.ifPresent(getter ->
                 result.add(new BeanParamProperty(
-                    getter.get(),
+                    getter,
                     field.getAnnotations()
-                ));
-            }
+                )));
         }
         return result;
     }
@@ -682,7 +681,7 @@ public class HttpClient implements InvocationHandler {
      * Recursive function getting all declared fields from the passed in class and its ancestors.
      *
      * @param clazz the clazz fetching fields from
-     * @return list of fields
+     * @return set of fields
      */
     private static Set<Field> getDeclaredFieldsFromClassAndAncestors(Class clazz) {
         final HashSet<Field> declaredFields = new HashSet<>(asList(clazz.getDeclaredFields()));

--- a/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
+++ b/client/src/main/java/se/fortnox/reactivewizard/client/HttpClient.java
@@ -282,7 +282,10 @@ public class HttpClient implements InvocationHandler {
     }
 
     private String resolveContentType(Method method, RwHttpClientResponse response) {
-        String contentType = HttpUtil.getMimeType(response.getHttpClientResponse().responseHeaders().get(CONTENT_TYPE)).toString();
+        String contentType = Optional.ofNullable(response.getHttpClientResponse().responseHeaders().get(CONTENT_TYPE))
+            .map(HttpUtil::getMimeType)
+            .map(CharSequence::toString)
+            .orElse(null);
 
         // Override response content-type if resource method is annotated with a non-empty @Produces
         JaxRsMeta jaxRsMeta = new JaxRsMeta(method);

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -1548,6 +1548,19 @@ class HttpClientTest {
                     .contains("does not match the Content-Type"));
     }
 
+    @Test
+    void shouldHandleMissingContentTypeInResponse() {
+        server = HttpServer.create().port(0).handle((request, response) ->
+            response.status(OK)
+                .sendString(Mono.just("[]"))
+                .then()).bindNow();
+        TestResource resource = getHttpProxy(server.port());
+
+        StepVerifier.create(resource.producesJson())
+            .expectNextCount(1)
+            .verifyComplete();
+    }
+
     @Path("/hello")
     public interface TestResource {
 

--- a/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
+++ b/client/src/test/java/se/fortnox/reactivewizard/client/HttpClientTest.java
@@ -329,7 +329,7 @@ class HttpClientTest {
     }
 
     @Test
-    void shouldNotReportUnhealthyWhenPoolIsExhaustedRatherSequentiatingTheRequests() throws URISyntaxException {
+    void shouldNotReportUnhealthyWhenPoolIsExhaustedRatherSequentiatingTheRequests() {
 
         AtomicBoolean wasUnhealthy = new AtomicBoolean(false);
 
@@ -350,7 +350,7 @@ class HttpClientTest {
                 config.setRetryCount(0);
                 TestResource resource = getHttpProxy(config);
 
-                List<Observable<String>> results = new ArrayList<Observable<String>>();
+                List<Observable<String>> results = new ArrayList<>();
                 for (int i = 0; i < 10; i++) {
                     results.add(resource.getHello());
                 }
@@ -419,7 +419,7 @@ class HttpClientTest {
         withServer(server -> {
             TestResource resource = getHttpProxy(server.port(), 5);
 
-            List<Observable<String>> results = new ArrayList<Observable<String>>();
+            List<Observable<String>> results = new ArrayList<>();
             for (int i = 0; i < 5; i++) {
                 results.add(resource.getHello());
             }
@@ -480,14 +480,13 @@ class HttpClientTest {
 
         TestResource resource = getHttpProxy(server.port());
         StepVerifier.create(resource.getHelloMono())
-            .verifyErrorSatisfies(error -> {
+            .verifyErrorSatisfies(error ->
                 assertThat(error)
                     .isInstanceOf(WebException.class)
                     .hasFieldOrPropertyWithValue("body", errorJson)
                     .cause()
                     .isInstanceOf(HttpClient.DetailedError.class)
-                    .hasMessage("My message");
-            });
+                    .hasMessage("My message"));
     }
 
     @Test
@@ -497,14 +496,13 @@ class HttpClientTest {
 
         TestResource resource = getHttpProxy(server.port());
         StepVerifier.create(resource.getHelloMono())
-            .verifyErrorSatisfies(error -> {
+            .verifyErrorSatisfies(error ->
                 assertThat(error)
                     .isInstanceOf(WebException.class)
                     .hasFieldOrPropertyWithValue("body", errorNonJson)
                     .cause()
                     .isInstanceOf(HttpClient.DetailedError.class)
-                    .hasMessage(errorNonJson);
-            });
+                    .hasMessage(errorNonJson));
     }
 
     @Test
@@ -988,16 +986,14 @@ class HttpClientTest {
 
         try {
             server = HttpServer.create().port(0)
-                .handle((request, response) -> {
-                    return Flux.defer(() -> {
+                .handle((request, response) ->
+                    Flux.defer(() -> {
                             response.status(OK);
                             return response.sendString(Mono.just("\"hello\""));
                         })
                         .delaySubscription(Duration.ofMillis(50000))
-                        .doOnError(e -> {
-                            e.printStackTrace();
-                        });
-                }).bindNow();
+                        .doOnError(Throwable::printStackTrace)
+                ).bindNow();
 
             // this config ensures that the autocleanup will run before the hystrix timeout
             HttpClientConfig config = new HttpClientConfig("localhost:" + server.port());
@@ -1022,7 +1018,7 @@ class HttpClientTest {
     @Test
     void willRequestWithMultipleCookies() {
         Consumer<HttpServerRequest> reqLog = mock(Consumer.class);
-        server = startServer(OK, "", reqLog::accept);
+        server = startServer(OK, "", reqLog);
 
         String cookie1Value = "stub1";
         String cookie2Value = "stub2";
@@ -1291,9 +1287,9 @@ class HttpClientTest {
         TestResource resource = client.create(TestResource.class);
         resource.getHello().toBlocking().single();
 
-        verify(preRequestHook, times(1)).apply((TestUtil.matches(requestBuilder -> {
-            assertThat(requestBuilder.getFullUrl()).isEqualToIgnoringCase(url + "/hello");
-        })));
+        verify(preRequestHook, times(1)).apply((TestUtil.matches(requestBuilder ->
+            assertThat(requestBuilder.getFullUrl()).isEqualToIgnoringCase(url + "/hello")
+        )));
     }
 
     @Test
@@ -1427,7 +1423,7 @@ class HttpClientTest {
     @Test
     void assertRequestContainsHost() {
         Consumer<HttpServerRequest> reqLog = mock(Consumer.class);
-        server = startServer(OK, "", reqLog::accept);
+        server = startServer(OK, "", reqLog);
 
         String host = "localhost";
 
@@ -1442,7 +1438,7 @@ class HttpClientTest {
     @Test
     void assertRequestContainsHostFromHeaderParam() {
         Consumer<HttpServerRequest> reqLog = mock(Consumer.class);
-        server = startServer(OK, "", reqLog::accept);
+        server = startServer(OK, "", reqLog);
 
         String host = "globalhost";
 
@@ -1526,15 +1522,15 @@ class HttpClientTest {
     @Test
     void shouldDisregardCharsetInContentTypeWhenComparingToResourceAnnotation() {
         String someRecordJson = """
-                [{
-                  "param1": "a",
-                  "param2": "b"
-                },
-                {
-                  "param1": "c",
-                  "param2": "d"
-                }
-                ]""";
+            [{
+              "param1": "a",
+              "param2": "b"
+            },
+            {
+              "param1": "c",
+              "param2": "d"
+            }
+            ]""";
         server = HttpServer.create().port(0).handle((request, response) ->
             response.status(OK)
                 .header("Content-Type", "application/json; charset=utf-8")


### PR DESCRIPTION
Disregard charset in Content-Type when parsing response, to avoid unnecessary logging if it differs from the default application/json or the Produces annotation on the resource method.