### PR TITLE
Add deprecated:true to OUT-metrics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: jdkfile
           jdkFile: ${{ runner.temp }}/jdk-21_linux-x64_bin.tar.gz
     - name: Build with Maven
-      run: mvn install sonar:sonar -Dsonar.organization=fortnoxab -Dsonar.login=$SONAR_TOKEN
+      run: mvn install sonar:sonar -Dsonar.organization=fortnoxab -Dsonar.login=$SONAR_TOKEN --batch-mode
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsResource.java
+++ b/jaxrs/src/main/java/se/fortnox/reactivewizard/jaxrs/JaxRsResource.java
@@ -102,7 +102,6 @@ public class JaxRsResource<T> implements Comparable<JaxRsResource> {
         return resultFactory.create(output, args);
     }
 
-    @SuppressWarnings("unchecked")
     private Function<Object[], Flux<T>> createMethodCaller(Method method, Object resourceInstance) {
         Class<?> returnType = method.getReturnType();
         Function<Object, Flux<T>> fluxConverter = FluxRxConverter.converterToFlux(returnType);
@@ -210,5 +209,12 @@ public class JaxRsResource<T> implements Comparable<JaxRsResource> {
 
     public String getPath() {
         return meta.getFullPath();
+    }
+
+    /**
+     * @return If the method defining the resource has been annotated with {@link Deprecated}
+     */
+    public boolean isDeprecated() {
+        return meta.isDeprecated();
     }
 }


### PR DESCRIPTION
Add deprecated:true to OUT-metrics when the method has been annotated with @Deprecated.
Also exposes deprecations in JaxRsResource for future use internally, will be used in a PR later on.

This will be used to more easily keep track and report on what deprecated endpoints that the service calls out too (this PR) and what deprecated endpoints of the service is being used (next PR). This is quite hard to keep track of today, so we are planning on implementing a Grafana dashboard as a first step that teams can use.