### PR TITLE
DAO module clean up and refactoring

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DaoMethodHandler.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DaoMethodHandler.java
@@ -1,0 +1,48 @@
+package se.fortnox.reactivewizard.db;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import se.fortnox.reactivewizard.db.paging.PagingOutput;
+import se.fortnox.reactivewizard.db.statement.DbStatementFactory;
+import se.fortnox.reactivewizard.metrics.Metrics;
+
+import java.lang.reflect.Method;
+
+public class DaoMethodHandler {
+
+    private final Method method;
+    private final DbStatementFactory statementFactory;
+    private final PagingOutput pagingOutput;
+    private final Metrics metrics;
+
+    public DaoMethodHandler(Method method,
+        DbStatementFactory statementFactory, PagingOutput pagingOutput, Metrics metrics) {
+        this.method = method;
+        this.statementFactory = statementFactory;
+        this.pagingOutput = pagingOutput;
+        this.metrics = metrics;
+    }
+
+    public Publisher<Object> run(Object[] args, ReactiveStatementFactory reactiveStatementFactory) {
+        if (Mono.class.isAssignableFrom(method.getReturnType())) {
+            return reactiveStatementFactory.createMono(
+                metrics,
+                () -> statementFactory.create(args)
+            );
+        } else if (Flux.class.isAssignableFrom(method.getReturnType())) {
+            return reactiveStatementFactory.createFlux(
+                metrics,
+                () -> statementFactory.create(args),
+                flux -> pagingOutput.apply(flux, args)
+            );
+        } else {
+            throw new IllegalArgumentException(String.format(
+                "DAO method %s::%s must return a Flux or Mono. Found %s",
+                method.getDeclaringClass().getName(),
+                method.getName(),
+                method.getReturnType().getName()
+            ));
+        }
+    }
+}

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DaoMethodHandler.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DaoMethodHandler.java
@@ -9,6 +9,11 @@ import se.fortnox.reactivewizard.metrics.Metrics;
 
 import java.lang.reflect.Method;
 
+/**
+ * When the dao method is called for the first time some pre-calculations are done.
+ * For example, sql text is parsed into ParameterizedQuery and StatementFactory is created based on it.
+ * These pre-calculations are stored in this class and reused each time dao method is called.
+ */
 public class DaoMethodHandler {
 
     private final Method method;
@@ -24,7 +29,14 @@ public class DaoMethodHandler {
         this.metrics = metrics;
     }
 
-    public Publisher<Object> run(Object[] args, ReactiveStatementFactory reactiveStatementFactory) {
+    /**
+     * Creates dao method handler.
+     *
+     * @param args the dao method arguments
+     * @param reactiveStatementFactory the instance of ReactiveStatementFactory
+     * @return the dao method handler
+     */
+    public Publisher<Object> create(Object[] args, ReactiveStatementFactory reactiveStatementFactory) {
         if (Mono.class.isAssignableFrom(method.getReturnType())) {
             return reactiveStatementFactory.createMono(
                 metrics,

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
@@ -3,9 +3,6 @@ package se.fortnox.reactivewizard.db;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
@@ -123,27 +120,11 @@ public class DbProxy implements InvocationHandler {
                     pagingOutput,
                     createMetrics(method),
                     databaseConfig,
-                    converterFromPublisher(method),
                     method);
             statementFactories.put(method, reactiveStatementFactory);
         }
 
         return reactiveStatementFactory.create(args, connectionScheduler);
-    }
-
-    private static Function<Publisher, Object> converterFromPublisher(Method method) {
-        Class<?> returnType = method.getReturnType();
-
-        if (Flux.class.isAssignableFrom(returnType)) {
-            return flux -> flux;
-        } else if (Mono.class.isAssignableFrom(returnType)) {
-            return Mono::from;
-        } else {
-            throw new IllegalArgumentException(String.format("DAO method %s::%s must return a Flux or Mono. Found %s",
-                method.getDeclaringClass().getName(),
-                method.getName(),
-                method.getReturnType().getName()));
-        }
     }
 
     private Metrics createMetrics(Method method) {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
@@ -69,7 +69,7 @@ public class DbProxy implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        var handler = handlers.get(method);
+        DaoMethodHandler handler = handlers.get(method);
         if (handler == null || DebugUtil.IS_DEBUG) {
             if (DebugUtil.IS_DEBUG) {
                 // Need to get the actual interface method in order to get updated annotations
@@ -85,7 +85,7 @@ public class DbProxy implements InvocationHandler {
             handlers.put(method, handler);
         }
 
-        return handler.run(args, reactiveStatementFactory);
+        return handler.create(args, reactiveStatementFactory);
     }
 
     private Metrics createMetrics(Method method) {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
@@ -137,7 +137,7 @@ public class ReactiveStatementFactory {
     private <T> Publisher<T> measure(Publisher<T> publisher, Metrics metrics) {
         return metrics.measure(publisher, time -> {
             if (time > config.getSlowQueryLogThreshold()) {
-                LOG.warn("Slow query: {} time: {}", metrics.getName(), time);
+                LOG.warn("Slow execution: {} time: {}", metrics.getName(), time);
             }
         });
     }

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
@@ -90,6 +90,13 @@ public class ReactiveStatementFactory {
         }));
     }
 
+    /**
+     * Creates Mono that executes provided statement.
+     *
+     * @param metrics the metric that measures statement execution
+     * @param statementSupplier the supplier of a statement to execute
+     * @return Mono that executes the statement
+     */
     public <T> Mono<T> createMono(
         Metrics metrics,
         Supplier<Statement> statementSupplier
@@ -105,6 +112,14 @@ public class ReactiveStatementFactory {
         return decorated(resultMono, statementContext);
     }
 
+    /**
+     * Creates Flux that executes provided statement.
+     *
+     * @param metrics the metric that measures statement execution
+     * @param statementSupplier the supplier of a statement to execute
+     * @param fluxMapper the function to be executed on the resulting Flux
+     * @return Flux that executes the statement
+     */
     public <T> Flux<T> createFlux(
         Metrics metrics,
         Supplier<Statement> statementSupplier,
@@ -117,19 +132,10 @@ public class ReactiveStatementFactory {
                 Flux.error(new RuntimeException(QUERY_FAILED, thrown))
             );
         }
-        if (fluxMapper != null) {
-            resultFlux = fluxMapper.apply(resultFlux);
-        }
+        resultFlux = fluxMapper.apply(resultFlux);
         resultFlux = Flux.from(measure(resultFlux, metrics));
         resultFlux = resultFlux.onBackpressureBuffer(RECORD_BUFFER_SIZE);
         return decorated(resultFlux, statementContext);
-    }
-
-    public <T> Flux<T> createFlux(
-        Metrics metrics,
-        Supplier<Statement> statementSupplier
-    ) {
-        return createFlux(metrics, statementSupplier, null);
     }
 
     private <T> Publisher<T> measure(Publisher<T> publisher, Metrics metrics) {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
@@ -19,11 +19,9 @@ import se.fortnox.reactivewizard.util.DebugUtil;
 import javax.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
-import static java.lang.String.format;
 import static se.fortnox.reactivewizard.util.ReactiveDecorator.decorated;
 
 public class ReactiveStatementFactory {

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ReactiveStatementFactory.java
@@ -1,22 +1,25 @@
 package se.fortnox.reactivewizard.db;
 
+import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
-import se.fortnox.reactivewizard.db.paging.PagingOutput;
-import se.fortnox.reactivewizard.db.statement.DbStatementFactory;
 import se.fortnox.reactivewizard.db.statement.Statement;
 import se.fortnox.reactivewizard.db.transactions.ConnectionScheduler;
 import se.fortnox.reactivewizard.db.transactions.StatementContext;
 import se.fortnox.reactivewizard.metrics.Metrics;
 import se.fortnox.reactivewizard.util.DebugUtil;
 
-import java.lang.reflect.Method;
+import javax.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static java.lang.String.format;
 import static se.fortnox.reactivewizard.util.ReactiveDecorator.decorated;
@@ -24,28 +27,28 @@ import static se.fortnox.reactivewizard.util.ReactiveDecorator.decorated;
 public class ReactiveStatementFactory {
 
     private static final int RECORD_BUFFER_SIZE = 100000;
+
     private static final Logger LOG = LoggerFactory.getLogger("Dao");
+
     private static final String QUERY_FAILED = "Query failed";
-    private final DbStatementFactory statementFactory;
-    private final PagingOutput pagingOutput;
-    private final Method method;
-    private final Metrics metrics;
 
     private final DatabaseConfig config;
 
-    public ReactiveStatementFactory(
-            DbStatementFactory statementFactory,
-            PagingOutput pagingOutput,
-            Metrics metrics,
-            DatabaseConfig config,
-            Method method) {
-        this.statementFactory = statementFactory;
-        this.pagingOutput = pagingOutput;
-        this.metrics = metrics;
-        this.config = config;
-        this.method = method;
+    private final Scheduler scheduler;
+
+    private final ConnectionScheduler connectionScheduler;
+
+    @Inject
+    public ReactiveStatementFactory(DatabaseConfig config, @Nullable ConnectionProvider connectionProvider) {
+        this(config, threadPool(config.getPoolSize()), connectionProvider);
     }
 
+    public ReactiveStatementFactory(DatabaseConfig config, Scheduler scheduler,
+        ConnectionProvider connectionProvider) {
+        this.config = config;
+        this.scheduler = scheduler;
+        this.connectionScheduler = new ConnectionScheduler(connectionProvider, scheduler);
+    }
 
     private static void closeSilently(Connection connection) {
         try {
@@ -55,7 +58,7 @@ public class ReactiveStatementFactory {
         }
     }
 
-    private Flux<Object> getResultFlux(StatementContext statementContext) {
+    private <T> Flux<T> getResultFlux(StatementContext statementContext) {
         return Flux.create(fluxSink -> {
             try {
                 statementContext.getConnectionScheduler()
@@ -72,7 +75,7 @@ public class ReactiveStatementFactory {
         }, FluxSink.OverflowStrategy.ERROR);
     }
 
-    private Mono<Object> getResultMono(StatementContext statementContext) {
+    private <T> Mono<T> getResultMono(StatementContext statementContext) {
         return Mono.create(monoSink -> monoSink.onRequest(unusedRequestedAmount -> {
             try {
                 statementContext.getConnectionScheduler()
@@ -87,50 +90,51 @@ public class ReactiveStatementFactory {
         }));
     }
 
-    /**
-     * Create Flux statement.
-     *
-     * @param args                the arguments
-     * @param connectionScheduler the scheduler
-     * @return the Flux statement
-     */
-    public Object create(Object[] args, ConnectionScheduler connectionScheduler) {
-        StatementContext statementContext = new StatementContext(() -> statementFactory.create(args), connectionScheduler);
-        if (Mono.class.isAssignableFrom(method.getReturnType())) {
-            Mono<Object> resultMono = getResultMono(statementContext);
-            if (shouldAddDebugErrorHandling()) {
-                Exception queryFailure = new RuntimeException(QUERY_FAILED);
-                resultMono = resultMono.onErrorResume(thrown -> {
-                    queryFailure.initCause(thrown);
-                    return Mono.error(queryFailure);
-                });
-            }
-            resultMono = Mono.from(metrics.measure(resultMono, this::logSlowQuery));
-            return decorated(resultMono, statementContext);
-        } else if (Flux.class.isAssignableFrom(method.getReturnType())) {
-            Flux<Object> resultFlux = getResultFlux(statementContext);
-            if (shouldAddDebugErrorHandling()) {
-                Exception queryFailure = new RuntimeException(QUERY_FAILED);
-                resultFlux = resultFlux.onErrorResume(thrown -> {
-                    queryFailure.initCause(thrown);
-                    return Flux.error(queryFailure);
-                });
-            }
-            resultFlux = pagingOutput.apply(resultFlux, args);
-            resultFlux = Flux.from(metrics.measure(resultFlux, this::logSlowQuery));
-            resultFlux = resultFlux.onBackpressureBuffer(RECORD_BUFFER_SIZE);
-            return decorated(resultFlux, statementContext);
-        } else {
-            throw new IllegalArgumentException(String.format("DAO method %s::%s must return a Flux or Mono. Found %s",
-                method.getDeclaringClass().getName(),
-                method.getName(),
-                method.getReturnType().getName()));
+    public <T> Mono<T> createMono(
+        Metrics metrics,
+        Supplier<Statement> statementSupplier
+    ) {
+        var statementContext = new StatementContext(statementSupplier, connectionScheduler);
+        Mono<T> resultMono = getResultMono(statementContext);
+        if (shouldAddDebugErrorHandling()) {
+            resultMono = resultMono.onErrorResume(thrown ->
+                Mono.error(new RuntimeException(QUERY_FAILED, thrown))
+            );
         }
+        resultMono = Mono.from(metrics.measure(resultMono, (time) -> logIfSlowQuery(time, metrics)));
+        return decorated(resultMono, statementContext);
     }
 
-    private void logSlowQuery(long time) {
+    public <T> Flux<T> createFlux(
+        Metrics metrics,
+        Supplier<Statement> statementSupplier,
+        Function<Flux<T>, Flux<T>> fluxMapper
+    ) {
+        var statementContext = new StatementContext(statementSupplier, connectionScheduler);
+        Flux<T> resultFlux = getResultFlux(statementContext);
+        if (shouldAddDebugErrorHandling()) {
+            resultFlux = resultFlux.onErrorResume(thrown ->
+                Flux.error(new RuntimeException(QUERY_FAILED, thrown))
+            );
+        }
+        if (fluxMapper != null) {
+            resultFlux = fluxMapper.apply(resultFlux);
+        }
+        resultFlux = Flux.from(metrics.measure(resultFlux, (time) -> logIfSlowQuery(time, metrics)));
+        resultFlux = resultFlux.onBackpressureBuffer(RECORD_BUFFER_SIZE);
+        return decorated(resultFlux, statementContext);
+    }
+
+    public <T> Flux<T> createFlux(
+        Metrics metrics,
+        Supplier<Statement> statementSupplier
+    ) {
+        return createFlux(metrics, statementSupplier, null);
+    }
+
+    private void logIfSlowQuery(long time, Metrics metrics) {
         if (time > config.getSlowQueryLogThreshold()) {
-            LOG.warn(format("Slow query: %s%ntime: %d", statementFactory, time));
+            LOG.warn(format("Slow query: %s time: %d", metrics.getName(), time));
         }
     }
 
@@ -148,5 +152,28 @@ public class ReactiveStatementFactory {
 
     private static boolean shouldAddDebugErrorHandling() {
         return DebugUtil.IS_DEBUG || LOG.isDebugEnabled();
+    }
+
+    private static Scheduler threadPool(int poolSize) {
+        if (poolSize == -1) {
+            return Schedulers.boundedElastic();
+        }
+        return Schedulers.newBoundedElastic(10, Integer.MAX_VALUE, "DbProxy");
+    }
+
+    public ReactiveStatementFactory usingConnectionProvider(ConnectionProvider connectionProvider) {
+        return new ReactiveStatementFactory(config, scheduler, connectionProvider);
+    }
+
+    public ReactiveStatementFactory usingConnectionProvider(ConnectionProvider connectionProvider, DatabaseConfig databaseConfig) {
+        return new ReactiveStatementFactory(databaseConfig, scheduler, connectionProvider);
+    }
+
+    public ReactiveStatementFactory usingConnectionProvider(ConnectionProvider newConnectionProvider, Scheduler newScheduler) {
+        return new ReactiveStatementFactory(config, newScheduler, newConnectionProvider);
+    }
+
+    public DatabaseConfig getDatabaseConfig() {
+        return config;
     }
 }

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoMethodHandlerTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoMethodHandlerTest.java
@@ -1,30 +1,24 @@
 package se.fortnox.reactivewizard.db;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import reactor.core.Disposable;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
-import reactor.core.publisher.MonoSink;
-import reactor.core.scheduler.Scheduler;
-import se.fortnox.reactivewizard.db.config.DatabaseConfig;
+import reactor.core.publisher.Mono;
 import se.fortnox.reactivewizard.db.paging.PagingOutput;
 import se.fortnox.reactivewizard.db.statement.DbStatementFactory;
-import se.fortnox.reactivewizard.db.statement.Statement;
 import se.fortnox.reactivewizard.metrics.Metrics;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import java.lang.reflect.Method;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.platform.commons.util.ReflectionUtils.getRequiredMethod;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DaoMethodHandlerTest {
@@ -35,80 +29,45 @@ class DaoMethodHandlerTest {
     private DbStatementFactory dbStatementFactory;
 
     @Mock
-    private DatabaseConfig databaseConfig;
-
-    @Mock
-    private Scheduler scheduler;
-
-    @Mock
-    private Scheduler.Worker worker;
-
     private ReactiveStatementFactory reactiveStatementFactory;
 
     private DaoMethodHandler daoMethodHandler;
 
-    @BeforeEach
-    public void setUp() throws SQLException {
-        when(pagingOutput.apply(any(), any())).then(invocationOnMock -> invocationOnMock.getArgument(0,
-            Flux.class));
-        when(scheduler.createWorker()).thenReturn(worker);
-        when(worker.schedule(any())).then(invocationOnMock -> {
-            invocationOnMock.getArgument(0, Runnable.class).run();
-            return mock(Disposable.class);
-        });
-        when(dbStatementFactory.create(any())).then(invocationOnMock -> new Statement() {
-            private MonoSink monoSink;
-            private FluxSink fluxSink;
+    @Test
+    void shouldReturnFluxForFluxReturnType() {
+        var method = getRequiredMethod(TestDao.class, "selectFlux");
+        setUpHandler(method);
 
-            @Override
-            public void execute(Connection connection) {
-                fluxSink.next("result");
-            }
+        Publisher<Object> stmt = daoMethodHandler.create(new Object[0], reactiveStatementFactory);
+        assertThat(stmt).isInstanceOf(Flux.class);
+        verify(reactiveStatementFactory, atLeastOnce()).createFlux(any(), any(), any());
+    }
 
-            @Override
-            public void onCompleted() {
-                fluxSink.complete();
-            }
+    @Test
+    void shouldReturnMonoForMonoReturnType() {
+        var method = getRequiredMethod(TestDao.class, "selectMono");
+        setUpHandler(method);
 
-            @Override
-            public void onError(Throwable throwable) {
-                fluxSink.error(throwable);
-            }
+        Publisher<Object> stmt = daoMethodHandler.create(new Object[0], reactiveStatementFactory);
+        assertThat(stmt).isInstanceOf(Mono.class);
+        verify(reactiveStatementFactory, atLeastOnce()).createMono(any(), any());
+    }
 
-            @Override
-            public PreparedStatement batch(Connection connection, PreparedStatement preparedStatement) {
-                return null;
-            }
+    @Test
+    void shouldThrowExceptionForStringReturnType() {
+        var method = getRequiredMethod(TestDao.class, "invalidSelect");
+        setUpHandler(method);
 
-            @Override
-            public void batchExecuted(int count) {
+        try {
+            daoMethodHandler.create(new Object[0], reactiveStatementFactory);
+            fail("Expected exception");
+        } catch (Exception e) {
+            assertThat(e.getMessage())
+                .isEqualTo("DAO method se.fortnox.reactivewizard.db.DaoMethodHandlerTest$TestDao::invalidSelect must return a Flux or Mono. Found java.lang.String");
+        }
+    }
 
-            }
-
-            @Override
-            public boolean sameBatch(Statement statement) {
-                return false;
-            }
-
-            @Override
-            public void setFluxSink(FluxSink<?> fluxSink) {
-                this.fluxSink = fluxSink;
-            }
-
-            @Override
-            public void setMonoSink(MonoSink monoSink) {
-                this.monoSink = monoSink;
-            }
-
-        });
-
-        reactiveStatementFactory = new ReactiveStatementFactory(
-            databaseConfig,
-            scheduler,
-            () -> mock(Connection.class)
-        );
-
-        var method = getRequiredMethod(TestDao.class, "select");
+    private void setUpHandler(Method method) {
         daoMethodHandler = new DaoMethodHandler(
             method,
             dbStatementFactory,
@@ -117,16 +76,14 @@ class DaoMethodHandlerTest {
         );
     }
 
-    @Test
-    void shouldReleaseSchedulerWorkers() {
-        Flux<Object> stmt = (Flux<Object>) daoMethodHandler.run(new Object[0], reactiveStatementFactory);
-        stmt.blockFirst();
-        verify(scheduler).createWorker();
-        verify(worker).dispose();
-    }
-
     private interface TestDao {
         @Query("SELECT * FROM foo")
-        Flux<String> select();
+        Flux<String> selectFlux();
+
+        @Query("SELECT * FROM foo")
+        Mono<String> selectMono();
+
+        @Query("SELECT * FROM foo")
+        String invalidSelect();
     }
 }

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTest.java
@@ -8,7 +8,6 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
 import se.fortnox.reactivewizard.db.statement.DbStatementFactoryFactory;
-import se.fortnox.reactivewizard.json.JsonSerializerFactory;
 
 import java.sql.SQLException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,8 +33,8 @@ class DaoTest {
             new DatabaseConfig(),
             Schedulers.newBoundedElastic(1, Integer.MAX_VALUE, "DaoTestDbProxy"),
             db.getConnectionProvider(),
-            new DbStatementFactoryFactory(),
-            new JsonSerializerFactory()).create(DaoTransactionsTest.TestDao.class);
+            new DbStatementFactoryFactory()
+        ).create(DaoTransactionsTest.TestDao.class);
     }
 
     @Test

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DaoTransactionsTest.java
@@ -16,7 +16,6 @@ import se.fortnox.reactivewizard.db.statement.MinimumAffectedRowsException;
 import se.fortnox.reactivewizard.db.transactions.DaoTransactions;
 import se.fortnox.reactivewizard.db.transactions.DaoTransactionsImpl;
 import se.fortnox.reactivewizard.db.transactions.StatementContext;
-import se.fortnox.reactivewizard.json.JsonSerializerFactory;
 import se.fortnox.reactivewizard.util.ReactiveDecorator;
 
 import java.sql.Connection;
@@ -432,7 +431,7 @@ class DaoTransactionsTest {
         VirtualTimeScheduler otherScheduler = VirtualTimeScheduler.create();
         DbProxy otherDbProxy = new DbProxy(
             new DatabaseConfig(), otherScheduler,
-            null, new DbStatementFactoryFactory(), new JsonSerializerFactory());
+            null, new DbStatementFactoryFactory());
         otherDbProxy = otherDbProxy.usingConnectionProvider(otherConnectionProvider);
 
         when(otherDb.getPreparedStatement().executeBatch())
@@ -461,7 +460,7 @@ class DaoTransactionsTest {
         ConnectionProvider otherConnectionProvider = secondDb.getConnectionProvider();
 
         DbProxy dbProxyWithoutConnectionProvider = new DbProxy(
-                new DatabaseConfig(), Schedulers.boundedElastic(), null, new DbStatementFactoryFactory(), new JsonSerializerFactory());
+                new DatabaseConfig(), Schedulers.boundedElastic(), null, new DbStatementFactoryFactory());
         DbProxy dbProxyWithConnectionProvider = dbProxyWithoutConnectionProvider.usingConnectionProvider(otherConnectionProvider);
 
         when(secondDb.getPreparedStatement().executeBatch())

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/DbProxyTest.java
@@ -1,6 +1,5 @@
 package se.fortnox.reactivewizard.db;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.inject.Injector;
 import org.assertj.core.api.ThrowableAssertAlternative;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,7 +12,6 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import se.fortnox.reactivewizard.config.TestInjector;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
-import se.fortnox.reactivewizard.json.JsonSerializerFactory;
 import se.fortnox.reactivewizard.util.DebugUtil;
 
 import java.sql.SQLException;
@@ -21,7 +19,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
@@ -29,13 +26,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -139,26 +134,6 @@ class DbProxyTest {
         verify(mockDb.getPreparedStatement()).close();
         verify(mockDb.getResultSet()).close();
         verify(mockDb.getConnection()).close();
-    }
-
-    @Test
-    void shouldReuseTypeReference() {
-        final JsonSerializerFactory jsonSerializerFactoryReal = new JsonSerializerFactory();
-        final JsonSerializerFactory jsonSerializerFactory = spy(jsonSerializerFactoryReal);
-        AtomicReference<TypeReference<?>> typeReferenceAtomicReference = new AtomicReference<>();
-
-        when(jsonSerializerFactory.createStringSerializer(any(TypeReference.class))).thenAnswer(invocationOnMock -> {
-            final TypeReference<?> argument = invocationOnMock.getArgument(0);
-            typeReferenceAtomicReference.set(argument);
-            return jsonSerializerFactoryReal.createStringSerializer(argument);
-        });
-        new DbProxy(new DatabaseConfig(), null, null, jsonSerializerFactory);
-
-        final TypeReference<?> firstTypeReference = typeReferenceAtomicReference.get();
-        new DbProxy(new DatabaseConfig(), null, null, jsonSerializerFactory);
-        final TypeReference<?> secondTypeReference = typeReferenceAtomicReference.get();
-
-        assertThat(firstTypeReference).isSameAs(secondTypeReference);
     }
 
     @Test

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/ReactiveStatementFactoryTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/ReactiveStatementFactoryTest.java
@@ -100,7 +100,7 @@ class ReactiveStatementFactoryTest {
 
         });
 
-        statementFactory = new ReactiveStatementFactory(dbStatementFactory, pagingOutput, Metrics.get("test"), databaseConfig, o -> o, getRequiredMethod(TestDao.class, "select"));
+        statementFactory = new ReactiveStatementFactory(dbStatementFactory, pagingOutput, Metrics.get("test"), databaseConfig, getRequiredMethod(TestDao.class, "select"));
     }
 
     @Test

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/ReactiveStatementFactoryTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/ReactiveStatementFactoryTest.java
@@ -1,0 +1,108 @@
+package se.fortnox.reactivewizard.db;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.MonoSink;
+import reactor.core.scheduler.Scheduler;
+import se.fortnox.reactivewizard.db.config.DatabaseConfig;
+import se.fortnox.reactivewizard.db.statement.Statement;
+import se.fortnox.reactivewizard.metrics.Metrics;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.function.UnaryOperator;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReactiveStatementFactoryTest {
+    @Mock
+    private DatabaseConfig databaseConfig;
+
+    @Mock
+    private Scheduler scheduler;
+
+    @Mock
+    private Scheduler.Worker worker;
+
+    private Statement statement;
+
+    private ReactiveStatementFactory statementFactory;
+
+    @BeforeEach
+    public void setUp() {
+        when(scheduler.createWorker()).thenReturn(worker);
+        when(worker.schedule(any())).then(invocationOnMock -> {
+            invocationOnMock.getArgument(0, Runnable.class).run();
+            return mock(Disposable.class);
+        });
+        statement = new Statement() {
+            private MonoSink monoSink;
+            private FluxSink fluxSink;
+
+            @Override
+            public void execute(Connection connection) {
+                fluxSink.next("result");
+            }
+
+            @Override
+            public void onCompleted() {
+                fluxSink.complete();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                fluxSink.error(throwable);
+            }
+
+            @Override
+            public PreparedStatement batch(Connection connection, PreparedStatement preparedStatement) {
+                return null;
+            }
+
+            @Override
+            public void batchExecuted(int count) {
+
+            }
+
+            @Override
+            public boolean sameBatch(Statement statement) {
+                return false;
+            }
+
+            @Override
+            public void setFluxSink(FluxSink<?> fluxSink) {
+                this.fluxSink = fluxSink;
+            }
+
+            @Override
+            public void setMonoSink(MonoSink monoSink) {
+                this.monoSink = monoSink;
+            }
+
+        };
+        statementFactory = new ReactiveStatementFactory(databaseConfig, scheduler, () -> mock(Connection.class));
+    }
+
+    @Test
+    void shouldReleaseSchedulerWorkers() {
+        Flux<Object> stmt = statementFactory.createFlux(Metrics.get("test"), () -> statement, UnaryOperator.identity());
+        stmt.blockFirst();
+        verify(scheduler).createWorker();
+        verify(worker).dispose();
+    }
+
+    private interface TestDao {
+        @Query("SELECT * FROM foo")
+        Flux<String> select();
+    }
+}

--- a/dao/src/test/java/se/fortnox/reactivewizard/db/SlowQueryTest.java
+++ b/dao/src/test/java/se/fortnox/reactivewizard/db/SlowQueryTest.java
@@ -1,0 +1,47 @@
+package se.fortnox.reactivewizard.db;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import se.fortnox.reactivewizard.db.config.DatabaseConfig;
+import se.fortnox.reactivewizard.test.LoggingVerifier;
+import se.fortnox.reactivewizard.test.LoggingVerifierExtension;
+
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.logging.log4j.Level.WARN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(LoggingVerifierExtension.class)
+class SlowQueryTest {
+
+    private final MockDb              mockDb             = new MockDb();
+    private final DatabaseConfig      databaseConfig     = new DatabaseConfig();
+    private final ConnectionProvider  connectionProvider = mockDb.getConnectionProvider();
+    private final DbProxy             dbProxy            = new DbProxy(databaseConfig, connectionProvider);
+    private final DbProxyTestDao      testDao            = dbProxy.create(DbProxyTestDao.class);
+
+    private final LoggingVerifier loggingVerifier = new LoggingVerifier(ReactiveStatementFactory.class);
+
+    @Test
+    void shouldLogSlowQueries() throws SQLException {
+        databaseConfig.setSlowQueryLogThreshold(1);
+
+        // Given
+        when(mockDb.getPreparedStatement().executeQuery()).thenAnswer(i -> {
+            Awaitility.await().atMost(2, TimeUnit.MICROSECONDS);
+            return mockDb.getResultSet();
+        });
+
+        // When
+        testDao.select("hej").block();
+
+        // Then
+        loggingVerifier.verify(WARN, log ->
+            assertThat(log.getMessage().getFormattedMessage())
+                .contains("Slow execution: DAO_type:query_method:se.fortnox.reactivewizard.db.DbProxyTestDao.select_1 time: ")
+        );
+    }
+}

--- a/metrics/src/main/java/se/fortnox/reactivewizard/metrics/Metrics.java
+++ b/metrics/src/main/java/se/fortnox/reactivewizard/metrics/Metrics.java
@@ -20,8 +20,10 @@ public class Metrics {
     };
 
     private final Timer timer;
+    private final String name;
 
     private Metrics(String name) {
+        this.name = name;
         this.timer = REGISTRY.timer(name);
     }
 
@@ -76,5 +78,9 @@ public class Metrics {
 
     private long getElapsedTime(Timer.Context context) {
         return context.stop() / NANOSECONDS_PER_MILLISECOND;
+    }
+
+    public String getName() {
+        return name;
     }
 }


### PR DESCRIPTION
**1. Remove resultConverter from ReactiveStatementFactory**
`ReactiveStatementFactory` always creates `Mono` if dao method return type is `Mono` and `Flux` if return type is `Flux`. So it looks like there is no need for a converter.
The check that return type is Mono or Flux was moved to `ReactiveStatementFactory`.

**2. Remove paramSerializer from DbProxy**
There are no usages of `paramSerializer` field in `DbProxy`. I have checked internal RW too. So it looks like it is safe to remove it.

**3. Move dao method related code from ReactiveStatementFactory to DaoMethodHandler**
Currently `DbProxy` has two "roles":
- proxies any dao method
- has fields related to query execution (connectionScheduler, databaseConfig)

And `ReactiveStatementFactory` has two "roles":
- builds Mono or Flux for query executions
- handles dao method execution and stores precalculated information for a specific dao method

My idea is to distribute "roles" in the following way:
- DbProxy: proxies any dao method
- ReactiveStatementFactory: executes the query
- DaoMethodHandler: handles dao method execution and stores precalculated information for a specific dao method

So this refactoring has moved the following code:
- precalculated info for dao method and dao method handling from `ReactiveStatementFactory` to a new class `DaoMethodHandler`
- everything needed for query execution from `DbProxy` to `ReactiveStatementFactory`

**Note:** previously if query execution was slow then the query sql was logged, now the metric name related to the dao method will be logged instead.
We did this change so that we don't need to pass sql text as a parameter.
And it will be easier for a developer to find this query in the code.

So previously log message may look like this:
```
Slow query: select * from table where name=:name
time: 6000
```
Now it may look like this:
```
Slow query: DAO_type:query_method:com.fortnox.reactivewizard.dao.MyDao.doSomethingMono_1 time: 6000
```