### PR TITLE
PLAT-3546: Validating Config-files

### DIFF
--- a/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
+++ b/bootstrap/src/main/java/se/fortnox/reactivewizard/Main.java
@@ -7,9 +7,6 @@ import com.google.inject.name.Names;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.fortnox.reactivewizard.binding.AutoBindModules;
-import se.fortnox.reactivewizard.config.ConfigFactory;
-
-import java.nio.file.NoSuchFileException;
 
 /**
  * Main application entry point. Will scan for all modules on the classpath and run them.
@@ -27,41 +24,16 @@ public class Main {
      */
     public static void main(String[] args) {
         try {
-            ConfigFactory  configFactory  = createConfigFactory(args);
             Module bootstrap = new AbstractModule() {
                 @Override
                 protected void configure() {
                     bind(String[].class).annotatedWith(Names.named("args")).toInstance(args);
-                    bind(ConfigFactory.class).toInstance(configFactory);
                 }
             };
             Guice.createInjector(new AutoBindModules(bootstrap));
         } catch (Exception exception) {
             LOG.error("Caught exception at startup.", exception);
             System.exit(-1);
-        }
-    }
-
-    /**
-     * Prepares a ConfigFactory before setting up Guice.
-     * <p>
-     * As logging can be part of the configuration file and the configuration file
-     * could be missing, we have a side effect of setting up and initializing a LoggingFactory
-     * that doesn't depend on ConfigFactory, if the configuration file is missing.
-     *
-     * @param args commandline arguments
-     * @return A ConfigFactory based on a configuration file.
-     * @throws NoSuchFileException If the configuration file cannot be found.
-     */
-    private static ConfigFactory createConfigFactory(String[] args) throws NoSuchFileException {
-        try {
-            return new ConfigFactory(args);
-        } catch (RuntimeException runtimeException) {
-            Throwable cause = runtimeException.getCause();
-            if (cause != null && cause.getClass().isAssignableFrom(NoSuchFileException.class)) {
-                throw (NoSuchFileException)cause;
-            }
-            throw runtimeException;
         }
     }
 }

--- a/validation/src/main/java/se/fortnox/reactivewizard/validation/ValidationModule.java
+++ b/validation/src/main/java/se/fortnox/reactivewizard/validation/ValidationModule.java
@@ -24,14 +24,12 @@ public class ValidationModule implements AutoBindModule {
 
     @Override
     public void configure(Binder binder) {
-        binder.bind(Validator.class).toProvider(() -> {
-            return Validation
-                    .byDefaultProvider()
-                    .configure()
-                    .parameterNameProvider(new JaxRsParameterNameResolver())
-                    .buildValidatorFactory()
-                    .getValidator();
-        }).in(Scopes.SINGLETON);
+        binder.bind(Validator.class).toProvider(() -> Validation
+                .byDefaultProvider()
+                .configure()
+                .parameterNameProvider(new JaxRsParameterNameResolver())
+                .buildValidatorFactory()
+                .getValidator()).in(Scopes.SINGLETON);
 
 
         // Validate config
@@ -55,5 +53,11 @@ public class ValidationModule implements AutoBindModule {
 
     private <T> Provider<T> validatingProvider(Class<T> iface, Provider<T> wrappedProvider, Provider<ValidatorUtil> validatorUtilProvider) {
         return () -> ValidatingProxy.create(iface, wrappedProvider.get(), validatorUtilProvider.get());
+    }
+
+    @Override
+    public Integer getPrio() {
+        // We want this module to override the default binding of ConfigFactory
+        return 110;
     }
 }

--- a/validation/src/test/java/se/fortnox/reactivewizard/validation/ValidationModuleTest.java
+++ b/validation/src/test/java/se/fortnox/reactivewizard/validation/ValidationModuleTest.java
@@ -1,0 +1,23 @@
+package se.fortnox.reactivewizard.validation;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import se.fortnox.reactivewizard.binding.scanners.ConfigClassScanner;
+import se.fortnox.reactivewizard.binding.scanners.InjectAnnotatedScanner;
+import se.fortnox.reactivewizard.config.ConfigAutoBindModule;
+
+import static org.mockito.Mockito.mock;
+
+public class ValidationModuleTest {
+
+    @Test
+    public void validationModuleShouldGoAfterConfigModule() {
+        InjectAnnotatedScanner injectAnnotatedScanner = mock(InjectAnnotatedScanner.class);
+        ValidationModule validationModule = new ValidationModule(injectAnnotatedScanner);
+
+        ConfigClassScanner configClassScanner = mock(ConfigClassScanner.class);
+        ConfigAutoBindModule configAutoBindModule = new ConfigAutoBindModule(configClassScanner);
+
+        Assertions.assertThat(configAutoBindModule.getPrio()).isLessThan(validationModule.getPrio());
+    }
+}


### PR DESCRIPTION
Validation of the config files seems to be broken for a long time. `ValidatingConfigFactory` did not have effect because its binding was always overridden by the default config factory from the bootstrap binding.

For some reason bootstrap binding was giving the highest priority, thus overriding the bindings of all the auto-bind modules. I could not find any justification for this behaviour. The only class that is bound in the bootstrap module is `ConfigFactory`, and we want it to be overridden by `ValidatingConfigFactory`. It looks like it was a bug.

The modules precedence is fixed so that the bootstrap is at the lowest place, overridden by the rest of the modules.