### PR TITLE
Add archive notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> ⚠️ This public version of Reactive Wizard has been archived and is no longer maintained.
+
 ## Reactive Wizard
 The Reactive Wizard project makes it easy to build performant and scalable web applications that harness the power of Project Reactor and Netty.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-> ⚠️ This public version of Reactive Wizard has been archived and is no longer maintained.
+> ⚠️ This public version of Reactive Wizard has been archived and is no longer maintained. Fortnox developers can reach us through our internal help channels for more information.
 
 ## Reactive Wizard
 The Reactive Wizard project makes it easy to build performant and scalable web applications that harness the power of Project Reactor and Netty.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-> ⚠️ This public version of Reactive Wizard has been archived and is no longer maintained. Fortnox developers can reach us through our internal help channels for more information.
+> ⚠️ This public version of Reactive Wizard has been archived and is no longer maintained. Fortnox developers can reach us through internal help channels for more information.
 
 ## Reactive Wizard
 The Reactive Wizard project makes it easy to build performant and scalable web applications that harness the power of Project Reactor and Netty.


### PR DESCRIPTION
Add a highly visible note/warning to the beginning of README.md to inform future visitors that the public version of Reactive Wizard has been archived and is no longer maintained.

* Use a [!NOTE] [alert block](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) to increase visibility.
* Include a warning emoji to draw more attention.
* Add message aimed at Fortnox developers.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FortnoxAB/reactive-wizard/pull/804?shareId=7ef477e3-0329-4aff-b346-5d28ddf00d7f).