### PR TITLE
PLAT-3447: Log real JaxRs resource class names

### DIFF
--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsResource.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsResource.java
@@ -166,7 +166,9 @@ public class JaxRsResource<T> implements Comparable<JaxRsResource> {
         return format("%1$s\t%2$s (%3$s.%4$s)",
             meta.getHttpMethod(),
             meta.getFullPath(),
-            method.getDeclaringClass().getName(),
+            JaxRsMeta.getJaxRsClass(method.getDeclaringClass())
+                .map(Class::getName)
+                .orElseGet(() -> method.getDeclaringClass().getName()),
             method.getName());
     }
 


### PR DESCRIPTION
This update will try to resolve the real JaxRs resource class names and log those names instead of the proxies at the startup and initialization time.