### PR TITLE
Adding dependency to allow for restapi to add open api annotations

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,6 +29,11 @@
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
         <byte-buddy.version>1.14.12</byte-buddy.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <bcpkix-jdk18on.version>1.77</bcpkix-jdk18on.version>
+        <swagger-annotations.version>2.2.20</swagger-annotations.version>
 
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>fortnoxab</sonar.organization>
@@ -484,6 +485,11 @@
                 <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bcpkix-jdk18on.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>${swagger-annotations.version}</version>
             </dependency>
         </dependencies>
 


### PR DESCRIPTION
With this dependency developers will be able to annotate their rest endpoints with swagger openapi annotations which could be used to generate openapi specifications from the code