### PR TITLE
Re-add old constructor to avoid breaking changes for downstream

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/DbProxy.java
@@ -7,6 +7,7 @@ import reactor.core.scheduler.Schedulers;
 import se.fortnox.reactivewizard.db.config.DatabaseConfig;
 import se.fortnox.reactivewizard.db.paging.PagingOutput;
 import se.fortnox.reactivewizard.db.statement.DbStatementFactoryFactory;
+import se.fortnox.reactivewizard.json.JsonSerializerFactory;
 import se.fortnox.reactivewizard.metrics.Metrics;
 import se.fortnox.reactivewizard.util.DebugUtil;
 import se.fortnox.reactivewizard.util.ReflectionUtil;
@@ -52,6 +53,20 @@ public class DbProxy implements InvocationHandler {
         this.dbStatementFactoryFactory = dbStatementFactoryFactory;
         this.reactiveStatementFactory = reactiveStatementFactory;
         this.handlers = handlers;
+    }
+
+    /**
+     * @deprecated The JsonSerializerFactory is no longer needed, use {@link #DbProxy(DatabaseConfig, ConnectionProvider, DbStatementFactoryFactory)} instead
+     */
+    @Deprecated(forRemoval = true)
+    public DbProxy(DatabaseConfig databaseConfig,
+                   ConnectionProvider connectionProvider,
+                   DbStatementFactoryFactory dbStatementFactoryFactory,
+                   JsonSerializerFactory unused
+    ) {
+        this(databaseConfig,
+            connectionProvider,
+            dbStatementFactoryFactory);
     }
 
     /**


### PR DESCRIPTION
No reason to cause issues for the services that call DbProxy, but marking the constructor as deprecated to indicate that it needs changing.