### PR TITLE
Check minimum rows affected when executing statement in a batch

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/statement/AbstractDbStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/statement/AbstractDbStatementFactory.java
@@ -70,11 +70,10 @@ public abstract class AbstractDbStatementFactory implements DbStatementFactory {
 
         @Override
         public void batchExecuted(int count) throws SQLException {
-            if (fluxSink != null) {
-                AbstractDbStatementFactory.this.batchExecuted(count, fluxSink);
-            }
             if (monoSink != null) {
                 AbstractDbStatementFactory.this.batchExecuted(count, monoSink);
+            } else {
+                AbstractDbStatementFactory.this.batchExecuted(count, fluxSink);
             }
         }
 


### PR DESCRIPTION
If statement is executed in a transaction then `monoSink` and `fluxSink` are not set for a statement.

If statement is also batched with another statement, then `batch()` and `batchExecuted()` methods are called instead of `execute()` method.

Current `batchExecuted()` method does nothing as `fluxSink` and `monoSink` are always `null`, so `ensureMinimumReached()` method is never called.