### PR TITLE
Fix setting loglevel to debug when a request fails due to 404

### DIFF
--- a/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/WebException.java
+++ b/jaxrs-api/src/main/java/se/fortnox/reactivewizard/jaxrs/WebException.java
@@ -155,7 +155,7 @@ public class WebException extends RuntimeException {
         if (httpStatus.code() >= 500) {
             return Level.ERROR;
 
-        } else if (httpStatus == HttpResponseStatus.NOT_FOUND) {
+        } else if (httpStatus.equals(HttpResponseStatus.NOT_FOUND)) {
             return Level.DEBUG;
         }
 

--- a/jaxrs-api/src/test/java/se/fortnox/reactivewizard/jaxrs/WebExceptionTest.java
+++ b/jaxrs-api/src/test/java/se/fortnox/reactivewizard/jaxrs/WebExceptionTest.java
@@ -1,5 +1,6 @@
 package se.fortnox.reactivewizard.jaxrs;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.jupiter.api.Test;
 
 import java.util.regex.Pattern;
@@ -45,6 +46,14 @@ class WebExceptionTest {
     @Test
     void shouldSetDebugLoggingFor404() {
         WebException webException = new WebException(NOT_FOUND);
+        assertThat(webException.getLogLevel()).isEqualTo(DEBUG);
+    }
+
+    @Test
+    void shouldSetDebugLoggingFor404OnlyRegardingTheStatusCode() {
+        HttpResponseStatus customStatus = new HttpResponseStatus(NOT_FOUND.code(), "A custom reason");
+
+        WebException webException = new WebException(customStatus);
         assertThat(webException.getLogLevel()).isEqualTo(DEBUG);
     }
 


### PR DESCRIPTION
Correctly set log level to debug when response status is 404 and ignore any other irrelevant differences in the exceptions.

The old code compared exact instances, but using equals we get the expected behaviour. New test that verifies the behaviour has been added as well.