### PR TITLE
Revert com.fasterxml.jackson:jackson-bom from 2.16.0 to 2.15.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
       - "softqwewasd"
     ignore:
       - dependency-name: "com.fasterxml.jackson:jackson-bom"
-        versions: ["2.13.2.20220324", "2.13.2.20220328", "2.13.4.20221013"]
+        versions: ["2.13.2.20220324", "2.13.2.20220328", "2.13.4.20221013", "2.16.0"]

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
         <reactor-bom.version>2023.0.0</reactor-bom.version>
         <netty.version>4.1.101.Final</netty.version>
-        <jackson-bom.version>2.16.0</jackson-bom.version>
+        <jackson-bom.version>2.15.3</jackson-bom.version>
         <guava.version>32.1.3-jre</guava.version>
         <rxjava.version>1.3.8</rxjava.version>
         <hikaricp.version>5.1.0</hikaricp.version>


### PR DESCRIPTION
Revert com.fasterxml.jackson:jackson-bom from 2.16.0 to 2.15.3 because of issue with custom deserializers.