### PR TITLE
Resolving the scorecard workflow issue

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Resolving the scorecard workflow issue: error signing scorecard json results

The issue is addressed in the following discussion: https://github.com/ossf/scorecard-action/issues/997

In short, the error is caused by breaking changes in Sigstore https://blog.sigstore.dev/tuf-root-update/
Scorecard v2.3.1 is required, as it uses a new enough version of cosign