### PR TITLE
Upgrading Github checkout action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@v4.1.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Upgrading Github checkout action to resolve the scoreboard supply-chain security warnings.