### PR TITLE
Allowing blocking calls inside Jackson's DeserializerCache::_createAndCacheValueDeserializer resolves the IllegalMonitorStateException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 
         <reactor-bom.version>2023.0.6</reactor-bom.version>
         <netty.version>4.1.110.Final</netty.version>
-        <jackson-bom.version>2.16.2</jackson-bom.version>
+        <jackson-bom.version>2.17.1</jackson-bom.version>
         <guava.version>33.2.1-jre</guava.version>
         <rxjava.version>1.3.8</rxjava.version>
         <hikaricp.version>5.1.0</hikaricp.version>

--- a/test/src/main/java/se/fortnox/reactivewizard/test/RwBlockHoundIntegration.java
+++ b/test/src/main/java/se/fortnox/reactivewizard/test/RwBlockHoundIntegration.java
@@ -13,6 +13,7 @@ public abstract class RwBlockHoundIntegration implements BlockHoundIntegration {
     public void applyTo(BlockHound.Builder builder) {
         builder
             .allowBlockingCallsInside("se.fortnox.reactivewizard.jaxrs.WebException", "createUUID")
-            .allowBlockingCallsInside("com.fasterxml.jackson.databind.cfg.MapperBuilder", "findAndAddModules");
+            .allowBlockingCallsInside("com.fasterxml.jackson.databind.cfg.MapperBuilder", "findAndAddModules")
+            .allowBlockingCallsInside("com.fasterxml.jackson.databind.deser.DeserializerCache", "_createAndCacheValueDeserializer");
     }
 }


### PR DESCRIPTION
Allowing blocking calls inside Jackson's DeserializerCache::_createAndCacheValueDeserializer resolves the IllegalMonitorStateException.

See https://github.com/FasterXML/jackson-databind/pull/4430

This PR resolves the issue we had when upgrading to Jackson 2.17.1. The upgrade to 2.17.1 caused some of our tests to fail with IllegalMonitorStateException. By configuring Blockhound to allow blocking calls inside _createAndCacheValueDeserializer, IllegalMonitorStateException is no longer thrown. You can read more about this issue here https://github.com/FasterXML/jackson-databind/pull/4430#issuecomment-2150633048. 