### PR TITLE
PLAT-13791: Setting a database connection timezone via DatabaseConfig.

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ConnectionProviderImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ConnectionProviderImpl.java
@@ -1,5 +1,6 @@
 package se.fortnox.reactivewizard.db;
 
+import com.google.common.base.Strings;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import jakarta.inject.Inject;
@@ -31,8 +32,10 @@ public class ConnectionProviderImpl implements ConnectionProvider {
         connectionPool.setMetricRegistry(Metrics.registry());
 
         connectionPool.addDataSourceProperty("socketTimeout", databaseConfig.getSocketTimeout());
-        if (databaseConfig.getTimeZone() != null) {
-            connectionPool.addDataSourceProperty("TimeZone", databaseConfig.getTimeZone());
+        if (!Strings.isNullOrEmpty(databaseConfig.getTimeZone())) {
+            // The statement SET TIME ZONE is not a real table operation;
+            // rather, it is a configuration statement that sets the time zone for the session.
+            connectionPool.setConnectionInitSql("SET TIME ZONE '%s'".formatted(databaseConfig.getTimeZone()));
         }
 
         DbDriver.loadDriver(databaseConfig.getUrl());

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/ConnectionProviderImpl.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/ConnectionProviderImpl.java
@@ -31,6 +31,9 @@ public class ConnectionProviderImpl implements ConnectionProvider {
         connectionPool.setMetricRegistry(Metrics.registry());
 
         connectionPool.addDataSourceProperty("socketTimeout", databaseConfig.getSocketTimeout());
+        if (databaseConfig.getTimeZone() != null) {
+            connectionPool.addDataSourceProperty("TimeZone", databaseConfig.getTimeZone());
+        }
 
         DbDriver.loadDriver(databaseConfig.getUrl());
 

--- a/dao/src/main/java/se/fortnox/reactivewizard/db/config/DatabaseConfig.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/config/DatabaseConfig.java
@@ -38,6 +38,8 @@ public class DatabaseConfig {
     private long   slowQueryLogThreshold = 5000;
     private long   socketTimeout         = 300;
 
+    private String timeZone;
+
     public String getSchema() {
         return schema;
     }
@@ -132,5 +134,13 @@ public class DatabaseConfig {
 
     public void setSocketTimeout(long socketTimeout) {
         this.socketTimeout = socketTimeout;
+    }
+
+    public String getTimeZone() {
+        return timeZone;
+    }
+
+    public void setTimeZone(String timeZone) {
+        this.timeZone = timeZone;
     }
 }

--- a/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProviderTest.java
+++ b/dbmigrate/src/test/java/se/fortnox/reactivewizard/dbmigrate/LiquibaseMigrateProviderTest.java
@@ -18,6 +18,7 @@ class LiquibaseMigrateProviderTest {
         when(liquibaseConfig.getUrl()).thenReturn("jdbc:h2:mem:test");
         when(liquibaseConfig.getMigrationsFile()).thenReturn("migrations.xml");
         when(liquibaseConfig.getSchema()).thenReturn(null);
+        when(liquibaseConfig.getTimeZone()).thenReturn("UTC");
 
         ConfigFactory configFactory = mock(ConfigFactory.class);
         when(configFactory.get(LiquibaseConfig.class)).thenReturn(liquibaseConfig);


### PR DESCRIPTION
If a timezone is not passed via database connection properties, Postgres JDBC driver uses the system default timezone. This can lead to flaky behaviours if the default timezone is not yet initialised at the time when connection is created. Instead, we added a timezone property to DatabaseConfig in order to explicitly specify a timezone when creating a connection.
