### PR TITLE
PLAT-3553: Flushing the logs at the server shutdown

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -37,6 +37,11 @@
 
         <dependency>
             <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-logging-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
             <artifactId>reactivewizard-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/config/src/test/java/se/fortnox/reactivewizard/config/TestInjector.java
+++ b/config/src/test/java/se/fortnox/reactivewizard/config/TestInjector.java
@@ -7,12 +7,14 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
 import se.fortnox.reactivewizard.binding.AutoBindModules;
+import se.fortnox.reactivewizard.logging.LoggingShutdownHandler;
 
 import javax.annotation.Nullable;
 import java.util.function.Consumer;
 
 import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.of;
+import static org.mockito.Mockito.mock;
 
 public class TestInjector {
 
@@ -44,6 +46,8 @@ public class TestInjector {
                     String[] argsWithConfig = concat(of(args), of(configFile)).toArray(String[]::new);
                     bind(String[].class).annotatedWith(Names.named("args")).toInstance(argsWithConfig);
                 }
+
+                bind(LoggingShutdownHandler.class).toInstance(mock(LoggingShutdownHandler.class));
 
                 binderConsumer.accept(binder());
             }

--- a/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
+++ b/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseAutoBindModuleTest.java
@@ -12,6 +12,7 @@ import se.fortnox.reactivewizard.binding.AutoBindModules;
 import se.fortnox.reactivewizard.config.ConfigFactory;
 import se.fortnox.reactivewizard.config.TestInjector;
 import se.fortnox.reactivewizard.json.JsonConfig;
+import se.fortnox.reactivewizard.logging.LoggingShutdownHandler;
 import se.fortnox.reactivewizard.server.ServerConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -157,6 +158,7 @@ class LiquibaseAutoBindModuleTest {
                     .toInstance(arg);
 
                 bind(LiquibaseMigrateProvider.class).toInstance(liquibaseMigrateProvider);
+                bind(LoggingShutdownHandler.class).toInstance(mock(LoggingShutdownHandler.class));
             }
         };
         LiquibaseAutoBindModule liquibaseAutoBindModule = new LiquibaseAutoBindModule(arg, liquibaseMigrateProvider);

--- a/logging-api/pom.xml
+++ b/logging-api/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>reactivewizard-logging-api</artifactId>
+
+    <parent>
+        <groupId>se.fortnox.reactivewizard</groupId>
+        <artifactId>reactivewizard-parent</artifactId>
+        <version>999.9.9-SNAPSHOT</version>
+    </parent>
+
+</project>

--- a/logging-api/src/main/java/se/fortnox/reactivewizard/logging/LoggingShutdownHandler.java
+++ b/logging-api/src/main/java/se/fortnox/reactivewizard/logging/LoggingShutdownHandler.java
@@ -1,0 +1,12 @@
+package se.fortnox.reactivewizard.logging;
+
+/**
+ * Interface for shutting down the logging system.
+ */
+public interface LoggingShutdownHandler {
+
+    /**
+     * Executes the shutdown of the logging system.
+     */
+    void shutdown();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <module>validation</module>
         <module>dbmigrate</module>
         <module>coverage</module>
+        <module>logging-api</module>
     </modules>
 
     <properties>
@@ -302,6 +303,11 @@
                 <artifactId>reactivewizard-jaxrs</artifactId>
                 <version>${project.version}</version>
                 <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>se.fortnox.reactivewizard</groupId>
+                <artifactId>reactivewizard-logging-api</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <!-- external libs -->

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -16,6 +16,10 @@
         </dependency>
         <dependency>
             <groupId>se.fortnox.reactivewizard</groupId>
+            <artifactId>reactivewizard-logging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>se.fortnox.reactivewizard</groupId>
             <artifactId>reactivewizard-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/server/src/test/java/se/fortnox/reactivewizard/server/AbortedRequestHandlingTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/AbortedRequestHandlingTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import reactor.core.publisher.Flux;
 import reactor.netty.http.client.HttpClient;
 import se.fortnox.reactivewizard.ExceptionHandler;
@@ -11,6 +12,7 @@ import se.fortnox.reactivewizard.RequestHandler;
 import se.fortnox.reactivewizard.jaxrs.JaxRsRequestHandler;
 import se.fortnox.reactivewizard.jaxrs.JaxRsResourceFactory;
 import se.fortnox.reactivewizard.jaxrs.RequestLogger;
+import se.fortnox.reactivewizard.logging.LoggingShutdownHandler;
 import se.fortnox.reactivewizard.test.LoggingMockUtil;
 
 import javax.ws.rs.GET;
@@ -30,6 +32,9 @@ import static se.fortnox.reactivewizard.test.TestUtil.matches;
  * When client aborts the connection the server should still finish gracefully with only a debug-log as the result.
  */
 class AbortedRequestHandlingTest {
+    @Mock
+    private LoggingShutdownHandler loggingShutdownHandler;
+
     @Test
     void shouldHandleAbortedRequestGracefully() throws InterruptedException {
         LoggingMockUtil.setLevel(ExceptionHandler.class, Level.DEBUG);
@@ -76,7 +81,7 @@ class AbortedRequestHandlingTest {
         ConnectionCounter connectionCounter = new ConnectionCounter();
         RequestLogger requestLogger = new RequestLogger();
         CompositeRequestHandler handlers = new CompositeRequestHandler(Collections.singleton(handler), new ExceptionHandler(new ObjectMapper(), requestLogger), connectionCounter, requestLogger);
-        return new RwServer(config, handlers, connectionCounter);
+        return new RwServer(config, handlers, connectionCounter, loggingShutdownHandler);
     }
 
     @Path("/")

--- a/server/src/test/java/se/fortnox/reactivewizard/server/NoContentFixConfiguratorTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/NoContentFixConfiguratorTest.java
@@ -3,18 +3,23 @@ package se.fortnox.reactivewizard.server;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import reactor.core.publisher.Flux;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
 import se.fortnox.reactivewizard.ExceptionHandler;
 import se.fortnox.reactivewizard.RequestHandler;
 import se.fortnox.reactivewizard.jaxrs.RequestLogger;
+import se.fortnox.reactivewizard.logging.LoggingShutdownHandler;
 
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class NoContentFixConfiguratorTest {
+
+    @Mock
+    private LoggingShutdownHandler loggingShutdownHandler;
 
     @Test
     void shouldOnlyRemoveHeaderContentLengthIfNoBody() {
@@ -59,7 +64,7 @@ class NoContentFixConfiguratorTest {
         config.setPort(0);
         ConnectionCounter connectionCounter = new ConnectionCounter();
         CompositeRequestHandler handlers = new CompositeRequestHandler(Collections.singleton(handler), new ExceptionHandler(new ObjectMapper(), new RequestLogger()), connectionCounter, new RequestLogger());
-        return new RwServer(config, handlers, connectionCounter);
+        return new RwServer(config, handlers, connectionCounter, loggingShutdownHandler);
     }
 
 }

--- a/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
+++ b/server/src/test/java/se/fortnox/reactivewizard/server/RwServerGzipTest.java
@@ -3,12 +3,14 @@ package se.fortnox.reactivewizard.server;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import se.fortnox.reactivewizard.ExceptionHandler;
 import se.fortnox.reactivewizard.RequestHandler;
 import se.fortnox.reactivewizard.jaxrs.RequestLogger;
+import se.fortnox.reactivewizard.logging.LoggingShutdownHandler;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,6 +25,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class RwServerGzipTest {
+    @Mock
+    private LoggingShutdownHandler loggingShutdownHandler;
+
     private RwServer rwServer;
 
     @Test
@@ -70,7 +75,7 @@ class RwServerGzipTest {
         ConnectionCounter connectionCounter = new ConnectionCounter();
         RequestLogger requestLogger = new RequestLogger();
         CompositeRequestHandler handlers = new CompositeRequestHandler(Collections.singleton(handler), new ExceptionHandler(new ObjectMapper(), requestLogger), connectionCounter, requestLogger);
-        return new RwServer(config, handlers, connectionCounter);
+        return new RwServer(config, handlers, connectionCounter, loggingShutdownHandler);
     }
 
     private void assertCompressionForContentType(boolean serverUsesCompression, String contentType, boolean compressionExpected) {


### PR DESCRIPTION
When RW server is shut down, the latest portions of the logs entries are not flushed to the storage, and are often lost. This update enables a new handler that will be called at the end of the shutdown procedure in order to flush the logs.