### PR TITLE
"Broken pipe" error handling

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
@@ -73,12 +73,7 @@ public class ExceptionHandler {
             webException = new WebException(BAD_REQUEST, "invalidjson", throwable.getMessage());
         } else if (throwable instanceof WebException we) {
             webException = we;
-        } else if (throwable instanceof ClosedChannelException
-            || throwable instanceof AbortedException
-            || throwable instanceof CancellationException
-            || (throwable instanceof IOException
-            && throwable.getMessage() != null
-            && throwable.getMessage().contains("Broken pipe"))) {
+        } else if (isAnticipatedClientException(throwable)) {
             LOG.atDebug()
                 .setMessage(INBOUND_CONNECTION_CLOSED)
                 .addArgument(request::method)
@@ -100,6 +95,15 @@ public class ExceptionHandler {
             return response.sendString(justOrEmpty(json(webException)));
         }
         return empty();
+    }
+
+    private static boolean isAnticipatedClientException(Throwable throwable) {
+        return throwable instanceof ClosedChannelException
+            || throwable instanceof AbortedException
+            || throwable instanceof CancellationException
+            || (throwable instanceof IOException
+            && throwable.getMessage() != null
+            && throwable.getMessage().contains("Broken pipe"));
     }
 
     private String json(WebException webException) {

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
@@ -73,8 +73,12 @@ public class ExceptionHandler {
             webException = new WebException(BAD_REQUEST, "invalidjson", throwable.getMessage());
         } else if (throwable instanceof WebException we) {
             webException = we;
-        } else if (throwable instanceof ClosedChannelException || throwable instanceof AbortedException || throwable instanceof CancellationException
-            || (throwable instanceof IOException && throwable.getMessage().contains("Broken pipe"))) {
+        } else if (throwable instanceof ClosedChannelException
+            || throwable instanceof AbortedException
+            || throwable instanceof CancellationException
+            || (throwable instanceof IOException
+            && throwable.getMessage() != null
+            && throwable.getMessage().contains("Broken pipe"))) {
             LOG.atDebug()
                 .setMessage(INBOUND_CONNECTION_CLOSED)
                 .addArgument(request::method)

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/ExceptionHandler.java
@@ -14,6 +14,7 @@ import se.fortnox.reactivewizard.jaxrs.RequestLogger;
 import se.fortnox.reactivewizard.jaxrs.WebException;
 import se.fortnox.reactivewizard.json.InvalidJsonException;
 
+import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.FileSystemException;
 import java.util.List;
@@ -72,7 +73,8 @@ public class ExceptionHandler {
             webException = new WebException(BAD_REQUEST, "invalidjson", throwable.getMessage());
         } else if (throwable instanceof WebException we) {
             webException = we;
-        } else if (throwable instanceof ClosedChannelException || throwable instanceof AbortedException || throwable instanceof CancellationException) {
+        } else if (throwable instanceof ClosedChannelException || throwable instanceof AbortedException || throwable instanceof CancellationException
+            || (throwable instanceof IOException && throwable.getMessage().contains("Broken pipe"))) {
             LOG.atDebug()
                 .setMessage(INBOUND_CONNECTION_CLOSED)
                 .addArgument(request::method)

--- a/jaxrs/src/test/java/se/fortnox/reactivewizard/ExceptionHandlerTest.java
+++ b/jaxrs/src/test/java/se/fortnox/reactivewizard/ExceptionHandlerTest.java
@@ -14,6 +14,7 @@ import se.fortnox.reactivewizard.test.LoggingMockUtil;
 import se.fortnox.reactivewizard.test.LoggingVerifier;
 import se.fortnox.reactivewizard.test.LoggingVerifierExtension;
 
+import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.FileSystemException;
 import java.nio.file.NoSuchFileException;
@@ -146,6 +147,22 @@ class ExceptionHandlerTest {
                 DEBUG,
                 "Inbound connection has been closed: GET /path",
                 cancellationException
+            );
+        } finally {
+            LoggingMockUtil.setLevel(ExceptionHandler.class, originalLevel);
+        }
+    }
+
+    @Test
+    void shouldLogNativeIoExceptionAtDebugLevel() {
+        Level originalLevel = LoggingMockUtil.setLevel(ExceptionHandler.class, DEBUG);
+        IOException brokenPipeException = new IOException("writevAddresses(..) failed: Broken pipe");
+        try {
+            assertLog(new MockHttpServerRequest("/path"),
+                brokenPipeException,
+                DEBUG,
+                "Inbound connection has been closed: GET /path",
+                brokenPipeException
             );
         } finally {
             LoggingMockUtil.setLevel(ExceptionHandler.class, originalLevel);


### PR DESCRIPTION
`io.netty.channel.unix.Errors.NativeIoException` thrown on a `Broken pipe` error should not be interpreted as an internal server error. It should be treated as one of the conditions that terminate the inbound connection. We cannot refer the `NativeIoException` directly here because it's for internal use only. Instead, we are checking for the parent `IOException` class in a combination with the message text.