### PR TITLE
Use bundled JDK and enable Maven caching

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,0 @@
-coverage:
-  status:
-    patch: off

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,20 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
-continuation_indent_size = 4
+ij_continuation_indent_size = 4
 ij_java_class_count_to_use_import_on_demand = 99
 ij_java_names_count_to_use_import_on_demand = 99
+
+
+[{*.yaml,*.yml}]
+indent_size = 2
+ij_yaml_align_values_properties = do_not_align
+ij_yaml_autoinsert_sequence_marker = true
+ij_yaml_block_mapping_on_new_line = false
+ij_yaml_indent_sequence_value = true
+ij_yaml_keep_indents_on_empty_lines = false
+ij_yaml_keep_line_breaks = true
+ij_yaml_sequence_on_new_line = false
+ij_yaml_space_before_colon = false
+ij_yaml_spaces_within_braces = true
+ij_yaml_spaces_within_brackets = true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,9 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "flowertwig"
       - "jepp3"
       - "softqwewasd"
+      - "splitfeed"
     ignore:
       - dependency-name: "com.fasterxml.jackson:jackson-bom"
-        versions: ["2.13.2.20220324", "2.13.2.20220328", "2.13.4.20221013", "2.16.0"]
+        versions: [ "2.13.2.20220324", "2.13.2.20220328", "2.13.4.20221013", "2.16.0" ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: build
 
 on:
@@ -11,25 +10,20 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: 'Download latest JDK 21'
-      run: |
-          wget \
-            --no-verbose \
-            --directory-prefix $RUNNER_TEMP \
-            https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz
-    - name: 'Set up JDK'
-      uses: actions/setup-java@v3
-      with:
+      - uses: actions/checkout@v4
+
+      - name: 'Set up JDK'
+        uses: actions/setup-java@v3
+        with:
           java-version: 21
-          distribution: jdkfile
-          jdkFile: ${{ runner.temp }}/jdk-21_linux-x64_bin.tar.gz
-    - name: Build with Maven
-      run: mvn install sonar:sonar -Dsonar.organization=fortnoxab -Dsonar.login=$SONAR_TOKEN --batch-mode
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          distribution: 'corretto'
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn install sonar:sonar -Dsonar.organization=fortnoxab -Dsonar.login=$SONAR_TOKEN --batch-mode
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/deploy_manually.yml
+++ b/.github/workflows/deploy_manually.yml
@@ -1,20 +1,20 @@
 name: Deploy manually
 run-name: Deploy of ${{ inputs.tag }} manually
 on:
-    workflow_dispatch:
-        inputs:
-            tag:
-                description: 'Tag to deploy'
-                required: true
-                type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to deploy'
+        required: true
+        type: string
 
 jobs:
-    deploy:
-        uses: ./.github/workflows/deploy_tag.yml
-        with:
-            tag: ${{ inputs.tag }}
-        secrets:
-            OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-            OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-            PASSPHRASE: ${{ secrets.PASSPHRASE }}
-            GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+  deploy:
+    uses: ./.github/workflows/deploy_tag.yml
+    with:
+      tag: ${{ inputs.tag }}
+    secrets:
+      OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -2,7 +2,7 @@ name: Automatic deploy on release
 run-name: Deploy of ${{ github.ref }} on release
 on:
   release:
-    types: [ created ]
+    types: [ published ]
 
 jobs:
   get_tag:

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -1,25 +1,26 @@
 name: Automatic deploy on release
 run-name: Deploy of ${{ github.ref }} on release
 on:
-    release:
-        types: [ created ]
+  release:
+    types: [ created ]
 
 jobs:
-    get_tag:
-        runs-on: ubuntu-latest
-        outputs:
-            tag: ${{ steps.get.outputs.tag }}
-        steps:
-            -   name: Get tag
-                id: get
-                run: echo "tag=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-    deploy:
-        needs: [ get_tag ]
-        uses: ./.github/workflows/deploy_tag.yml
-        with:
-            tag: ${{ needs.get_tag.outputs.tag }}
-        secrets:
-            OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-            OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-            PASSPHRASE: ${{ secrets.PASSPHRASE }}
-            GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+  get_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get.outputs.tag }}
+    steps:
+      - name: Get tag
+        id: get
+        run: echo "tag=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+
+  deploy:
+    needs: [ get_tag ]
+    uses: ./.github/workflows/deploy_tag.yml
+    with:
+      tag: ${{ needs.get_tag.outputs.tag }}
+    secrets:
+      OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/deploy_tag.yml
+++ b/.github/workflows/deploy_tag.yml
@@ -1,60 +1,58 @@
 name: Build and deploy tag
 run-name: Build and deploy ${{ github.event.inputs.release_tag }}
 on:
-    workflow_call:
-        inputs:
-            tag:
-                description: 'Tag to deploy'
-                required: true
-                type: string
-        secrets:
-            OSSRH_USERNAME:
-                required: true
-            OSSRH_TOKEN:
-                required: true
-            PASSPHRASE:
-                required: true
-            GPG_PRIVATE_KEY:
-                required: true
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to deploy'
+        required: true
+        type: string
+    secrets:
+      OSSRH_USERNAME:
+        required: true
+      OSSRH_TOKEN:
+        required: true
+      PASSPHRASE:
+        required: true
+      GPG_PRIVATE_KEY:
+        required: true
 
 jobs:
-    publish:
-        runs-on: ubuntu-latest
-        steps:
-            -   name: Checkout
-                uses: actions/checkout@v4
-                with:
-                    ref: ${{ inputs.tag }}
-            -   name: 'Download latest JDK 21'
-                run: |
-                    wget \
-                     --no-verbose \
-                     --directory-prefix $RUNNER_TEMP \
-                     https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz
-            -   name: 'Set up JDK'
-                uses: actions/setup-java@v3
-                with:
-                    java-version: 21
-                    distribution: jdkfile
-                    jdkFile: ${{ runner.temp }}/jdk-21_linux-x64_bin.tar.gz
-            -   name: Set up Java for publishing to Maven Central Repository
-                uses: actions/setup-java@v3
-                with:
-                    java-version: 21
-                    distribution: jdkfile
-                    jdkFile: ${{ runner.temp }}/jdk-21_linux-x64_bin.tar.gz
-                    server-id: ossrh
-                    server-username: USER_NAME
-                    server-password: PASSWORD
-                    gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-                    gpg-passphrase: GPG_PASS
-            -   name: set version
-                run: mvn versions:set -DnewVersion=${{ inputs.tag }}
-            -   name: Publish to the Maven Central Repository
-                run: mvn clean deploy -Prelease
-                env:
-                    USER_NAME: ${{ secrets.OSSRH_USERNAME }}
-                    PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-                    GPG_PASS: ${{ secrets.PASSPHRASE }}
-                    MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: 'Set up JDK'
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: 'corretto'
+          cache: 'maven'
+
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: 'corretto'
+          cache: 'maven'
+          server-id: ossrh
+          server-username: USER_NAME
+          server-password: PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASS
+
+      - name: set version
+        run: mvn versions:set -DnewVersion=${{ inputs.tag }}
+
+      - name: Publish to the Maven Central Repository
+        run: mvn clean deploy -Prelease
+        env:
+          USER_NAME: ${{ secrets.OSSRH_USERNAME }}
+          PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASS: ${{ secrets.PASSPHRASE }}
+          MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
 

--- a/.github/workflows/deploy_tag.yml
+++ b/.github/workflows/deploy_tag.yml
@@ -46,10 +46,10 @@ jobs:
           gpg-passphrase: GPG_PASS
 
       - name: set version
-        run: mvn versions:set -DnewVersion=${{ inputs.tag }}
+        run: mvn versions:set -DnewVersion=${{ inputs.tag }} --batch-mode
 
       - name: Publish to the Maven Central Repository
-        run: mvn clean deploy -Prelease
+        run: mvn clean deploy -Prelease --batch-mode
         env:
           USER_NAME: ${{ secrets.OSSRH_USERNAME }}
           PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
Enabled Maven caches
https://github.com/actions/setup-java?tab=readme-ov-file#caching-maven-dependencies
This should save a bunch of time from the builds and, if working properly, not introducing a higher risk of issues :)

Updated YAML formatting in editorconfig and cleaned up the format of the .github/ files

Added myself to dependabot and removed flowertwig 

Updated deploy_on_release.yml to make it work with drafts as well, since `created` only triggers when releases are directly created instead of made as drafts and then published