### PR TITLE
Helper methods for writing WebException conditions

### DIFF
--- a/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/WebException.java
+++ b/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/WebException.java
@@ -165,4 +165,29 @@ public class WebException extends RuntimeException {
     private String createUUID() {
         return UUID.randomUUID().toString();
     }
+
+    /**
+     * @param throwable Throwable to check
+     * @param status Status to compare with
+     * @return If the throwable is a WebException and has status equal to the second argument
+     */
+    public static boolean hasStatus(Throwable throwable, HttpResponseStatus status) {
+        if (throwable instanceof WebException webException) {
+            return webException.getStatus().equals(status);
+        }
+        return false;
+    }
+
+
+    /**
+     * @param throwable Throwable to check
+     * @param error Error string to compare with
+     * @return If the throwable is a WebException and has an error code equal to the second argument
+     */
+    public static boolean hasError(Throwable throwable, String error) {
+        if (throwable instanceof WebException webException) {
+            return webException.getError().equals(error);
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Add helper methods for checking if any throwable is a WebException with a particular status or error code.

Keeps a lot of instanceof checks from the production code, helps make it more readable and reduces risk of mistakes.