### PR TITLE
Fix support for JSON operators in DAO

### DIFF
--- a/dao/src/main/java/se/fortnox/reactivewizard/db/query/ParameterizedQuery.java
+++ b/dao/src/main/java/se/fortnox/reactivewizard/db/query/ParameterizedQuery.java
@@ -41,10 +41,6 @@ public class ParameterizedQuery {
 
         sqlInput = sqlPreProcess(sqlInput);
 
-        if (sqlInput.indexOf('?') != -1) {
-            throw new RuntimeException("Unnamed parameters are not supported: " + sqlInput);
-        }
-
         int     pos     = 0;
         Matcher matcher = NAMED_PARAMETER_PATTERN.matcher(sqlInput);
         if (matcher.find()) {


### PR DESCRIPTION
Remove check for unnamed parameters as it falsely triggers on JSON operators such as `?|` or `?`, so that queries such as this one can be used:
```
SELECT *
FROM message_projections
WHERE message_json->'categories' ?| array['newsletter', 'spam'];
```


Even after removing the exception thrown, Postgres picks up on the error and throws `org.postgresql.util.PSQLException: No value specified for parameter 1.`